### PR TITLE
fess-crawler-webdriver: Disable default PostConstruct on phantomjs

### DIFF
--- a/fess-crawler-webdriver/src/main/java/org/codelibs/fess/crawler/client/http/webdriver/CrawlerWebDriver.java
+++ b/fess-crawler-webdriver/src/main/java/org/codelibs/fess/crawler/client/http/webdriver/CrawlerWebDriver.java
@@ -19,8 +19,6 @@ import java.net.URL;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.PostConstruct;
-
 import org.apache.commons.pool2.PooledObject;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
@@ -70,7 +68,6 @@ public class CrawlerWebDriver implements WebDriver, JavascriptExecutor, FindsByI
 
     protected URL remoteAddress;
 
-    @PostConstruct
     public void phantomjs() {
         if (capabilities == null) {
             capabilities = DesiredCapabilities.phantomjs();


### PR DESCRIPTION
### Problem: Cannot disable completely PhantomJS when change to ChromeDriver.

Hi all, 

I want to run crawler with webdriver is chrome instead of Phantomjs as:
In webdriver.xml, change postConstruct to chrome, as below:

```xml
<component name="webDriver" class="org.codelibs.fess.crawler.client.http.webdriver.CrawlerWebDriver"
	instance="prototype">
	...
	<postConstruct name="chrome"></postConstruct>
</component>
``` 
 But when crawling, phantomjs is still executed.
 As seen in below picture, I can see execution for both phantomjs and chrome driver as below:

![phantojs_is_still_called (1)](https://user-images.githubusercontent.com/57885830/121485749-b45e0680-c9fa-11eb-9ca2-045895f823e7.jpg)

It is risk when I want to crawl with chrome only but some pages are crawl with Phantomjs only, not Chrome. 

### Solution: Remove  @PostConstruct of Phantomjs function in java code

I remove @PostConstruct of Phantomjs function in CrawlerWebDriver.java then let PostConstruct be handled by webdriver.xml as:
```xml
<component name="webDriver" class="org.codelibs.fess.crawler.client.http.webdriver.CrawlerWebDriver"
	instance="prototype">
	<postConstruct name="chrome"></postConstruct>
</component>
```
With above soluiton, Fess can run crawler with chrome only, as seen execution log for chrome in below:

![chromedriver (1)](https://user-images.githubusercontent.com/57885830/121486393-4c5bf000-c9fb-11eb-90a0-f29c006ce044.jpg)

### Testing environment
Fess-crawler version 3.13.0-SNAPSHOT:  Latest commit https://github.com/codelibs/fess-crawler/commit/df683c777315b19e697d773aa5d20a7fdc8e60e6
Fess version 13.13.0-SNAPSHOT:  Commit https://github.com/codelibs/fess/commit/9c2621fa5599aa2d9c30fa4192be7c278e499c06
Elasticsearch version 7.13.0


