### PR TITLE
[webdriver] Add options for chrome arguments and prefs

### DIFF
--- a/fess-crawler-webdriver/pom.xml
+++ b/fess-crawler-webdriver/pom.xml
@@ -96,5 +96,10 @@
 			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-chrome-driver</artifactId>
+			<version>3.141.59</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/fess-crawler-webdriver/src/main/java/org/codelibs/fess/crawler/client/http/webdriver/CrawlerWebDriver.java
+++ b/fess-crawler-webdriver/src/main/java/org/codelibs/fess/crawler/client/http/webdriver/CrawlerWebDriver.java
@@ -17,6 +17,7 @@ package org.codelibs.fess.crawler.client.http.webdriver;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.pool2.PooledObject;
@@ -68,6 +69,8 @@ public class CrawlerWebDriver implements WebDriver, JavascriptExecutor, FindsByI
     protected URL remoteAddress;
 
     protected String[] chromeArguments;
+
+    protected Map<String, Object> prefs;
 
     public void phantomjs() {
         if (capabilities == null) {
@@ -123,6 +126,9 @@ public class CrawlerWebDriver implements WebDriver, JavascriptExecutor, FindsByI
             ChromeOptions options = new ChromeOptions();
             if (chromeArguments != null) {
                 options.addArguments(chromeArguments);
+            }
+            if (prefs != null) {
+                options.setExperimentalOption("prefs", prefs);
             }
             ((DesiredCapabilities) capabilities).setCapability(ChromeOptions.CAPABILITY, options);
         }
@@ -554,5 +560,9 @@ public class CrawlerWebDriver implements WebDriver, JavascriptExecutor, FindsByI
 
     public void setChromeArguments(String[] chromeArguments) {
         this.chromeArguments = chromeArguments;
+    }
+
+    public void setPrefs(Map<String, Object> prefs) {
+        this.prefs = prefs;
     }
 }

--- a/fess-crawler-webdriver/src/main/java/org/codelibs/fess/crawler/client/http/webdriver/CrawlerWebDriver.java
+++ b/fess-crawler-webdriver/src/main/java/org/codelibs/fess/crawler/client/http/webdriver/CrawlerWebDriver.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.apache.commons.pool2.PooledObject;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.OutputType;
@@ -65,6 +66,8 @@ public class CrawlerWebDriver implements WebDriver, JavascriptExecutor, FindsByI
     protected String webdriverChromeDriver;
 
     protected URL remoteAddress;
+
+    protected String[] chromeArguments;
 
     public void phantomjs() {
         if (capabilities == null) {
@@ -116,8 +119,14 @@ public class CrawlerWebDriver implements WebDriver, JavascriptExecutor, FindsByI
             if (webdriverChromeDriver != null) {
                 ((DesiredCapabilities) capabilities).setCapability("webdriver.chrome.driver", webdriverChromeDriver);
             }
+
+            ChromeOptions options = new ChromeOptions();
+            if (chromeArguments != null) {
+                options.addArguments(chromeArguments);
+            }
+            ((DesiredCapabilities) capabilities).setCapability(ChromeOptions.CAPABILITY, options);
         }
-        webDriver = new RemoteWebDriver(remoteAddress, DesiredCapabilities.chrome());
+        webDriver = new RemoteWebDriver(remoteAddress, capabilities);
     }
 
     public static class OnDestroyListener
@@ -541,5 +550,9 @@ public class CrawlerWebDriver implements WebDriver, JavascriptExecutor, FindsByI
 
     public void setRemoteAddress(URL remoteAddress) {
         this.remoteAddress = remoteAddress;
+    }
+
+    public void setChromeArguments(String[] chromeArguments) {
+        this.chromeArguments = chromeArguments;
     }
 }

--- a/fess-crawler-webdriver/src/main/resources/crawler/webdriver.xml
+++ b/fess-crawler-webdriver/src/main/resources/crawler/webdriver.xml
@@ -19,6 +19,7 @@
 	<component name="webDriver" class="org.codelibs.fess.crawler.client.http.webdriver.CrawlerWebDriver"
 		instance="prototype">
         <!-- <property name="phantomjsBinaryPath">".../phantomjs"</property> -->
+        <!-- <property name="chromeArguments">[""]</property> -->
 		<postConstruct name="phantomjs"></postConstruct>
 	</component>
 

--- a/fess-crawler-webdriver/src/main/resources/crawler/webdriver.xml
+++ b/fess-crawler-webdriver/src/main/resources/crawler/webdriver.xml
@@ -20,6 +20,7 @@
 		instance="prototype">
         <!-- <property name="phantomjsBinaryPath">".../phantomjs"</property> -->
         <!-- <property name="chromeArguments">[""]</property> -->
+        <!-- <property name="prefs">{}</property> -->
 		<postConstruct name="phantomjs"></postConstruct>
 	</component>
 


### PR DESCRIPTION
Hi all,

### Problem 
I want to specify arguments and prefs for chrome but with the current fess-crawler-webdriver, there is no way to do that.

For example, passing option `--headless` for running chrome in non-graphical environment or change download directory to prevent storage is full because of downloading too many files.

### Solution
This PR adds a way for user to specify chrome arguments and prefs from `webdriver.xml`.  

Example:
```xml
<component name="webDriver" class="org.codelibs.fess.crawler.client.http.webdriver.CrawlerWebDriver"
	instance="prototype">
	...
	<property name="chromeArguments">["--headless","--no-sandbox"]</property>
        <property name="prefs">{"download.default_directory":"/dev/null"}</property>
	<postConstruct name="chrome"></postConstruct>
</component>
```

### Test environment
Fess version 13.13.0-SNAPSHOT: Commit codelibs/fess@9c2621f
fess-crawler version 3.13.0-SNAPSHOT: Commit 621d1ed1497f737b49fcf049e235d0fc8d2ffbbf
Elasticsearch version 7.13.0