### PR TITLE
fess-crawler-webdriver: Make webDriver quit after finish crawling

### DIFF
--- a/fess-crawler-webdriver/src/main/java/org/codelibs/fess/crawler/client/http/WebDriverClient.java
+++ b/fess-crawler-webdriver/src/main/java/org/codelibs/fess/crawler/client/http/WebDriverClient.java
@@ -109,6 +109,7 @@ public class WebDriverClient extends AbstractCrawlerClient {
             if (webDriver != null) {
                 try {
                     webDriverPool.returnObject(webDriver);
+                    webDriverPool.invalidateObject(webDriver);
                 } catch (final Exception e) {
                     logger.warn("Failed to return a returned object.", e);
                 }


### PR DESCRIPTION
Hi all, 

### Problem
With current design when crawling one URL, a new webdriver object will be created then it will be returned to webdriver pool after crawling but this webdriver has still exist.
So after finish getting one URL, processes of PhantomJS or ChromeDriver don't exit. It will end up eat all the RAM.
For example, these are processes of PhantomJS after finish crawling:

![process-phantomjs1](https://user-images.githubusercontent.com/57885830/121989834-fc987280-cdc6-11eb-8291-bf8e26481422.png)

### Solution
Before having another design about crawling, should we have a temporary solution that invalidate the webDriver object after return this webdriver object to the webdriver pool?

### Test environment
Fess version 13.13.0-SNAPSHOT: Commit codelibs/fess@9c2621f
fess-crawler version 3.13.0-SNAPSHOT: Commit a065f60dd2be62974eb39c1610632377335a8f83
Elasticsearch version 7.13.0
