### PR TITLE
Adapt crawler OpenSearch integration to OpenSearch 3.0 APIs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      PARENT_BRANCH: ${{ github.ref_name == 'master' && 'main' || github.ref_name }}
+      PARENT_BRANCH: main
 
     steps:
     - uses: actions/checkout@v4

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/client/FesenClient.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/client/FesenClient.java
@@ -84,8 +84,6 @@ import org.opensearch.action.termvectors.TermVectorsResponse;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateRequestBuilder;
 import org.opensearch.action.update.UpdateResponse;
-import org.opensearch.client.AdminClient;
-import org.opensearch.client.Client;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -97,6 +95,8 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.Scroll;
 import org.opensearch.search.SearchHit;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.AdminClient;
+import org.opensearch.transport.client.Client;
 
 import jakarta.annotation.PreDestroy;
 
@@ -584,5 +584,28 @@ public class FesenClient implements Client {
     @Override
     public void pitSegments(final PitSegmentsRequest pitSegmentsRequest, final ActionListener<IndicesSegmentResponse> listener) {
         client.pitSegments(pitSegmentsRequest, listener);
+    }
+
+    @Override
+    public void searchView(org.opensearch.action.admin.indices.view.SearchViewAction.Request request,
+            ActionListener<SearchResponse> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<SearchResponse> searchView(org.opensearch.action.admin.indices.view.SearchViewAction.Request request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void listViewNames(org.opensearch.action.admin.indices.view.ListViewNamesAction.Request request,
+            ActionListener<org.opensearch.action.admin.indices.view.ListViewNamesAction.Response> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<org.opensearch.action.admin.indices.view.ListViewNamesAction.Response> listViewNames(
+            org.opensearch.action.admin.indices.view.ListViewNamesAction.Request request) {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/AbstractCrawlerService.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/AbstractCrawlerService.java
@@ -66,7 +66,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentType;
@@ -329,7 +329,7 @@ public abstract class AbstractCrawlerService {
             callback.accept(builder);
             return builder.execute();
         }).getHits().getTotalHits();
-        return totalHits != null ? (int) totalHits.value : 0;
+        return totalHits != null ? (int) totalHits.value() : 0;
     }
 
     protected <T> T get(final Class<T> clazz, final String sessionId, final String url) {
@@ -393,7 +393,7 @@ public abstract class AbstractCrawlerService {
         final OpenSearchResultList<T> targetList = new OpenSearchResultList<>();
         final SearchHits hits = response.getHits();
         final TotalHits totalHits = hits.getTotalHits();
-        final long totalHitsValue = totalHits != null ? totalHits.value : 0;
+        final long totalHitsValue = totalHits != null ? totalHits.value() : 0;
         targetList.setTotalHits(totalHitsValue);
         targetList.setTookInMillis(response.getTook().getMillis());
         if (totalHitsValue != 0) {

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/OpenSearchDataService.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/OpenSearchDataService.java
@@ -101,7 +101,7 @@ public class OpenSearchDataService extends AbstractCrawlerService implements Dat
         final OpenSearchResultList<OpenSearchAccessResult> targetList = new OpenSearchResultList<>();
         final SearchHits hits = response.getHits();
         final TotalHits totalHits = hits.getTotalHits();
-        final long totalHitsValue = totalHits != null ? totalHits.value : 0;
+        final long totalHitsValue = totalHits != null ? totalHits.value() : 0;
         targetList.setTotalHits(totalHitsValue);
         targetList.setTookInMillis(response.getTook().getMillis());
         if (totalHitsValue != 0) {

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
@@ -88,11 +88,11 @@ public class OpenSearchUrlQueueServiceTest extends LastaDiTestCase {
 
         urlQueueService.insert(urlQueue);
         assertTrue(fesenClient.prepareSearch("fess_crawler.queue").setQuery(QueryBuilders.termQuery("sessionId", "sessionId")).setSize(0)
-                .execute().actionGet().getHits().getTotalHits().value > 0);
+                .execute().actionGet().getHits().getTotalHits().value() > 0);
 
         urlQueueService.delete("sessionId");
         assertFalse(fesenClient.prepareSearch("fess_crawler.queue").setQuery(QueryBuilders.termQuery("sessionId", "sessionId")).setSize(0)
-                .execute().actionGet().getHits().getTotalHits().value > 0);
+                .execute().actionGet().getHits().getTotalHits().value() > 0);
 
     }
 
@@ -115,20 +115,20 @@ public class OpenSearchUrlQueueServiceTest extends LastaDiTestCase {
 
         urlQueueService.insert(urlQueue2);
         assertTrue(fesenClient.prepareSearch("fess_crawler.queue").setQuery(QueryBuilders.termQuery("sessionId", "id1")).execute()
-                .actionGet().getHits().getTotalHits().value > 0);
+                .actionGet().getHits().getTotalHits().value() > 0);
         assertTrue(fesenClient.prepareSearch("fess_crawler.queue").setQuery(QueryBuilders.termQuery("sessionId", "id2")).execute()
-                .actionGet().getHits().getTotalHits().value > 0);
+                .actionGet().getHits().getTotalHits().value() > 0);
 
         urlQueueService.delete("id1");
         assertFalse(fesenClient.prepareSearch("fess_crawler.queue").setQuery(QueryBuilders.termQuery("sessionId", "id1")).execute()
-                .actionGet().getHits().getTotalHits().value > 0);
+                .actionGet().getHits().getTotalHits().value() > 0);
         assertTrue(fesenClient.prepareSearch("fess_crawler.queue").setQuery(QueryBuilders.termQuery("sessionId", "id2")).execute()
-                .actionGet().getHits().getTotalHits().value > 0);
+                .actionGet().getHits().getTotalHits().value() > 0);
 
         urlQueueService.deleteAll();
         assertFalse(fesenClient.prepareSearch("fess_crawler.queue").setQuery(QueryBuilders.termQuery("sessionId", "id1")).execute()
-                .actionGet().getHits().getTotalHits().value > 0);
+                .actionGet().getHits().getTotalHits().value() > 0);
         assertFalse(fesenClient.prepareSearch("fess_crawler.queue").setQuery(QueryBuilders.termQuery("sessionId", "id2")).execute()
-                .actionGet().getHits().getTotalHits().value > 0);
+                .actionGet().getHits().getTotalHits().value() > 0);
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to improve compatibility with updated OpenSearch APIs and enhance code maintainability. The most notable updates include replacing deprecated methods with their updated counterparts, introducing new unimplemented methods for future functionality, and updating imports to reflect API changes.

### Updates for OpenSearch API compatibility:

* Updated calls to `TotalHits.value` to use the method `TotalHits.value()` in multiple files to align with the updated OpenSearch API. This change affects `AbstractCrawlerService.java`, `OpenSearchDataService.java`, and test files. [[1]](diffhunk://#diff-93297d7f47fd11e5f14684bec0c35bef7ceba51997025f2f3e29b485e85504bbL332-R332) [[2]](diffhunk://#diff-93297d7f47fd11e5f14684bec0c35bef7ceba51997025f2f3e29b485e85504bbL396-R396) [[3]](diffhunk://#diff-25713a5b6474b6f8933eed551d1096d3d09bedb169f404a39c108f012e052843L104-R104) [[4]](diffhunk://#diff-4221d5c0660efc175f9b1b010bf1d6417ab49e2723ba371b3826f8bb1ccef834L91-R95) [[5]](diffhunk://#diff-4221d5c0660efc175f9b1b010bf1d6417ab49e2723ba371b3826f8bb1ccef834L118-R132)

### New unimplemented methods:

* Added placeholder methods (`searchView` and `listViewNames`) in `FesenClient.java` to prepare for future functionality related to search views and view names. These methods currently throw `UnsupportedOperationException`.

### Import updates:

* Replaced deprecated `AcknowledgedResponse` import with `clustermanager.AcknowledgedResponse` in `AbstractCrawlerService.java` to reflect changes in OpenSearch API.
* Adjusted imports in `FesenClient.java` to include `AdminClient` and `Client` from the `transport.client` package, replacing their previous locations. [[1]](diffhunk://#diff-8d27d1f72bbb5bfba562c16b9ba247289a704c9b067ace750a1ace764bd9e724L87-L88) [[2]](diffhunk://#diff-8d27d1f72bbb5bfba562c16b9ba247289a704c9b067ace750a1ace764bd9e724R98-R99)