### PR TITLE
Update parent POM version to 15.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.0.0-SNAPSHOT</version>
+		<version>15.0.0</version>
 	</parent>
 	<modules>
 		<module>fess-crawler</module>


### PR DESCRIPTION
This update changes the parent POM version from 15.0.0-SNAPSHOT to the final release version 15.0.0. This typically indicates a release preparation or version stabilization step.
