### PR TITLE
Fix Javadoc warnings.

### DIFF
--- a/fess-crawler-lasta/src/main/java/org/codelibs/fess/crawler/container/LastaCrawlerContainer.java
+++ b/fess-crawler-lasta/src/main/java/org/codelibs/fess/crawler/container/LastaCrawlerContainer.java
@@ -17,8 +17,17 @@ package org.codelibs.fess.crawler.container;
 
 import org.lastaflute.di.core.factory.SingletonLaContainerFactory;
 
+/**
+ * LastaFlute implementation of {@link CrawlerContainer}.
+ *
+ * @author shinsuke
+ *
+ */
 public class LastaCrawlerContainer implements CrawlerContainer {
 
+    /**
+     * Creates a new instance of LastaCrawlerContainer.
+     */
     public LastaCrawlerContainer() {
         initialize();
     }

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/entity/OpenSearchAccessResult.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/entity/OpenSearchAccessResult.java
@@ -23,38 +23,102 @@ import org.lastaflute.di.core.SingletonLaContainer;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 
+/**
+ * OpenSearchAccessResult is an implementation of {@link AccessResult} for OpenSearch.
+ *
+ * @author shinsuke
+ *
+ */
 public class OpenSearchAccessResult extends AccessResultImpl<String> implements ToXContent {
 
+    /**
+     * Creates a new instance of OpenSearchAccessResult.
+     */
+    public OpenSearchAccessResult() {
+        // NOP
+    }
+
+    /**
+     * Field name for ID.
+     */
     public static final String ID = "id";
 
+    /**
+     * Field name for session ID.
+     */
     public static final String SESSION_ID = "sessionId";
 
+    /**
+     * Field name for rule ID.
+     */
     public static final String RULE_ID = "ruleId";
 
+    /**
+     * Field name for URL.
+     */
     public static final String URL = "url";
 
+    /**
+     * Field name for parent URL.
+     */
     public static final String PARENT_URL = "parentUrl";
 
+    /**
+     * Field name for status.
+     */
     public static final String STATUS = "status";
 
+    /**
+     * Field name for HTTP status code.
+     */
     public static final String HTTP_STATUS_CODE = "httpStatusCode";
 
+    /**
+     * Field name for method.
+     */
     public static final String METHOD = "method";
 
+    /**
+     * Field name for MIME type.
+     */
     public static final String MIME_TYPE = "mimeType";
 
+    /**
+     * Field name for creation time.
+     */
     public static final String CREATE_TIME = "createTime";
 
+    /**
+     * Field name for execution time.
+     */
     public static final String EXECUTION_TIME = "executionTime";
 
+    /**
+     * Field name for content length.
+     */
     public static final String CONTENT_LENGTH = "contentLength";
 
+    /**
+     * Field name for last modified timestamp.
+     */
     public static final String LAST_MODIFIED = "lastModified";
 
+    /**
+     * Field name for access result data.
+     */
     public static final String ACCESS_RESULT_DATA = "accessResultData";
 
+    /**
+     * Flag indicating whether the access result data has been initialized.
+     */
     private boolean initializedData = false;
 
+    /**
+     * Initializes the access result with response data and result data.
+     *
+     * @param responseData The response data from the crawl operation.
+     * @param resultData The result data from content processing.
+     */
     @Override
     public void init(final ResponseData responseData, final ResultData resultData) {
 
@@ -70,6 +134,11 @@ public class OpenSearchAccessResult extends AccessResultImpl<String> implements 
         setAccessResultData(accessResultData);
     }
 
+    /**
+     * Gets the access result data, loading it from the data service if not already initialized.
+     *
+     * @return The access result data.
+     */
     @Override
     public AccessResultData<String> getAccessResultData() {
         if (!initializedData) {
@@ -84,12 +153,25 @@ public class OpenSearchAccessResult extends AccessResultImpl<String> implements 
         return accessResultData;
     }
 
+    /**
+     * Sets the access result data and marks it as initialized.
+     *
+     * @param accessResultDataAsOne The access result data to set.
+     */
     @Override
     public void setAccessResultData(final AccessResultData<String> accessResultDataAsOne) {
         accessResultData = accessResultDataAsOne;
         initializedData = true;
     }
 
+    /**
+     * Converts this access result to XContent format for OpenSearch indexing.
+     *
+     * @param builder The XContentBuilder to write to.
+     * @param params Additional parameters for the conversion.
+     * @return The XContentBuilder with the access result data.
+     * @throws IOException if the conversion fails.
+     */
     @Override
     public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
         builder.startObject();

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/entity/OpenSearchAccessResultData.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/entity/OpenSearchAccessResultData.java
@@ -23,19 +23,44 @@ import org.codelibs.fess.crawler.exception.OpenSearchAccessException;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 
+/**
+ * OpenSearchAccessResultData is an implementation of {@link AccessResultData} for OpenSearch.
+ */
 public class OpenSearchAccessResultData extends AccessResultDataImpl<String> implements ToXContent {
 
+    /**
+     * Field name for ID.
+     */
     public static final String ID = "id";
 
+    /**
+     * Field name for transformer name.
+     */
     public static final String TRANSFORMER_NAME = "transformerName";
 
+    /**
+     * Field name for data.
+     */
     public static final String DATA = "data";
 
+    /**
+     * Field name for encoding.
+     */
     public static final String ENCODING = "encoding";
 
+    /**
+     * Creates a new instance of OpenSearchAccessResultData.
+     */
     public OpenSearchAccessResultData() {
     }
 
+    /**
+     * Creates a new instance of OpenSearchAccessResultData from a source map.
+     * This constructor is used when loading data from OpenSearch.
+     *
+     * @param src The source map containing the access result data fields.
+     * @throws OpenSearchAccessException if the data cannot be decoded.
+     */
     public OpenSearchAccessResultData(final Map<String, Object> src) {
         setTransformerName((String) src.get(TRANSFORMER_NAME));
         setEncoding((String) src.get(ENCODING));
@@ -49,6 +74,14 @@ public class OpenSearchAccessResultData extends AccessResultDataImpl<String> imp
         }
     }
 
+    /**
+     * Converts this access result data to XContent format for OpenSearch indexing.
+     *
+     * @param builder The XContentBuilder to write to.
+     * @param params Additional parameters for the conversion.
+     * @return The XContentBuilder with the access result data.
+     * @throws IOException if the conversion fails.
+     */
     @Override
     public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
         builder.startObject();

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/entity/OpenSearchUrlFilter.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/entity/OpenSearchUrlFilter.java
@@ -20,54 +20,125 @@ import java.io.IOException;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 
+/**
+ * OpenSearchUrlFilter is an entity for URL filters in OpenSearch.
+ */
 public class OpenSearchUrlFilter implements ToXContent {
 
+    /**
+     * Creates a new instance of OpenSearchUrlFilter.
+     */
+    public OpenSearchUrlFilter() {
+        // NOP
+    }
+
+    /**
+     * Field name for session ID.
+     */
     public static final String SESSION_ID = "sessionId";
 
+    /**
+     * Field name for filter type.
+     */
     public static final String FILTER_TYPE = "filterType";
 
+    /**
+     * Field name for URL.
+     */
     public static final String URL = "url";
 
+    /**
+     * The unique identifier for this URL filter.
+     */
     private String id;
 
+    /**
+     * The session ID associated with this URL filter.
+     */
     private String sessionId;
 
+    /**
+     * The type of filter (e.g., include, exclude).
+     */
     private String filterType;
 
+    /**
+     * The URL pattern for this filter.
+     */
     private String url;
 
+    /**
+     * Returns the ID.
+     * @return The ID.
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Sets the ID.
+     * @param id The ID.
+     */
     public void setId(final String id) {
         this.id = id;
     }
 
+    /**
+     * Returns the session ID.
+     * @return The session ID.
+     */
     public String getSessionId() {
         return sessionId;
     }
 
+    /**
+     * Sets the session ID.
+     * @param sessionId The session ID.
+     */
     public void setSessionId(final String sessionId) {
         this.sessionId = sessionId;
     }
 
+    /**
+     * Returns the filter type.
+     * @return The filter type.
+     */
     public String getFilterType() {
         return filterType;
     }
 
+    /**
+     * Sets the filter type.
+     * @param filterType The filter type.
+     */
     public void setFilterType(final String filterType) {
         this.filterType = filterType;
     }
 
+    /**
+     * Returns the URL.
+     * @return The URL.
+     */
     public String getUrl() {
         return url;
     }
 
+    /**
+     * Sets the URL.
+     * @param url The URL.
+     */
     public void setUrl(final String url) {
         this.url = url;
     }
 
+    /**
+     * Converts this URL filter to XContent format for OpenSearch indexing.
+     *
+     * @param builder The XContentBuilder to write to.
+     * @param params Additional parameters for the conversion.
+     * @return The XContentBuilder with the URL filter data.
+     * @throws IOException if the conversion fails.
+     */
     @Override
     public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
         builder.startObject();

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/entity/OpenSearchUrlQueue.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/entity/OpenSearchUrlQueue.java
@@ -20,26 +20,71 @@ import java.io.IOException;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 
+/**
+ * OpenSearchUrlQueue is an implementation of {@link UrlQueue} for OpenSearch.
+ */
 public class OpenSearchUrlQueue extends UrlQueueImpl<String> implements ToXContent {
 
+    /**
+     * Creates a new instance of OpenSearchUrlQueue.
+     */
+    public OpenSearchUrlQueue() {
+        // NOP
+    }
+
+    /**
+     * Field name for ID.
+     */
     public static final String ID = "id";
 
+    /**
+     * Field name for session ID.
+     */
     public static final String SESSION_ID = "sessionId";
 
+    /**
+     * Field name for method.
+     */
     public static final String METHOD = "method";
 
+    /**
+     * Field name for URL.
+     */
     public static final String URL = "url";
 
+    /**
+     * Field name for parent URL.
+     */
     public static final String PARENT_URL = "parentUrl";
 
+    /**
+     * Field name for depth.
+     */
     public static final String DEPTH = "depth";
 
+    /**
+     * Field name for last modified timestamp.
+     */
     public static final String LAST_MODIFIED = "lastModified";
 
+    /**
+     * Field name for creation time.
+     */
     public static final String CREATE_TIME = "createTime";
 
+    /**
+     * Field name for weight.
+     */
     public static final String WEIGHT = "weight";
 
+    /**
+     * Converts this URL queue entry to XContent format for OpenSearch indexing.
+     *
+     * @param builder The XContentBuilder to write to.
+     * @param params Additional parameters for the conversion.
+     * @return The XContentBuilder with the URL queue data.
+     * @throws IOException if the conversion fails.
+     */
     @Override
     public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
         builder.startObject();

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/exception/OpenSearchAccessException.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/exception/OpenSearchAccessException.java
@@ -15,14 +15,31 @@
  */
 package org.codelibs.fess.crawler.exception;
 
+/**
+ * This exception is thrown when an error occurs during OpenSearch access.
+ *
+ * @author shinsuke
+ *
+ */
 public class OpenSearchAccessException extends CrawlerSystemException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new instance of OpenSearchAccessException.
+     *
+     * @param message the detail message
+     */
     public OpenSearchAccessException(final String message) {
         super(message);
     }
 
+    /**
+     * Creates a new instance of OpenSearchAccessException.
+     *
+     * @param message the detail message
+     * @param cause the cause
+     */
     public OpenSearchAccessException(final String message, final Throwable cause) {
         super(message, cause);
     }

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/util/OpenSearchCrawlerConfig.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/util/OpenSearchCrawlerConfig.java
@@ -15,93 +15,204 @@
  */
 package org.codelibs.fess.crawler.util;
 
+/**
+ * Configuration class for OpenSearch crawler settings.
+ * This class provides configuration for index names, shards, and replicas
+ * for the queue, data, and filter indices used by the crawler.
+ */
 public class OpenSearchCrawlerConfig {
+    /**
+     * Constructs a new OpenSearchCrawlerConfig.
+     */
+    public OpenSearchCrawlerConfig() {
+        // Default constructor
+    }
+
+    /**
+     * Queue index name.
+     */
     protected String queueIndex = ".crawler.queue";
 
+    /**
+     * Data index name.
+     */
     protected String dataIndex = ".crawler.data";
 
+    /**
+     * Filter index name.
+     */
     protected String filterIndex = ".crawler.filter";
 
+    /**
+     * Number of shards for the queue index.
+     */
     protected int queueShards = Runtime.getRuntime().availableProcessors() * 2;
 
+    /**
+     * Number of shards for the data index.
+     */
     protected int dataShards = Runtime.getRuntime().availableProcessors() * 2;
 
+    /**
+     * Number of shards for the filter index.
+     */
     protected int filterShards = Runtime.getRuntime().availableProcessors() * 2;
 
+    /**
+     * Number of replicas for the queue index.
+     */
     protected int queueReplicas = 1;
 
+    /**
+     * Number of replicas for the data index.
+     */
     protected int dataReplicas = 1;
 
+    /**
+     * Number of replicas for the filter index.
+     */
     protected int filterReplicas = 1;
 
+    /**
+     * Returns the queue index name.
+     * @return The queue index name.
+     */
     public String getQueueIndex() {
         return queueIndex;
     }
 
+    /**
+     * Sets the queue index name.
+     * @param queueIndex The queue index name.
+     */
     public void setQueueIndex(final String queueIndex) {
         this.queueIndex = queueIndex;
     }
 
+    /**
+     * Returns the data index name.
+     * @return The data index name.
+     */
     public String getDataIndex() {
         return dataIndex;
     }
 
+    /**
+     * Sets the data index name.
+     * @param dataIndex The data index name.
+     */
     public void setDataIndex(final String dataIndex) {
         this.dataIndex = dataIndex;
     }
 
+    /**
+     * Returns the filter index name.
+     * @return The filter index name.
+     */
     public String getFilterIndex() {
         return filterIndex;
     }
 
+    /**
+     * Sets the filter index name.
+     * @param filterIndex The filter index name.
+     */
     public void setFilterIndex(final String filterIndex) {
         this.filterIndex = filterIndex;
     }
 
+    /**
+     * Returns the number of queue shards.
+     * @return The number of queue shards.
+     */
     public int getQueueShards() {
         return queueShards;
     }
 
+    /**
+     * Sets the number of queue shards.
+     * @param queueShards The number of queue shards.
+     */
     public void setQueueShards(final int queueShards) {
         this.queueShards = queueShards;
     }
 
+    /**
+     * Returns the number of data shards.
+     * @return The number of data shards.
+     */
     public int getDataShards() {
         return dataShards;
     }
 
+    /**
+     * Sets the number of data shards.
+     * @param dataShards The number of data shards.
+     */
     public void setDataShards(final int dataShards) {
         this.dataShards = dataShards;
     }
 
+    /**
+     * Returns the number of filter shards.
+     * @return The number of filter shards.
+     */
     public int getFilterShards() {
         return filterShards;
     }
 
+    /**
+     * Sets the number of filter shards.
+     * @param filterShards The number of filter shards.
+     */
     public void setFilterShards(final int filterShards) {
         this.filterShards = filterShards;
     }
 
+    /**
+     * Returns the number of queue replicas.
+     * @return The number of queue replicas.
+     */
     public int getQueueReplicas() {
         return queueReplicas;
     }
 
+    /**
+     * Sets the number of queue replicas.
+     * @param queueReplicas The number of queue replicas.
+     */
     public void setQueueReplicas(final int queueReplicas) {
         this.queueReplicas = queueReplicas;
     }
 
+    /**
+     * Returns the number of data replicas.
+     * @return The number of data replicas.
+     */
     public int getDataReplicas() {
         return dataReplicas;
     }
 
+    /**
+     * Sets the number of data replicas.
+     * @param dataReplicas The number of data replicas.
+     */
     public void setDataReplicas(final int dataReplicas) {
         this.dataReplicas = dataReplicas;
     }
 
+    /**
+     * Returns the number of filter replicas.
+     * @return The number of filter replicas.
+     */
     public int getFilterReplicas() {
         return filterReplicas;
     }
 
+    /**
+     * Sets the number of filter replicas.
+     * @param filterReplicas The number of filter replicas.
+     */
     public void setFilterReplicas(final int filterReplicas) {
         this.filterReplicas = filterReplicas;
     }

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/util/OpenSearchResultList.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/util/OpenSearchResultList.java
@@ -17,26 +17,59 @@ package org.codelibs.fess.crawler.util;
 
 import java.util.ArrayList;
 
+/**
+ * OpenSearchResultList is a list of OpenSearch results.
+ *
+ * @param <E> The type of elements in this list.
+ */
 public class OpenSearchResultList<E> extends ArrayList<E> {
+    /**
+     * Constructs a new OpenSearchResultList.
+     */
+    public OpenSearchResultList() {
+        super();
+    }
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Total number of hits.
+     */
     private long totalHits;
 
+    /**
+     * Time taken for the search in milliseconds.
+     */
     private long tookInMillis;
 
+    /**
+     * Sets the total number of hits.
+     * @param totalHits The total number of hits.
+     */
     public void setTotalHits(final long totalHits) {
         this.totalHits = totalHits;
     }
 
+    /**
+     * Returns the total number of hits.
+     * @return The total number of hits.
+     */
     public long getTotalHits() {
         return totalHits;
     }
 
+    /**
+     * Sets the time taken for the search in milliseconds.
+     * @param tookInMillis The time taken in milliseconds.
+     */
     public void setTookInMillis(final long tookInMillis) {
         this.tookInMillis = tookInMillis;
     }
 
+    /**
+     * Returns the time taken for the search in milliseconds.
+     * @return The time taken in milliseconds.
+     */
     public long getTookInMillis() {
         return tookInMillis;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/Constants.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/Constants.java
@@ -25,44 +25,104 @@ import java.nio.charset.StandardCharsets;
  * It is designed to avoid the instantiation.
  */
 public final class Constants {
+    /**
+     * The GET method.
+     */
     public static final String GET_METHOD = "GET";
 
+    /**
+     * The HEAD method.
+     */
     public static final String HEAD_METHOD = "HEAD";
 
+    /**
+     * The POST method.
+     */
     public static final String POST_METHOD = "POST";
 
+    /**
+     * The status code for OK.
+     */
     public static final int OK_STATUS = 0;
 
+    /**
+     * The status code for Not Modified.
+     */
     public static final int NOT_MODIFIED_STATUS = 304;
 
+    /**
+     * The HTTP status code for OK.
+     */
     public static final int OK_STATUS_CODE = 200;
 
+    /**
+     * The HTTP status code for Not Modified.
+     */
     public static final int NOT_MODIFIED_STATUS_CODE = 304;
 
+    /**
+     * The HTTP status code for Bad Request.
+     */
     public static final int BAD_REQUEST_STATUS_CODE = 400;
 
+    /**
+     * The HTTP status code for Forbidden.
+     */
     public static final int FORBIDDEN_STATUS_CODE = 403;
 
+    /**
+     * The HTTP status code for Not Found.
+     */
     public static final int NOT_FOUND_STATUS_CODE = 404;
 
+    /**
+     * The HTTP status code for Server Error.
+     */
     public static final int SERVER_ERROR_STATUS_CODE = 500;
 
+    /**
+     * A constant for no transformer.
+     */
     public static final String NO_TRANSFORMER = "NONE";
 
+    /**
+     * A constant for "false".
+     */
     public static final String FALSE = "false";
 
+    /**
+     * A constant for "UTF-8".
+     */
     public static final String UTF_8 = "UTF-8";
 
+    /**
+     * A constant for UTF-8 charset.
+     */
     public static final Charset UTF_8_CHARSET = StandardCharsets.UTF_8;
 
+    /**
+     * The default charset.
+     */
     public static final Charset DEFAULT_CHARSET;
 
+    /**
+     * The ISO date-time format.
+     */
     public static final String ISO_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
+    /**
+     * The feature for secure processing in XML.
+     */
     public static final String FEATURE_SECURE_PROCESSING = "http://javax.xml.XMLConstants/feature/secure-processing";
 
+    /**
+     * The feature for external general entities in XML.
+     */
     public static final String FEATURE_EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
 
+    /**
+     * Feature for external parameter entities in XML.
+     */
     public static final String FEATURE_EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
 
     static {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerContext.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerContext.java
@@ -40,29 +40,67 @@ import org.codelibs.fess.crawler.rule.RuleManager;
  * </p>
  */
 public class CrawlerContext {
+    /**
+     * Constructs a new CrawlerContext.
+     */
+    public CrawlerContext() {
+        // Default constructor
+    }
+
+    /**
+     * Session identifier for the crawling session.
+     */
     protected String sessionId;
 
+    /**
+     * Current number of active crawler threads.
+     */
     protected Integer activeThreadCount = 0;
 
+    /**
+     * Lock object for synchronizing access to active thread count.
+     */
     protected Object activeThreadCountLock = new Object();
 
+    /**
+     * Atomic counter for tracking the number of accesses made.
+     */
     protected AtomicLong accessCount = new AtomicLong(0);
 
+    /**
+     * Current status of the crawler.
+     */
     protected volatile CrawlerStatus status = CrawlerStatus.INITIALIZING;
 
+    /**
+     * Filter for URLs to control which URLs are processed.
+     */
     protected UrlFilter urlFilter;
 
+    /**
+     * Manager for crawling rules and configurations.
+     */
     protected RuleManager ruleManager;
 
+    /**
+     * Controller for managing crawling intervals and delays.
+     */
     protected IntervalController intervalController;
 
+    /**
+     * Set of robots.txt URLs that have been processed.
+     */
     protected Set<String> robotsTxtUrlSet = new LruHashSet<>(10000);
 
+    /**
+     * Thread-local storage for sitemaps.
+     */
     protected ThreadLocal<String[]> sitemapsLocal = new ThreadLocal<>();
 
     /** The number of threads used by the crawler */
     protected int numOfThread = 10;
 
+    /** The maximum number of times to check for active threads. */
     protected int maxThreadCheckCount = 20;
 
     /** The maximum depth for crawling. A value of -1 indicates no depth check. */
@@ -71,114 +109,226 @@ public class CrawlerContext {
     /** The maximum number of URLs to access. A value of 0 indicates no limit. */
     protected long maxAccessCount = 0;
 
+    /**
+     * Returns the session ID.
+     * @return The session ID.
+     */
     public String getSessionId() {
         return sessionId;
     }
 
+    /**
+     * Sets the session ID.
+     * @param sessionId The session ID.
+     */
     public void setSessionId(final String sessionId) {
         this.sessionId = sessionId;
     }
 
+    /**
+     * Returns the active thread count.
+     * @return The active thread count.
+     */
     public Integer getActiveThreadCount() {
         return activeThreadCount;
     }
 
+    /**
+     * Sets the active thread count.
+     * @param activeThreadCount The active thread count.
+     */
     public void setActiveThreadCount(final Integer activeThreadCount) {
         this.activeThreadCount = activeThreadCount;
     }
 
+    /**
+     * Returns the access count.
+     * @return The access count.
+     */
     public long getAccessCount() {
         return accessCount.get();
     }
 
+    /**
+     * Increments the access count and returns the new value.
+     * @return The incremented access count.
+     */
     public long incrementAndGetAccessCount() {
         return accessCount.incrementAndGet();
     }
 
+    /**
+     * Decrements the access count and returns the new value.
+     * @return The decremented access count.
+     */
     public long decrementAndGetAccessCount() {
         return accessCount.decrementAndGet();
     }
 
+    /**
+     * Returns the crawler status.
+     * @return The CrawlerStatus.
+     */
     public CrawlerStatus getStatus() {
         return status;
     }
 
+    /**
+     * Sets the crawler status.
+     * @param status The CrawlerStatus.
+     */
     public void setStatus(final CrawlerStatus status) {
         this.status = status;
     }
 
+    /**
+     * Returns the URL filter.
+     * @return The UrlFilter.
+     */
     public UrlFilter getUrlFilter() {
         return urlFilter;
     }
 
+    /**
+     * Sets the URL filter.
+     * @param urlFilter The UrlFilter.
+     */
     public void setUrlFilter(final UrlFilter urlFilter) {
         this.urlFilter = urlFilter;
     }
 
+    /**
+     * Returns the rule manager.
+     * @return The RuleManager.
+     */
     public RuleManager getRuleManager() {
         return ruleManager;
     }
 
+    /**
+     * Sets the rule manager.
+     * @param ruleManager The RuleManager.
+     */
     public void setRuleManager(final RuleManager ruleManager) {
         this.ruleManager = ruleManager;
     }
 
+    /**
+     * Returns the interval controller.
+     * @return The IntervalController.
+     */
     public IntervalController getIntervalController() {
         return intervalController;
     }
 
+    /**
+     * Sets the interval controller.
+     * @param intervalController The IntervalController.
+     */
     public void setIntervalController(final IntervalController intervalController) {
         this.intervalController = intervalController;
     }
 
+    /**
+     * Returns the set of robots.txt URLs.
+     * @return The set of robots.txt URLs.
+     */
     public Set<String> getRobotsTxtUrlSet() {
         return robotsTxtUrlSet;
     }
 
+    /**
+     * Sets the set of robots.txt URLs.
+     * @param robotsTxtUrlSet The set of robots.txt URLs.
+     */
     public void setRobotsTxtUrlSet(final Set<String> robotsTxtUrlSet) {
         this.robotsTxtUrlSet = robotsTxtUrlSet;
     }
 
+    /**
+     * Returns the lock object for active thread count.
+     * @return The lock object.
+     */
     public Object getActiveThreadCountLock() {
         return activeThreadCountLock;
     }
 
+    /**
+     * Returns the number of threads.
+     * @return The number of threads.
+     */
     public int getNumOfThread() {
         return numOfThread;
     }
 
+    /**
+     * Sets the number of threads.
+     * @param numOfThread The number of threads.
+     */
     public void setNumOfThread(final int numOfThread) {
         this.numOfThread = numOfThread;
     }
 
+    /**
+     * Returns the maximum thread check count.
+     * @return The maximum thread check count.
+     */
     public int getMaxThreadCheckCount() {
         return maxThreadCheckCount;
     }
 
+    /**
+     * Sets the maximum thread check count.
+     * @param maxThreadCheckCount The maximum thread check count.
+     */
     public void setMaxThreadCheckCount(final int maxThreadCheckCount) {
         this.maxThreadCheckCount = maxThreadCheckCount;
     }
 
+    /**
+     * Returns the maximum depth.
+     * @return The maximum depth.
+     */
     public int getMaxDepth() {
         return maxDepth;
     }
 
+    /**
+     * Sets the maximum depth.
+     * @param maxDepth The maximum depth.
+     */
     public void setMaxDepth(final int maxDepth) {
         this.maxDepth = maxDepth;
     }
 
+    /**
+     * Returns the maximum access count.
+     * @return The maximum access count.
+     */
     public long getMaxAccessCount() {
         return maxAccessCount;
     }
 
+    /**
+     * Sets the maximum access count.
+     * @param maxAccessCount The maximum access count.
+     */
     public void setMaxAccessCount(final long maxAccessCount) {
         this.maxAccessCount = maxAccessCount;
     }
 
+    /**
+     * Adds sitemaps to the thread-local storage.
+     * @param sitemaps An array of sitemap URLs.
+     */
     public void addSitemaps(final String[] sitemaps) {
         sitemapsLocal.set(sitemaps);
     }
 
+    /**
+     * Removes sitemaps from the thread-local storage and returns them.
+     * @return An array of sitemap URLs, or null if none were present.
+     */
     public String[] removeSitemaps() {
         final String[] sitemaps = sitemapsLocal.get();
         if (sitemaps != null) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/builder/RequestDataBuilder.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/builder/RequestDataBuilder.java
@@ -40,10 +40,18 @@ public final class RequestDataBuilder {
     private RequestDataBuilder() {
     }
 
+    /**
+     * Creates a new RequestDataContext for building RequestData instances.
+     *
+     * @return a new RequestDataContext instance
+     */
     public static RequestDataContext newRequestData() {
         return new RequestDataContext();
     }
 
+    /**
+     * Context class for building RequestData instances using a fluent API.
+     */
     public static class RequestDataContext {
         private final RequestData data;
 
@@ -51,6 +59,12 @@ public final class RequestDataBuilder {
             data = new RequestData();
         }
 
+        /**
+         * Sets the HTTP method for the request.
+         *
+         * @param method the HTTP method (GET, POST, HEAD)
+         * @return this RequestDataContext for method chaining
+         */
         public RequestDataContext method(final String method) {
             if (Constants.GET_METHOD.equalsIgnoreCase(method)) {
                 return get();
@@ -64,19 +78,36 @@ public final class RequestDataBuilder {
             return get();
         }
 
+        /**
+         * Sets the HTTP method for the request.
+         * @param method The HTTP method.
+         * @return The current RequestDataContext instance.
+         */
         public RequestDataContext method(final Method method) {
             data.setMethod(method);
             return this;
         }
 
+        /**
+         * Sets the HTTP method to GET.
+         * @return The current RequestDataContext instance.
+         */
         public RequestDataContext get() {
             return method(Method.GET);
         }
 
+        /**
+         * Sets the HTTP method to HEAD.
+         * @return The current RequestDataContext instance.
+         */
         public RequestDataContext head() {
             return method(Method.HEAD);
         }
 
+        /**
+         * Sets the HTTP method to POST.
+         * @return The current RequestDataContext instance.
+         */
         public RequestDataContext post() {
             return method(Method.POST);
         }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/AbstractCrawlerClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/AbstractCrawlerClient.java
@@ -40,25 +40,45 @@ public abstract class AbstractCrawlerClient implements CrawlerClient {
 
     private static final Logger logger = LogManager.getLogger(AbstractCrawlerClient.class);
 
+    /** The MIME type for application/octet-stream. */
     protected static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
 
+    /** The property name for access timeout. */
     public static final String ACCESS_TIMEOUT_PROPERTY = "accessTimeout";
 
+    /** The property name for maximum content length. */
     public static final String MAX_CONTENT_LENGTH = "maxContentLength";
 
+    /** The property name for maximum cached content size. */
     public static final String MAX_CACHED_CONTENT_SIZE = "maxCachedContentSize";
 
+    /** The crawler container. */
     @Resource
     protected CrawlerContainer crawlerContainer;
 
+    /** The initialization parameter map. */
     protected Map<String, Object> initParamMap;
 
+    /** The maximum cached content size in bytes. Default is 1MB. */
     protected long maxCachedContentSize = 1024L * 1024L; // 1MB
 
+    /** The access timeout in seconds. Default is null (no timeout). */
     protected Integer accessTimeout = null; // seconds
 
+    /** The maximum content length in bytes. Default is null (no limit). */
     protected Long maxContentLength = null;
 
+    /**
+     * Constructs a new AbstractCrawlerClient.
+     */
+    public AbstractCrawlerClient() {
+        // NOP
+    }
+
+    /**
+     * Initializes the client with parameters from initParamMap.
+     * Sets maxContentLength, accessTimeout, and maxCachedContentSize.
+     */
     public void init() {
         // max content length
         final Long maxContentLengthParam = getInitParameter(MAX_CONTENT_LENGTH, maxContentLength, Long.class);
@@ -79,6 +99,14 @@ public abstract class AbstractCrawlerClient implements CrawlerClient {
         }
     }
 
+    /**
+     * Retrieves an initialization parameter, converting it to the specified class type.
+     * @param <T> The type of the parameter.
+     * @param key The key of the parameter.
+     * @param defaultValue The default value if the parameter is not found.
+     * @param clazz The class type to convert the parameter to.
+     * @return The parameter value, or the default value if not found.
+     */
     protected <T> T getInitParameter(final String key, final T defaultValue, final Class<T> clazz) {
         if (initParamMap != null) {
             try {
@@ -95,6 +123,13 @@ public abstract class AbstractCrawlerClient implements CrawlerClient {
         return defaultValue;
     }
 
+    /**
+     * Converts an object to the specified class type.
+     * @param <T> The target type.
+     * @param value The object to convert.
+     * @param clazz The class type to convert to.
+     * @return The converted object.
+     */
     @SuppressWarnings("unchecked")
     protected <T> T convertObj(final Object value, final Class<T> clazz) {
         if (clazz.isAssignableFrom(String.class)) {
@@ -122,11 +157,20 @@ public abstract class AbstractCrawlerClient implements CrawlerClient {
         return (T) value;
     }
 
+    /**
+     * Sets the initialization parameter map.
+     * @param params The map of parameters.
+     */
     @Override
     public void setInitParameterMap(final Map<String, Object> params) {
         initParamMap = params;
     }
 
+    /**
+     * Executes the request based on the HTTP method.
+     * @param request The request data.
+     * @return The response data.
+     */
     @Override
     public ResponseData execute(final RequestData request) {
         return switch (request.getMethod()) {
@@ -137,6 +181,10 @@ public abstract class AbstractCrawlerClient implements CrawlerClient {
         };
     }
 
+    /**
+     * Checks if the content length exceeds the maximum allowed length.
+     * @param responseData The response data.
+     */
     protected void checkMaxContentLength(final ResponseData responseData) {
         if (maxContentLength != null && responseData.getContentLength() > maxContentLength.longValue()) {
             throw new MaxLengthExceededException("The content length (" + responseData.getContentLength() + " byte) is over "
@@ -144,18 +192,40 @@ public abstract class AbstractCrawlerClient implements CrawlerClient {
         }
     }
 
+    /**
+     * Performs a GET request.
+     * @param url The URL to request.
+     * @return The ResponseData.
+     */
     protected ResponseData doGet(final String url) {
         throw new CrawlerSystemException("GET method is not supported.");
     }
 
+    /**
+     * Performs a HEAD request.
+     * @param url The URL to request.
+     * @return The ResponseData.
+     */
     protected ResponseData doHead(final String url) {
         throw new CrawlerSystemException("HEAD method is not supported.");
     }
 
+    /**
+     * Performs a POST request.
+     * @param url The URL to request.
+     * @return The ResponseData.
+     */
     protected ResponseData doPost(final String url) {
         throw new CrawlerSystemException("POST method is not supported.");
     }
 
+    /**
+     * Creates a temporary file.
+     * @param prefix The prefix string to be used in generating the file's name.
+     * @param suffix The suffix string to be used in generating the file's name.
+     * @param directory The directory in which the file is to be created, or null if the default temporary-file directory is to be used.
+     * @return The created temporary file.
+     */
     protected File createTempFile(final String prefix, final String suffix, final File directory) {
         try {
             final File tempFile = File.createTempFile(prefix, suffix, directory);
@@ -169,14 +239,26 @@ public abstract class AbstractCrawlerClient implements CrawlerClient {
         }
     }
 
+    /**
+     * Sets the maximum cached content size.
+     * @param maxCachedContentSize The maximum cached content size in bytes.
+     */
     public void setMaxCachedContentSize(final long maxCachedContentSize) {
         this.maxCachedContentSize = maxCachedContentSize;
     }
 
+    /**
+     * Sets the access timeout.
+     * @param accessTimeout The access timeout in seconds.
+     */
     public void setAccessTimeout(final Integer accessTimeout) {
         this.accessTimeout = accessTimeout;
     }
 
+    /**
+     * Sets the maximum content length.
+     * @param maxContentLength The maximum content length in bytes.
+     */
     public void setMaxContentLength(final Long maxContentLength) {
         this.maxContentLength = maxContentLength;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/AccessTimeoutTarget.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/AccessTimeoutTarget.java
@@ -44,10 +44,16 @@ public class AccessTimeoutTarget implements TimeoutTarget {
 
     private static final int MAX_LOOP_COUNT = 10;
 
+    /** The thread being monitored. */
     protected Thread runningThread;
 
+    /** Flag indicating if the thread is still running. */
     protected AtomicBoolean running = new AtomicBoolean();
 
+    /**
+     * Constructs an AccessTimeoutTarget with the specified thread.
+     * @param thread The thread to monitor.
+     */
     public AccessTimeoutTarget(final Thread thread) {
         runningThread = thread;
         running.set(true);
@@ -71,6 +77,9 @@ public class AccessTimeoutTarget implements TimeoutTarget {
         }
     }
 
+    /**
+     * Stops the timeout target by setting the running flag to false.
+     */
     public void stop() {
         if (logger.isDebugEnabled()) {
             logger.debug("Timeout target has been stopped.");

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/CrawlerClientCreator.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/CrawlerClientCreator.java
@@ -36,18 +36,36 @@ import jakarta.annotation.Resource;
  *
  */
 public class CrawlerClientCreator {
+    /**
+     * Constructs a new CrawlerClientCreator.
+     */
+    public CrawlerClientCreator() {
+        // Default constructor
+    }
 
+    /** Logger instance for this class */
     private static final Logger logger = LogManager.getLogger(CrawlerClientCreator.class);
 
+    /** Container for managing crawler components */
     @Resource
     protected CrawlerContainer crawlerContainer;
 
+    /** Map of regular expressions to component names */
     protected Map<String, String> clientMap = new LinkedHashMap<>();
 
+    /** List of registered crawler client factories */
     protected List<CrawlerClientFactory> clientFactoryList = new LinkedList<>();
 
+    /**
+     * The maximum size of the client factory list.
+     */
     protected int maxClientFactorySize = 10000;
 
+    /**
+     * Registers a CrawlerClientFactory with this creator.
+     * All existing client mappings will be loaded into the new factory.
+     * @param crawlerClientFactory The CrawlerClientFactory to register.
+     */
     public synchronized void register(final CrawlerClientFactory crawlerClientFactory) {
         clientMap.entrySet().stream().forEach(e -> load(crawlerClientFactory, e.getKey(), e.getValue()));
         clientFactoryList.add(crawlerClientFactory);
@@ -56,6 +74,12 @@ public class CrawlerClientCreator {
         }
     }
 
+    /**
+     * Registers a client component with a regular expression.
+     * The component will be loaded into all registered CrawlerClientFactories.
+     * @param regex The regular expression to match URLs.
+     * @param componentName The name of the component to register.
+     */
     public synchronized void register(final String regex, final String componentName) {
         clientMap.put(regex, componentName);
         clientFactoryList.forEach(f -> load(f, regex, componentName));
@@ -83,6 +107,10 @@ public class CrawlerClientCreator {
         }
     }
 
+    /**
+     * Sets the maximum client factory size.
+     * @param maxClientFactorySize The maximum size.
+     */
     public void setMaxClientFactorySize(final int maxClientFactorySize) {
         if (maxClientFactorySize <= 0) {
             throw new IllegalArgumentException("maxClientFactorySize must be positive.");

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/CrawlerClientFactory.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/CrawlerClientFactory.java
@@ -54,11 +54,28 @@ import jakarta.annotation.Resource;
 public class CrawlerClientFactory implements AutoCloseable {
     private static final Logger logger = LogManager.getLogger(CrawlerClientFactory.class);
 
+    /**
+     * The crawler container.
+     */
     @Resource
     protected CrawlerContainer crawlerContainer;
 
+    /**
+     * A map of regular expression patterns to crawler clients.
+     */
     protected Map<Pattern, CrawlerClient> clientMap = new LinkedHashMap<>();
 
+    /**
+     * Creates a new instance of CrawlerClientFactory.
+     */
+    public CrawlerClientFactory() {
+        // NOP
+    }
+
+    /**
+     * Initializes the CrawlerClientFactory.
+     * Attempts to register itself with a "crawlerClientCreator" component if available.
+     */
     @PostConstruct
     public void init() {
         try {
@@ -73,6 +90,11 @@ public class CrawlerClientFactory implements AutoCloseable {
         }
     }
 
+    /**
+     * Adds a client with a regular expression pattern.
+     * @param regex The regular expression to match URLs.
+     * @param client The CrawlerClient instance.
+     */
     public void addClient(final String regex, final CrawlerClient client) {
         if (StringUtil.isBlank(regex)) {
             throw new CrawlerSystemException("A regular expression is null.");
@@ -83,6 +105,12 @@ public class CrawlerClientFactory implements AutoCloseable {
         clientMap.put(Pattern.compile(regex), client);
     }
 
+    /**
+     * Adds a client with a regular expression pattern at a specific position.
+     * @param regex The regular expression to match URLs.
+     * @param client The CrawlerClient instance.
+     * @param pos The position to add the client.
+     */
     public void addClient(final String regex, final CrawlerClient client, final int pos) {
         if (StringUtil.isBlank(regex)) {
             throw new CrawlerSystemException("A regular expression is null.");
@@ -107,6 +135,11 @@ public class CrawlerClientFactory implements AutoCloseable {
         clientMap = newClientMap;
     }
 
+    /**
+     * Adds a client with a list of regular expression patterns.
+     * @param regexList The list of regular expressions to match URLs.
+     * @param client The CrawlerClient instance.
+     */
     public void addClient(final List<String> regexList, final CrawlerClient client) {
         if (regexList == null || regexList.isEmpty()) {
             throw new CrawlerSystemException("A regular expression list is null or empty.");
@@ -121,6 +154,11 @@ public class CrawlerClientFactory implements AutoCloseable {
         }
     }
 
+    /**
+     * Retrieves a client that matches the given URL key.
+     * @param urlKey The URL key to match.
+     * @return The matching CrawlerClient instance, or null if no match is found.
+     */
     public CrawlerClient getClient(final String urlKey) {
         if (StringUtil.isBlank(urlKey)) {
             return null;
@@ -135,6 +173,10 @@ public class CrawlerClientFactory implements AutoCloseable {
         return null;
     }
 
+    /**
+     * Sets the initialization parameter map for all clients.
+     * @param params The map of parameters.
+     */
     public void setInitParameterMap(final Map<String, Object> params) {
         if (params != null) {
             for (final CrawlerClient client : clientMap.values()) {
@@ -143,10 +185,17 @@ public class CrawlerClientFactory implements AutoCloseable {
         }
     }
 
+    /**
+     * Sets the client map.
+     * @param clientMap The map of clients.
+     */
     public void setClientMap(final Map<Pattern, CrawlerClient> clientMap) {
         this.clientMap = clientMap;
     }
 
+    /**
+     * Closes all clients in the factory.
+     */
     @Override
     public void close() {
         clientMap.values().stream().distinct().forEach(client -> {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/CrawlerClientFactoryWrapper.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/CrawlerClientFactoryWrapper.java
@@ -51,59 +51,113 @@ public class CrawlerClientFactoryWrapper extends CrawlerClientFactory {
         this.factory = factory;
     }
 
+    /**
+     * Returns the parent CrawlerClientFactory.
+     * @return The parent CrawlerClientFactory.
+     */
     public CrawlerClientFactory getParent() {
         return factory;
     }
 
+    /**
+     * Sets the initialization parameter map for this wrapper.
+     * These parameters will be applied to the wrapped factory upon calling initParameterMap().
+     * @param params The map of parameters.
+     */
     @Override
     public void setInitParameterMap(final Map<String, Object> params) {
         this.params.putAll(params);
     }
 
+    /**
+     * Initializes the parameter map of the wrapped factory with the parameters stored in this wrapper.
+     */
     public void initParameterMap() {
         factory.setInitParameterMap(params);
     }
 
+    /**
+     * Initializes the wrapped factory.
+     */
     @Override
     public void init() {
         factory.init();
     }
 
+    /**
+     * Adds a client to the wrapped factory.
+     * @param regex The regular expression for the client.
+     * @param client The CrawlerClient instance.
+     */
     @Override
     public void addClient(final String regex, final CrawlerClient client) {
         factory.addClient(regex, client);
     }
 
+    /**
+     * Adds a client to the wrapped factory at a specific position.
+     * @param regex The regular expression for the client.
+     * @param client The CrawlerClient instance.
+     * @param pos The position to add the client.
+     */
     @Override
     public void addClient(final String regex, final CrawlerClient client, final int pos) {
         factory.addClient(regex, client, pos);
     }
 
+    /**
+     * Returns the hash code of the wrapped factory.
+     * @return The hash code.
+     */
     @Override
     public int hashCode() {
         return factory.hashCode();
     }
 
+    /**
+     * Adds a list of clients to the wrapped factory.
+     * @param regexList The list of regular expressions for the clients.
+     * @param client The CrawlerClient instance.
+     */
     @Override
     public void addClient(final List<String> regexList, final CrawlerClient client) {
         factory.addClient(regexList, client);
     }
 
+    /**
+     * Retrieves a client from the wrapped factory that matches the given URL.
+     * @param url The URL to match.
+     * @return The matching CrawlerClient instance.
+     */
     @Override
     public CrawlerClient getClient(final String url) {
         return factory.getClient(url);
     }
 
+    /**
+     * Sets the client map for the wrapped factory.
+     * @param clientMap The map of clients.
+     */
     @Override
     public void setClientMap(final Map<Pattern, CrawlerClient> clientMap) {
         factory.setClientMap(clientMap);
     }
 
+    /**
+     * Compares this wrapper to another object for equality.
+     * Equality is determined by the wrapped factory.
+     * @param obj The object to compare.
+     * @return true if equal, false otherwise.
+     */
     @Override
     public boolean equals(final Object obj) {
         return factory.equals(obj);
     }
 
+    /**
+     * Returns a string representation of this wrapper.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "CrawlerClientFactoryWrapper{" + "factory=" + factory + '}';

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/FaultTolerantClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/FaultTolerantClient.java
@@ -53,15 +53,27 @@ import org.codelibs.fess.crawler.exception.MultipleCrawlingAccessException;
  */
 public class FaultTolerantClient implements CrawlerClient {
 
+    /** Logger instance for this class */
     private static final Logger logger = LogManager.getLogger(FaultTolerantClient.class);
 
+    /** The underlying crawler client */
     protected CrawlerClient client;
 
+    /** Maximum number of retry attempts */
     protected int maxRetryCount = 5;
 
+    /** Interval between retry attempts in milliseconds */
     protected long retryInterval = 500;
 
+    /** Request listener for monitoring request lifecycle */
     protected RequestListener listener;
+
+    /**
+     * Constructs a new FaultTolerantClient.
+     */
+    public FaultTolerantClient() {
+        // Default constructor
+    }
 
     @Override
     /**
@@ -73,6 +85,11 @@ public class FaultTolerantClient implements CrawlerClient {
         client.setInitParameterMap(params);
     }
 
+    /**
+     * Executes the request with retry logic.
+     * @param request The request data.
+     * @return The response data.
+     */
     @Override
     public ResponseData execute(final RequestData request) {
         if (listener != null) {
@@ -129,46 +146,109 @@ public class FaultTolerantClient implements CrawlerClient {
         client.close();
     }
 
+    /**
+     * Returns the underlying CrawlerClient.
+     * @return The CrawlerClient instance.
+     */
     public CrawlerClient getCrawlerClient() {
         return client;
     }
 
+    /**
+     * Sets the underlying CrawlerClient.
+     * @param client The CrawlerClient instance to set.
+     */
     public void setCrawlerClient(final CrawlerClient client) {
         this.client = client;
     }
 
+    /**
+     * Returns the maximum retry count.
+     * @return The maximum retry count.
+     */
     public int getMaxRetryCount() {
         return maxRetryCount;
     }
 
+    /**
+     * Sets the maximum retry count.
+     * @param maxRetryCount The maximum retry count.
+     */
     public void setMaxRetryCount(final int maxRetryCount) {
         this.maxRetryCount = maxRetryCount;
     }
 
+    /**
+     * Returns the retry interval.
+     * @return The retry interval in milliseconds.
+     */
     public long getRetryInterval() {
         return retryInterval;
     }
 
+    /**
+     * Sets the retry interval.
+     * @param retryInterval The retry interval in milliseconds.
+     */
     public void setRetryInterval(final long retryInterval) {
         this.retryInterval = retryInterval;
     }
 
+    /**
+     * Returns the request listener.
+     * @return The RequestListener instance.
+     */
     public RequestListener getRequestListener() {
         return listener;
     }
 
+    /**
+     * Sets the request listener.
+     * @param listener The RequestListener instance to set.
+     */
     public void setRequestListener(final RequestListener listener) {
         this.listener = listener;
     }
 
+    /**
+     * Interface for listening to request lifecycle events.
+     */
     public interface RequestListener {
 
+        /**
+         * Called when a request starts.
+         *
+         * @param client the fault-tolerant client
+         * @param request the request data
+         */
         void onRequestStart(FaultTolerantClient client, RequestData request);
 
+        /**
+         * Called before each request attempt.
+         *
+         * @param client the fault-tolerant client
+         * @param request the request data
+         * @param count the current retry count
+         */
         void onRequest(FaultTolerantClient client, RequestData request, int count);
 
+        /**
+         * Called when a request ends.
+         *
+         * @param client the fault-tolerant client
+         * @param request the request data
+         * @param exceptionList the list of exceptions that occurred during retries
+         */
         void onRequestEnd(FaultTolerantClient client, RequestData request, List<Exception> exceptionList);
 
+        /**
+         * Called when an exception occurs during a request attempt.
+         *
+         * @param client the fault-tolerant client
+         * @param request the request data
+         * @param count the current retry count
+         * @param e the exception that occurred
+         */
         void onException(FaultTolerantClient client, RequestData request, int count, Exception e);
 
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/fs/FileSystemClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/fs/FileSystemClient.java
@@ -64,20 +64,34 @@ import jakarta.annotation.Resource;
  */
 public class FileSystemClient extends AbstractCrawlerClient {
 
+    /** Logger instance for this class */
     private static final Logger logger = LogManager.getLogger(FileSystemClient.class);
 
+    /** Key for file attribute view in metadata */
     public static final String FILE_ATTRIBUTE_VIEW = "fileAttributeView";
 
+    /** Key for file user in metadata */
     public static final String FS_FILE_USER = "fsFileUser";
 
+    /** Key for file groups in metadata */
     public static final String FS_FILE_GROUPS = "fsFileGroups";
 
+    /** Character encoding for files */
     protected String charset = Constants.UTF_8;
 
+    /** Helper for managing content length limits */
     @Resource
     protected ContentLengthHelper contentLengthHelper;
 
+    /** Flag to track initialization status */
     protected AtomicBoolean isInit = new AtomicBoolean(false);
+
+    /**
+     * Constructs a new FileSystemClient.
+     */
+    public FileSystemClient() {
+        // Default constructor
+    }
 
     /*
      * (non-Javadoc)
@@ -89,6 +103,14 @@ public class FileSystemClient extends AbstractCrawlerClient {
         return processRequest(uri, true);
     }
 
+    /**
+     * Processes a request for the given URI.
+     *
+     * @param uri the URI to process
+     * @param includeContent whether to include content in the response
+     * @return the response data
+     * @throws CrawlingAccessException if the request fails
+     */
     protected ResponseData processRequest(final String uri, final boolean includeContent) {
         if (!isInit.get()) {
             synchronized (isInit) {
@@ -119,6 +141,15 @@ public class FileSystemClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Gets response data for the given URI.
+     *
+     * @param uri the URI to get response data for
+     * @param includeContent whether to include content in the response
+     * @return the response data
+     * @throws CrawlingAccessException if unable to access the URI
+     * @throws ChildUrlsException if the URI represents a directory with child URLs
+     */
     protected ResponseData getResponseData(final String uri, final boolean includeContent) {
         final ResponseData responseData = new ResponseData();
         try {
@@ -208,6 +239,14 @@ public class FileSystemClient extends AbstractCrawlerClient {
         return responseData;
     }
 
+    /**
+     * Parses file ownership attributes and adds them to the response data.
+     *
+     * @param responseData the response data to add attributes to
+     * @param file the file to parse attributes from
+     * @return the file owner attribute view
+     * @throws CrawlingAccessException if parsing fails
+     */
     protected FileOwnerAttributeView parseFileOwnerAttribute(final ResponseData responseData, final File file) {
         try {
             final FileOwnerAttributeView ownerAttrView = Files.getFileAttributeView(file.toPath(), FileOwnerAttributeView.class);
@@ -237,6 +276,13 @@ public class FileSystemClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Preprocesses a URI to ensure it's in the correct format for file system access.
+     *
+     * @param uri the URI to preprocess
+     * @return the preprocessed URI
+     * @throws CrawlerSystemException if the URI is empty
+     */
     protected String preprocessUri(final String uri) {
         if (StringUtil.isEmpty(uri)) {
             throw new CrawlerSystemException("The uri is empty.");
@@ -267,22 +313,38 @@ public class FileSystemClient extends AbstractCrawlerClient {
         return buf.toString();
     }
 
+    /**
+     * Gets the character set for the given file.
+     *
+     * @param file the file to get the character set for
+     * @return the character set
+     */
     protected String getCharSet(final File file) {
         return charset;
     }
 
+    /**
+     * Gets the character encoding used for files.
+     *
+     * @return the character encoding
+     */
     public String getCharset() {
         return charset;
     }
 
+    /**
+     * Sets the character encoding used for files.
+     *
+     * @param charset the character encoding to set
+     */
     public void setCharset(final String charset) {
         this.charset = charset;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.client.CrawlerClient#doHead(java.lang.String)
+    /**
+     * Executes a HEAD request for the given URL.
+     * @param url The URL to request.
+     * @return The ResponseData.
      */
     @Override
     public ResponseData doHead(final String url) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/ftp/FtpAuthentication.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/ftp/FtpAuthentication.java
@@ -31,6 +31,13 @@ import org.codelibs.core.lang.StringUtil;
 public class FtpAuthentication {
     private static final Logger logger = LogManager.getLogger(FtpAuthentication.class);
 
+    /**
+     * Constructs a new FtpAuthentication.
+     */
+    public FtpAuthentication() {
+        // Default constructor
+    }
+
     private String server;
 
     private int port;
@@ -39,38 +46,75 @@ public class FtpAuthentication {
 
     private String password;
 
+    /**
+     * Returns the server address.
+     * @return The server address.
+     */
     public String getServer() {
         return server;
     }
 
+    /**
+     * Sets the server address.
+     * @param server The server address.
+     */
     public void setServer(final String server) {
         this.server = server;
     }
 
+    /**
+     * Returns the port number.
+     * @return The port number.
+     */
     public int getPort() {
         return port;
     }
 
+    /**
+     * Sets the port number.
+     * @param port The port number.
+     */
     public void setPort(final int port) {
         this.port = port;
     }
 
+    /**
+     * Returns the username.
+     * @return The username.
+     */
     public String getUsername() {
         return username;
     }
 
+    /**
+     * Sets the username.
+     * @param username The username.
+     */
     public void setUsername(final String username) {
         this.username = username;
     }
 
+    /**
+     * Returns the password.
+     * @return The password.
+     */
     public String getPassword() {
         return password;
     }
 
+    /**
+     * Sets the password.
+     * @param password The password.
+     */
     public void setPassword(final String password) {
         this.password = password;
     }
 
+    /**
+     * Checks if this authentication matches the given FTP path.
+     * @param path The FTP path to check.
+     * @return true if it matches, false otherwise.
+     */
     boolean matches(final String path) {
         if (StringUtil.isBlank(path)) {
             return false;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/ftp/FtpAuthenticationHolder.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/ftp/FtpAuthenticationHolder.java
@@ -25,12 +25,28 @@ import java.util.List;
 public class FtpAuthenticationHolder {
     List<FtpAuthentication> authenticationList = new ArrayList<>();
 
+    /**
+     * Constructs a new FtpAuthenticationHolder.
+     */
+    public FtpAuthenticationHolder() {
+        // Default constructor
+    }
+
+    /**
+     * Adds an FtpAuthentication object to the holder.
+     * @param auth The FtpAuthentication object to add.
+     */
     public void add(final FtpAuthentication auth) {
         if (auth != null) {
             authenticationList.add(auth);
         }
     }
 
+    /**
+     * Retrieves an FtpAuthentication object that matches the given path.
+     * @param path The path to match.
+     * @return The matching FtpAuthentication object, or null if no match is found.
+     */
     public FtpAuthentication get(final String path) {
         if (path == null) {
             return null;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/Authentication.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/Authentication.java
@@ -44,6 +44,11 @@ public interface Authentication {
      *
      * @return the authentication scheme
      */
+    /**
+     * Retrieves the authentication scheme to be used for HTTP requests.
+     *
+     * @return the authentication scheme
+     */
     AuthScheme getAuthScheme();
 
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/HcConnectionMonitorTarget.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/HcConnectionMonitorTarget.java
@@ -50,8 +50,16 @@ public class HcConnectionMonitorTarget implements TimeoutTarget {
 
     private final HttpClientConnectionManager clientConnectionManager;
 
+    /**
+     * The timeout duration (in milliseconds) for idle connections.
+     */
     private final long idleConnectionTimeout;
 
+    /**
+     * Constructs a new HcConnectionMonitorTarget.
+     * @param clientConnectionManager The HttpClientConnectionManager to monitor.
+     * @param idleConnectionTimeout The idle connection timeout in milliseconds.
+     */
     public HcConnectionMonitorTarget(final HttpClientConnectionManager clientConnectionManager, final long idleConnectionTimeout) {
         this.clientConnectionManager = clientConnectionManager;
         this.idleConnectionTimeout = idleConnectionTimeout;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/HcHttpClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/HcHttpClient.java
@@ -152,113 +152,173 @@ import jakarta.annotation.Resource;
  */
 public class HcHttpClient extends AbstractCrawlerClient {
 
+    /**
+     * Constructs a new HcHttpClient.
+     */
+    public HcHttpClient() {
+        // Default constructor
+    }
+
+    /** Property name for connection timeout setting */
     public static final String CONNECTION_TIMEOUT_PROPERTY = "connectionTimeout";
 
+    /** Property name for socket timeout setting */
     public static final String SO_TIMEOUT_PROPERTY = "soTimeout";
 
+    /** Property name for proxy host setting */
     public static final String PROXY_HOST_PROPERTY = "proxyHost";
 
+    /** Property name for proxy port setting */
     public static final String PROXY_PORT_PROPERTY = "proxyPort";
 
+    /** Property name for proxy authentication scheme setting */
     public static final String PROXY_AUTH_SCHEME_PROPERTY = "proxyAuthScheme";
 
+    /** Property name for proxy credentials setting */
     public static final String PROXY_CREDENTIALS_PROPERTY = "proxyCredentials";
 
+    /** Property name for user agent setting */
     public static final String USER_AGENT_PROPERTY = "userAgent";
 
+    /** Property name for robots.txt enabled setting */
     public static final String ROBOTS_TXT_ENABLED_PROPERTY = "robotsTxtEnabled";
 
+    /** Property name for web authentications setting */
     public static final String AUTHENTICATIONS_PROPERTY = "webAuthentications";
 
+    /** Property name for request headers setting */
     public static final String REQUEST_HEADERS_PROPERTY = "requestHeaders";
 
+    /** Property name for redirects enabled setting */
     public static final String REDIRECTS_ENABLED = "redirectsEnabled";
 
+    /** Property name for cookies setting */
     public static final String COOKIES_PROPERTY = "cookies";
 
+    /** Property name for authentication scheme providers setting */
     public static final String AUTH_SCHEME_PROVIDERS_PROPERTY = "authSchemeProviders";
 
+    /** Property name for ignore SSL certificate setting */
     public static final String IGNORE_SSL_CERTIFICATE_PROPERTY = "ignoreSslCertificate";
 
+    /** Property name for default maximum connections per route setting */
     public static final String DEFAULT_MAX_CONNECTION_PER_ROUTE_PROPERTY = "defaultMaxConnectionPerRoute";
 
+    /** Property name for maximum total connections setting */
     public static final String MAX_TOTAL_CONNECTION_PROPERTY = "maxTotalConnection";
 
+    /** Property name for time to live time unit setting */
     public static final String TIME_TO_LIVE_TIME_UNIT_PROPERTY = "timeToLiveTimeUnit";
 
+    /** Property name for time to live setting */
     public static final String TIME_TO_LIVE_PROPERTY = "timeToLive";
 
+    /** Logger instance for this class */
     private static final Logger logger = LogManager.getLogger(HcHttpClient.class);
 
+    /** Helper for processing robots.txt files */
     @Resource
     protected RobotsTxtHelper robotsTxtHelper;
 
+    /** Helper for managing content length limits */
     @Resource
     protected ContentLengthHelper contentLengthHelper;
 
+    /** Helper for determining MIME types */
     @Resource
     protected MimeTypeHelper mimeTypeHelper;
 
+    /** The HTTP client instance */
     protected volatile CloseableHttpClient httpClient;
 
+    /** List of request headers to be sent with each request */
     private final List<Header> requestHeaderList = new ArrayList<>();
 
+    /** Map of HTTP client properties */
     private final Map<String, Object> httpClientPropertyMap = new HashMap<>();
 
+    /** Task for monitoring idle connections */
     private TimeoutTask connectionMonitorTask;
 
+    /** Connection timeout in milliseconds */
     protected Integer connectionTimeout;
 
+    /** Maximum total number of connections */
     protected Integer maxTotalConnections;
 
+    /** Maximum connections per route */
     protected Integer maxConnectionsPerRoute;
 
+    /** Socket timeout in milliseconds */
     protected Integer soTimeout;
 
+    /** Cookie specification to use */
     protected String cookieSpec;
 
+    /** User agent string */
     protected String userAgent = "Crawler";
 
+    /** HTTP client context for requests */
     protected HttpClientContext httpClientContext = HttpClientContext.create();
 
+    /** Proxy host name */
     protected String proxyHost;
 
+    /** Proxy port number */
     protected Integer proxyPort;
 
+    /** Proxy authentication scheme */
     protected AuthScheme proxyAuthScheme = new BasicScheme();
 
+    /** Proxy credentials */
     protected Credentials proxyCredentials;
 
+    /** Default MIME type for unknown content */
     protected String defaultMimeType = APPLICATION_OCTET_STREAM;
 
+    /** Cookie store for managing cookies */
     protected CookieStore cookieStore = new BasicCookieStore();
 
+    /** HTTP client connection manager */
     protected HttpClientConnectionManager clientConnectionManager;
 
+    /** DNS resolver for hostname resolution */
     protected DnsResolver dnsResolver = new IdnDnsResolver();
 
+    /** Map of authentication scheme providers */
     protected Map<String, AuthSchemeProvider> authSchemeProviderMap;
 
+    /** Connection check interval in seconds */
     protected int connectionCheckInterval = 5; // sec
 
+    /** Idle connection timeout in milliseconds */
     protected long idleConnectionTimeout = 60 * 1000L; // 1min
 
+    /** Pattern for matching HTTP redirect status codes */
     protected Pattern redirectHttpStatusPattern = Pattern.compile("[3][0-9][0-9]");
 
+    /** Whether to use robots.txt disallow rules */
     protected boolean useRobotsTxtDisallows = true;
 
+    /** Whether to use robots.txt allow rules */
     protected boolean useRobotsTxtAllows = true;
 
+    /** Credentials provider for authentication */
     protected CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
 
+    /** Authentication cache */
     protected AuthCache authCache = new BasicAuthCache();
 
+    /** HTTP route planner */
     protected HttpRoutePlanner routePlanner;
 
+    /** Whether HTTP redirects are enabled */
     protected boolean redirectsEnabled = false;
 
+    /** Cookie specification registry */
     protected Lookup<CookieSpecProvider> cookieSpecRegistry;
 
+    /** Cookie date patterns for parsing */
     protected String[] cookieDatePatterns = { //
             DateUtils.PATTERN_RFC1123, //
             DateUtils.PATTERN_RFC1036, //
@@ -266,6 +326,7 @@ public class HcHttpClient extends AbstractCrawlerClient {
             StringUtil.EMPTY//
     };
 
+    /** SSL socket factory for HTTPS connections */
     protected LayeredConnectionSocketFactory sslSocketFactory;
 
     /**
@@ -427,6 +488,12 @@ public class HcHttpClient extends AbstractCrawlerClient {
         httpClient = closeableHttpClient;
     }
 
+    /**
+     * Builds the HTTP client connection manager with SSL and connection pool settings.
+     *
+     * @param httpClientBuilder The HTTP client builder
+     * @return The configured connection manager
+     */
     protected HttpClientConnectionManager buildConnectionManager(final HttpClientBuilder httpClientBuilder) {
         // SSL
         final LayeredConnectionSocketFactory sslSocketFactory = buildSSLSocketFactory(httpClientBuilder);
@@ -446,6 +513,12 @@ public class HcHttpClient extends AbstractCrawlerClient {
         return connectionManager;
     }
 
+    /**
+     * Builds the SSL socket factory for HTTPS connections.
+     *
+     * @param httpClientBuilder The HTTP client builder
+     * @return The configured SSL socket factory
+     */
     protected LayeredConnectionSocketFactory buildSSLSocketFactory(final HttpClientBuilder httpClientBuilder) {
         if (sslSocketFactory != null) {
             return sslSocketFactory;
@@ -462,6 +535,11 @@ public class HcHttpClient extends AbstractCrawlerClient {
         return SSLConnectionSocketFactory.getSocketFactory();
     }
 
+    /**
+     * Builds the cookie specification registry.
+     *
+     * @return The configured cookie specification registry
+     */
     protected Lookup<CookieSpecProvider> buildCookieSpecRegistry() {
         if (cookieSpecRegistry != null) {
             return cookieSpecRegistry;
@@ -509,12 +587,25 @@ public class HcHttpClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Adds a property to the HTTP client configuration.
+     *
+     * @param name The property name
+     * @param value The property value
+     */
     public void addHttpClientProperty(final String name, final Object value) {
         if (StringUtil.isNotBlank(name) && value != null) {
             httpClientPropertyMap.put(name, value);
         }
     }
 
+    /**
+     * Processes robots.txt for the given URL.
+     * This method fetches and parses the robots.txt file to extract disallow/allow rules
+     * and sitemap information.
+     *
+     * @param url The URL to process robots.txt for
+     */
     protected void processRobotsTxt(final String url) {
         if (StringUtil.isBlank(url)) {
             throw new CrawlerSystemException("url is null or empty.");
@@ -634,6 +725,12 @@ public class HcHttpClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Converts a robots.txt pattern to a regular expression.
+     *
+     * @param path The robots.txt pattern to convert
+     * @return The equivalent regular expression
+     */
     protected String convertRobotsTxtPatternToRegex(final String path) {
         String newPath = path.replace(".", "\\.").replace("?", "\\?").replace("*", ".*");
         if (newPath.charAt(0) != '/') {
@@ -677,6 +774,13 @@ public class HcHttpClient extends AbstractCrawlerClient {
         return doHttpMethod(url, httpHead);
     }
 
+    /**
+     * Executes an HTTP method for the given URL and request.
+     *
+     * @param url The URL to access
+     * @param httpRequest The HTTP request to execute
+     * @return The response data
+     */
     public ResponseData doHttpMethod(final String url, final HttpUriRequest httpRequest) {
         if (httpClient == null) {
             init();
@@ -706,6 +810,15 @@ public class HcHttpClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Processes an HTTP method request and returns the response data.
+     * This method handles the complete HTTP request lifecycle including content processing,
+     * redirect handling, and error management.
+     *
+     * @param url The URL being accessed
+     * @param httpRequest The HTTP request to process
+     * @return The response data containing the retrieved information
+     */
     protected ResponseData processHttpMethod(final String url, final HttpUriRequest httpRequest) {
         try {
             processRobotsTxt(url);
@@ -881,19 +994,44 @@ public class HcHttpClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Closes resources associated with the HTTP request.
+     *
+     * @param httpRequest The HTTP request to abort
+     * @param responseData The response data to close
+     */
     protected void closeResources(final HttpUriRequest httpRequest, final ResponseData responseData) {
         CloseableUtil.closeQuietly(responseData);
         httpRequest.abort();
     }
 
+    /**
+     * Checks if the HTTP status code indicates a redirect.
+     *
+     * @param httpStatusCode The HTTP status code to check
+     * @return True if the status code indicates a redirect, false otherwise
+     */
     protected boolean isRedirectHttpStatus(final int httpStatusCode) {
         return redirectHttpStatusPattern.matcher(Integer.toString(httpStatusCode)).matches();
     }
 
+    /**
+     * Executes the HTTP client request.
+     *
+     * @param httpRequest The HTTP request to execute
+     * @return The HTTP response
+     * @throws IOException If an I/O error occurs
+     */
     protected HttpResponse executeHttpClient(final HttpUriRequest httpRequest) throws IOException {
         return httpClient.execute(httpRequest, new BasicHttpContext(httpClientContext));
     }
 
+    /**
+     * Parses the last modified date from a string value.
+     *
+     * @param value The date string to parse
+     * @return The parsed date, or null if parsing fails
+     */
     protected Date parseLastModifiedDate(final String value) {
         final SimpleDateFormat sdf = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
         try {
@@ -903,6 +1041,11 @@ public class HcHttpClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Builds the HTTP route planner with proxy configuration.
+     *
+     * @return The configured route planner, or null if no proxy is configured
+     */
     protected HttpRoutePlanner buildRoutePlanner() {
         if (routePlanner != null) {
             return routePlanner;
@@ -928,6 +1071,13 @@ public class HcHttpClient extends AbstractCrawlerClient {
         return null;
     }
 
+    /**
+     * Constructs the redirect location from a base URL and location header.
+     *
+     * @param url The base URL
+     * @param location The location header value
+     * @return The constructed redirect location
+     */
     protected static String constructRedirectLocation(final String url, final String location) {
         try {
             URI uri = new URI(url);
@@ -940,110 +1090,244 @@ public class HcHttpClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Sets the connection timeout in milliseconds.
+     *
+     * @param connectionTimeout The connection timeout
+     */
     public void setConnectionTimeout(final Integer connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
     }
 
+    /**
+     * Sets the maximum total number of connections.
+     *
+     * @param maxTotalConnections The maximum total connections
+     */
     public void setMaxTotalConnections(final Integer maxTotalConnections) {
         this.maxTotalConnections = maxTotalConnections;
     }
 
+    /**
+     * Sets the maximum connections per route.
+     *
+     * @param maxConnectionsPerRoute The maximum connections per route
+     */
     public void setMaxConnectionsPerRoute(final Integer maxConnectionsPerRoute) {
         this.maxConnectionsPerRoute = maxConnectionsPerRoute;
     }
 
+    /**
+     * Sets the socket timeout in milliseconds.
+     *
+     * @param soTimeout The socket timeout
+     */
     public void setSoTimeout(final Integer soTimeout) {
         this.soTimeout = soTimeout;
     }
 
+    /**
+     * Sets the cookie specification to use.
+     *
+     * @param cookieSpec The cookie specification
+     */
     public void setCookieSpec(final String cookieSpec) {
         this.cookieSpec = cookieSpec;
     }
 
+    /**
+     * Sets the user agent string.
+     *
+     * @param userAgent The user agent string
+     */
     public void setUserAgent(final String userAgent) {
         this.userAgent = userAgent;
     }
 
+    /**
+     * Sets the proxy host name.
+     *
+     * @param proxyHost The proxy host name
+     */
     public void setProxyHost(final String proxyHost) {
         this.proxyHost = proxyHost;
     }
 
+    /**
+     * Sets the proxy port number.
+     *
+     * @param proxyPort The proxy port number
+     */
     public void setProxyPort(final Integer proxyPort) {
         this.proxyPort = proxyPort;
     }
 
+    /**
+     * Sets the proxy authentication scheme.
+     *
+     * @param proxyAuthScheme The proxy authentication scheme
+     */
     public void setProxyAuthScheme(final AuthScheme proxyAuthScheme) {
         this.proxyAuthScheme = proxyAuthScheme;
     }
 
+    /**
+     * Sets the proxy credentials.
+     *
+     * @param proxyCredentials The proxy credentials
+     */
     public void setProxyCredentials(final Credentials proxyCredentials) {
         this.proxyCredentials = proxyCredentials;
     }
 
+    /**
+     * Sets the default MIME type for unknown content.
+     *
+     * @param defaultMimeType The default MIME type
+     */
     public void setDefaultMimeType(final String defaultMimeType) {
         this.defaultMimeType = defaultMimeType;
     }
 
+    /**
+     * Sets the cookie store for managing cookies.
+     *
+     * @param cookieStore The cookie store
+     */
     public void setCookieStore(final CookieStore cookieStore) {
         this.cookieStore = cookieStore;
     }
 
+    /**
+     * Sets the HTTP client context for requests.
+     *
+     * @param httpClientContext The HTTP client context
+     */
     public void setHttpClientContext(final HttpClientContext httpClientContext) {
         this.httpClientContext = httpClientContext;
     }
 
+    /**
+     * Sets the authentication scheme provider map.
+     *
+     * @param authSchemeProviderMap The authentication scheme provider map
+     */
     public void setAuthSchemeProviderMap(final Map<String, AuthSchemeProvider> authSchemeProviderMap) {
         this.authSchemeProviderMap = authSchemeProviderMap;
     }
 
+    /**
+     * Sets the connection check interval in seconds.
+     *
+     * @param connectionCheckInterval The connection check interval
+     */
     public void setConnectionCheckInterval(final int connectionCheckInterval) {
         this.connectionCheckInterval = connectionCheckInterval;
     }
 
+    /**
+     * Sets the idle connection timeout in milliseconds.
+     *
+     * @param idleConnectionTimeout The idle connection timeout
+     */
     public void setIdleConnectionTimeout(final long idleConnectionTimeout) {
         this.idleConnectionTimeout = idleConnectionTimeout;
     }
 
+    /**
+     * Sets the pattern for matching HTTP redirect status codes.
+     *
+     * @param redirectHttpStatusPattern The redirect HTTP status pattern
+     */
     public void setRedirectHttpStatusPattern(final Pattern redirectHttpStatusPattern) {
         this.redirectHttpStatusPattern = redirectHttpStatusPattern;
     }
 
+    /**
+     * Sets whether to use robots.txt disallow rules.
+     *
+     * @param useRobotsTxtDisallows True to use disallow rules, false otherwise
+     */
     public void setUseRobotsTxtDisallows(final boolean useRobotsTxtDisallows) {
         this.useRobotsTxtDisallows = useRobotsTxtDisallows;
     }
 
+    /**
+     * Sets whether to use robots.txt allow rules.
+     *
+     * @param useRobotsTxtAllows True to use allow rules, false otherwise
+     */
     public void setUseRobotsTxtAllows(final boolean useRobotsTxtAllows) {
         this.useRobotsTxtAllows = useRobotsTxtAllows;
     }
 
+    /**
+     * Sets the credentials provider for authentication.
+     *
+     * @param credentialsProvider The credentials provider
+     */
     public void setCredentialsProvider(final CredentialsProvider credentialsProvider) {
         this.credentialsProvider = credentialsProvider;
     }
 
+    /**
+     * Sets the authentication cache.
+     *
+     * @param authCache The authentication cache
+     */
     public void setAuthCache(final AuthCache authCache) {
         this.authCache = authCache;
     }
 
+    /**
+     * Sets the HTTP route planner.
+     *
+     * @param routePlanner The HTTP route planner
+     */
     public void setRoutePlanner(final HttpRoutePlanner routePlanner) {
         this.routePlanner = routePlanner;
     }
 
+    /**
+     * Sets whether HTTP redirects are enabled.
+     *
+     * @param redirectsEnabled True to enable redirects, false otherwise
+     */
     public void setRedirectsEnabled(final boolean redirectsEnabled) {
         this.redirectsEnabled = redirectsEnabled;
     }
 
+    /**
+     * Sets the cookie specification registry.
+     *
+     * @param cookieSpecRegistry The cookie specification registry
+     */
     public void setCookieSpecRegistry(final Lookup<CookieSpecProvider> cookieSpecRegistry) {
         this.cookieSpecRegistry = cookieSpecRegistry;
     }
 
+    /**
+     * Sets the cookie date patterns for parsing.
+     *
+     * @param cookieDatePatterns The cookie date patterns
+     */
     public void setCookieDatePatterns(final String[] cookieDatePatterns) {
         this.cookieDatePatterns = cookieDatePatterns;
     }
 
+    /**
+     * Sets the DNS resolver for hostname resolution.
+     *
+     * @param dnsResolver The DNS resolver
+     */
     public void setDnsResolver(final DnsResolver dnsResolver) {
         this.dnsResolver = dnsResolver;
     }
 
+    /**
+     * Sets the SSL socket factory.
+     * @param sslSocketFactory The SSL socket factory.
+     */
     public void setSslSocketFactory(final LayeredConnectionSocketFactory sslSocketFactory) {
         this.sslSocketFactory = sslSocketFactory;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/RequestHeader.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/RequestHeader.java
@@ -41,8 +41,14 @@ public class RequestHeader implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The name of the request header.
+     */
     private String name;
 
+    /**
+     * The value of the request header.
+     */
     private String value;
 
     /**
@@ -56,22 +62,43 @@ public class RequestHeader implements Serializable {
         this.value = value;
     }
 
+    /**
+     * Returns the name of the request header.
+     * @return The name of the request header.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets the name of the request header.
+     * @param name The name of the request header.
+     */
     public void setName(final String name) {
         this.name = name;
     }
 
+    /**
+     * Returns the value of the request header.
+     * @return The value of the request header.
+     */
     public String getValue() {
         return value;
     }
 
+    /**
+     * Sets the value of the request header.
+     * @param value The value of the request header.
+     */
     public void setValue(final String value) {
         this.value = value;
     }
 
+    /**
+     * Checks if the request header is valid.
+     * A header is considered valid if its name is not blank and its value is not null.
+     * @return true if the header is valid, false otherwise.
+     */
     public boolean isValid() {
         if (StringUtil.isBlank(name) || value == null) {
             return false;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/conn/IdnDnsResolver.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/conn/IdnDnsResolver.java
@@ -45,15 +45,38 @@ import org.apache.http.conn.DnsResolver;
  */
 public class IdnDnsResolver implements DnsResolver {
 
+    /** Flag for IDN conversion. */
     protected int flag = 0;
 
+    /** Encoding for URL decoding. */
     protected String encoding = "UTF-8";
 
+    /**
+     * Creates a new IdnDnsResolver instance with default settings.
+     */
+    public IdnDnsResolver() {
+        super();
+    }
+
+    /**
+     * Resolves the given host name to an array of IP addresses.
+     * The host name is first converted to ASCII using IDN before resolution.
+     *
+     * @param host the host name to resolve
+     * @return an array of IP addresses for the host
+     * @throws UnknownHostException if the host name cannot be resolved
+     */
     @Override
     public InetAddress[] resolve(final String host) throws UnknownHostException {
         return InetAddress.getAllByName(toAscii(host));
     }
 
+    /**
+     * Decodes the given host string using the specified encoding.
+     *
+     * @param host the host string to decode
+     * @return the decoded host string
+     */
     protected String decode(final String host) {
         if (host.indexOf('%') == -1) {
             return host;
@@ -65,14 +88,30 @@ public class IdnDnsResolver implements DnsResolver {
         }
     }
 
+    /**
+     * Converts the given host string to ASCII using IDN.
+     *
+     * @param host the host string to convert
+     * @return the ASCII representation of the host string
+     */
     protected String toAscii(final String host) {
         return IDN.toASCII(decode(host), flag);
     }
 
+    /**
+     * Sets the flag for IDN conversion.
+     *
+     * @param flag the flag to set
+     */
     public void setFlag(final int flag) {
         this.flag = flag;
     }
 
+    /**
+     * Sets the encoding for URL decoding.
+     *
+     * @param encoding the encoding to set
+     */
     public void setEncoding(final String encoding) {
         this.encoding = encoding;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/form/FormScheme.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/form/FormScheme.java
@@ -110,6 +110,10 @@ public class FormScheme implements AuthScheme {
 
     private final Map<String, String> parameterMap;
 
+    /**
+     * Constructs a FormScheme with the given parameter map.
+     * @param parameterMap The map of parameters.
+     */
     public FormScheme(final Map<String, String> parameterMap) {
         this.parameterMap = parameterMap;
     }
@@ -149,6 +153,11 @@ public class FormScheme implements AuthScheme {
         return null;
     }
 
+    /**
+     * Authenticates using the form scheme.
+     * @param credentials The credentials.
+     * @param executor The executor for HTTP requests.
+     */
     public void authenticate(final Credentials credentials,
             final BiConsumer<HttpUriRequest, BiConsumer<HttpResponse, HttpEntity>> executor) {
         final String tokenUrl = getParameter(TOKEN_URL);
@@ -259,6 +268,12 @@ public class FormScheme implements AuthScheme {
 
     }
 
+    /**
+     * Parses the token page and extracts token information.
+     * @param tokenPattern The regex pattern to extract the token.
+     * @param responseParams The list to store response parameters.
+     * @param entity The HTTP entity containing the token page content.
+     */
     protected void parseTokenPage(final String tokenPattern, final List<Pair<String, String>> responseParams, final HttpEntity entity) {
         try {
             final String tokenName = getParameter(TOKEN_NAME);
@@ -277,6 +292,13 @@ public class FormScheme implements AuthScheme {
         }
     }
 
+    /**
+     * Parses request parameters from a string.
+     * @param params The parameter string.
+     * @param paramList Additional parameters.
+     * @param encoding The encoding.
+     * @return The HttpEntity containing the parsed parameters.
+     */
     protected HttpEntity parseRequestParameters(final String params, final List<Pair<String, String>> paramList, final String encoding) {
         try {
             final List<BasicNameValuePair> parameters =
@@ -303,6 +325,12 @@ public class FormScheme implements AuthScheme {
         }
     }
 
+    /**
+     * Extracts the token value from the content using the given pattern.
+     * @param tokenPattern The regex pattern.
+     * @param content The content to search.
+     * @return The extracted token value.
+     */
     protected String getTokenValue(final String tokenPattern, final String content) {
         final Matcher matcher = Pattern.compile(tokenPattern).matcher(content);
         if (matcher.find()) {
@@ -316,6 +344,12 @@ public class FormScheme implements AuthScheme {
         return null;
     }
 
+    /**
+     * Replaces credentials in the given value.
+     * @param credentials The credentials.
+     * @param value The value to replace.
+     * @return The value with credentials replaced.
+     */
     protected String replaceCredentials(final Credentials credentials, final String value) {
         if (StringUtil.isNotBlank(value)) {
             return value.replace(USERNAME, credentials.getUserPrincipal().getName()).replace(PASSWORD, credentials.getPassword());
@@ -323,6 +357,10 @@ public class FormScheme implements AuthScheme {
         return StringUtil.EMPTY;
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "FormScheme [parameterMap=" + parameterMap + "]";

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/impl/AuthenticationImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/impl/AuthenticationImpl.java
@@ -53,11 +53,19 @@ public class AuthenticationImpl implements Authentication {
     /**
      * Initializes the AuthenticationImpl with the provided AuthScope and Credentials,
      * and sets the AuthScheme to null.
+     * @param authScope The authentication scope.
+     * @param credentials The credentials.
      */
     public AuthenticationImpl(final AuthScope authScope, final Credentials credentials) {
         this(authScope, credentials, null);
     }
 
+    /**
+     * Initializes the AuthenticationImpl with the provided AuthScope, Credentials, and AuthScheme.
+     * @param authScope The authentication scope.
+     * @param credentials The credentials.
+     * @param authScheme The authentication scheme.
+     */
     public AuthenticationImpl(final AuthScope authScope, final Credentials credentials, final AuthScheme authScheme) {
         this.authScope = authScope;
         this.credentials = credentials;
@@ -93,6 +101,10 @@ public class AuthenticationImpl implements Authentication {
         this.authScope = authScope;
     }
 
+    /**
+     * Sets the credentials.
+     * @param credentials The credentials to set.
+     */
     public void setCredentials(final Credentials credentials) {
         this.credentials = credentials;
     }
@@ -107,6 +119,10 @@ public class AuthenticationImpl implements Authentication {
         return authScheme;
     }
 
+    /**
+     * Sets the authentication scheme.
+     * @param authScheme The authentication scheme to set.
+     */
     public void setAuthScheme(final AuthScheme authScheme) {
         this.authScheme = authScheme;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/ntlm/JcifsEngine.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/ntlm/JcifsEngine.java
@@ -39,11 +39,19 @@ import jcifs.ntlmssp.Type3Message;
  */
 public class JcifsEngine implements NTLMEngine {
 
+    /** Flags for Type 1 NTLM message. */
     protected static final int TYPE_1_FLAGS = NtlmFlags.NTLMSSP_NEGOTIATE_56 | NtlmFlags.NTLMSSP_NEGOTIATE_128
             | NtlmFlags.NTLMSSP_NEGOTIATE_NTLM | NtlmFlags.NTLMSSP_NEGOTIATE_ALWAYS_SIGN | NtlmFlags.NTLMSSP_REQUEST_TARGET;
 
+    /** The CIFS context for NTLM authentication. */
     protected BaseContext cifsContext;
 
+    /**
+     * Constructs a JcifsEngine with the specified properties.
+     *
+     * @param props the properties for configuring the CIFS context
+     * @throws CrawlingAccessException if an error occurs during initialization
+     */
     public JcifsEngine(final Properties props) {
         try {
             cifsContext = new BaseContext(new PropertyConfiguration(props));
@@ -52,12 +60,32 @@ public class JcifsEngine implements NTLMEngine {
         }
     }
 
+    /**
+     * Generates a Type 1 NTLM message.
+     *
+     * @param domain the domain name
+     * @param workstation the workstation name
+     * @return the Base64-encoded Type 1 message
+     * @throws NTLMEngineException if an NTLM engine error occurs
+     */
     @Override
     public String generateType1Msg(final String domain, final String workstation) throws NTLMEngineException {
         final Type1Message type1Message = new Type1Message(cifsContext, TYPE_1_FLAGS, domain, workstation);
         return Base64.getEncoder().encodeToString(type1Message.toByteArray());
     }
 
+    /**
+     * Generates a Type 3 NTLM message.
+     *
+     * @param username the username
+     * @param password the password
+     * @param domain the domain
+     * @param workstation the workstation
+     * @param challenge the Type 2 challenge message
+     * @return the Base64-encoded Type 3 message
+     * @throws NTLMEngineException if an NTLM engine error occurs
+     * @throws CrawlingAccessException if an error occurs during message generation
+     */
     @Override
     public String generateType3Msg(final String username, final String password, final String domain, final String workstation,
             final String challenge) throws NTLMEngineException {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/ntlm/NTLMSchemeProvider.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/ntlm/NTLMSchemeProvider.java
@@ -28,6 +28,18 @@ import org.apache.http.protocol.HttpContext;
  */
 public class NTLMSchemeProvider implements AuthSchemeProvider {
 
+    /**
+     * Creates a new NTLMSchemeProvider instance.
+     */
+    public NTLMSchemeProvider() {
+        super();
+    }
+
+    /**
+     * Creates a new NTLMScheme instance.
+     * @param context The HTTP context.
+     * @return A new NTLMScheme instance.
+     */
     @Override
     public AuthScheme create(final HttpContext context) {
         return new NTLMScheme(new SmbjEngine());

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/ntlm/SmbjEngine.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/ntlm/SmbjEngine.java
@@ -26,15 +26,39 @@ import org.apache.http.impl.auth.NTLMEngineException;
  */
 public class SmbjEngine implements NTLMEngine {
 
+    /**
+     * Creates a new SmbjEngine instance.
+     */
+    public SmbjEngine() {
+        super();
+    }
+
+    /**
+     * Generates a Type 1 NTLM message.
+     * @param arg0 The domain.
+     * @param arg1 The workstation.
+     * @return The Type 1 message.
+     * @throws NTLMEngineException if an NTLM engine error occurs.
+     */
     @Override
     public String generateType1Msg(final String arg0, final String arg1) throws NTLMEngineException {
         // TODO Auto-generated method stub
         return null;
     }
 
+    /**
+     * Generates a Type 3 NTLM message.
+     * @param username The username.
+     * @param password The password.
+     * @param domain The domain.
+     * @param workstation The workstation.
+     * @param challenge The Type 2 challenge message.
+     * @return The Type 3 message.
+     * @throws NTLMEngineException if an NTLM engine error occurs.
+     */
     @Override
-    public String generateType3Msg(final String arg0, final String arg1, final String arg2, final String arg3, final String arg4)
-            throws NTLMEngineException {
+    public String generateType3Msg(final String username, final String password, final String domain, final String workstation,
+            final String challenge) throws NTLMEngineException {
         // TODO Auto-generated method stub
         return null;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb/SmbAuthentication.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb/SmbAuthentication.java
@@ -43,6 +43,17 @@ public class SmbAuthentication {
 
     private String domain;
 
+    /**
+     * Creates a new SmbAuthentication instance.
+     */
+    public SmbAuthentication() {
+        super();
+    }
+
+    /**
+     * Returns the path prefix for SMB URLs.
+     * @return The path prefix.
+     */
     public String getPathPrefix() {
         final StringBuilder buf = new StringBuilder(100);
         buf.append("smb://");
@@ -57,46 +68,90 @@ public class SmbAuthentication {
         return buf.toString();
     }
 
+    /**
+     * Returns the SMB server address.
+     * @return the server address
+     */
     public String getServer() {
         return server;
     }
 
+    /**
+     * Sets the SMB server address.
+     * @param server the server address to set
+     */
     public void setServer(final String server) {
         this.server = server;
     }
 
+    /**
+     * Returns the SMB server port.
+     * @return the server port
+     */
     public int getPort() {
         return port;
     }
 
+    /**
+     * Sets the SMB server port.
+     * @param port the server port to set
+     */
     public void setPort(final int port) {
         this.port = port;
     }
 
+    /**
+     * Returns the username for SMB authentication.
+     * @return the username
+     */
     public String getUsername() {
         return username;
     }
 
+    /**
+     * Sets the username for SMB authentication.
+     * @param username the username to set
+     */
     public void setUsername(final String username) {
         this.username = username;
     }
 
+    /**
+     * Returns the password for SMB authentication.
+     * @return the password
+     */
     public String getPassword() {
         return password;
     }
 
+    /**
+     * Sets the password for SMB authentication.
+     * @param password the password to set
+     */
     public void setPassword(final String password) {
         this.password = password;
     }
 
+    /**
+     * Returns the domain for SMB authentication.
+     * @return the domain
+     */
     public String getDomain() {
         return domain;
     }
 
+    /**
+     * Sets the domain for SMB authentication.
+     * @param domain the domain to set
+     */
     public void setDomain(final String domain) {
         this.domain = domain;
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "[" + domain + "] " + username + "@" + server + ":" + port;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb/SmbAuthenticationHolder.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb/SmbAuthenticationHolder.java
@@ -33,7 +33,15 @@ import org.apache.logging.log4j.Logger;
 public class SmbAuthenticationHolder {
     private static final Logger logger = LogManager.getLogger(SmbAuthenticationHolder.class);
 
+    /** Map of path prefixes to SMB authentication configurations. */
     private final Map<String, SmbAuthentication> authMap = new HashMap<>();
+
+    /**
+     * Creates a new SmbAuthenticationHolder instance.
+     */
+    public SmbAuthenticationHolder() {
+        super();
+    }
 
     /**
      * Adds an SMB authentication configuration to the holder.

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb/SmbClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb/SmbClient.java
@@ -112,27 +112,52 @@ import jcifs.smb.SmbFileInputStream;
 public class SmbClient extends AbstractCrawlerClient {
     private static final Logger logger = LogManager.getLogger(SmbClient.class);
 
+    /** Property key for SMB authentications configuration. */
     public static final String SMB_AUTHENTICATIONS_PROPERTY = "smbAuthentications";
 
+    /** Property key for SMB allowed SID entries. */
     public static final String SMB_ALLOWED_SID_ENTRIES = "smbAllowedSidEntries";
 
+    /** Property key for SMB denied SID entries. */
     public static final String SMB_DENIED_SID_ENTRIES = "smbDeniedSidEntries";
 
+    /** Property key for SMB file creation time. */
     public static final String SMB_CREATE_TIME = "smbCreateTime";
 
+    /** Property key for SMB owner attributes. */
     public static final String SMB_OWNER_ATTRIBUTES = "smbOwnerAttributes";
 
+    /** Character set used for encoding SMB content. */
     protected String charset = Constants.UTF_8;
 
+    /** Flag indicating whether to resolve SIDs to names. */
     protected boolean resolveSids = true;
 
+    /** Helper for content length operations. */
     @Resource
     protected ContentLengthHelper contentLengthHelper;
 
+    /**
+     * The SMB authentication holder.
+     */
     protected volatile SmbAuthenticationHolder smbAuthenticationHolder;
 
+    /**
+     * The CIFS context.
+     */
     protected CIFSContext cifsContext;
 
+    /**
+     * Creates a new SmbClient instance.
+     */
+    public SmbClient() {
+        super();
+    }
+
+    /**
+    * Initializes the SMB client.
+    * @see org.codelibs.fess.crawler.client.AbstractCrawlerClient#init()
+    */
     @Override
     public synchronized void init() {
         if (smbAuthenticationHolder != null) {
@@ -188,6 +213,13 @@ public class SmbClient extends AbstractCrawlerClient {
         return processRequest(uri, true);
     }
 
+    /**
+     * Processes an SMB request for the given URI.
+     *
+     * @param uri the URI to process
+     * @param includeContent whether to include content in the response
+     * @return the response data
+     */
     protected ResponseData processRequest(final String uri, final boolean includeContent) {
         if (smbAuthenticationHolder == null) {
             init();
@@ -213,11 +245,24 @@ public class SmbClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Creates an NTLM password authenticator from the given SMB authentication.
+     *
+     * @param smbAuthentication the SMB authentication information
+     * @return the NTLM password authenticator
+     */
     protected NtlmPasswordAuthenticator getAuthenticator(final SmbAuthentication smbAuthentication) {
         return new NtlmPasswordAuthenticator(smbAuthentication.getDomain() == null ? "" : smbAuthentication.getDomain(),
                 smbAuthentication.getUsername(), smbAuthentication.getPassword());
     }
 
+    /**
+     * Retrieves response data for the given URI.
+     *
+     * @param uri the URI to retrieve data from
+     * @param includeContent whether to include content in the response
+     * @return the response data
+     */
     protected ResponseData getResponseData(final String uri, final boolean includeContent) {
         final ResponseData responseData = new ResponseData();
         responseData.setMethod(Constants.GET_METHOD);
@@ -368,6 +413,12 @@ public class SmbClient extends AbstractCrawlerClient {
         return responseData;
     }
 
+    /**
+     * Processes access control entries (ACEs) for the given SMB file and adds them to the response data.
+     *
+     * @param responseData the response data to update
+     * @param file the SMB file to process
+     */
     protected void processAccessControlEntries(final ResponseData responseData, final SmbFile file) {
         try {
             final ACE[] aces = file.getSecurity(resolveSids);
@@ -388,6 +439,14 @@ public class SmbClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Processes allowed SIDs (Security Identifiers) and adds them to the SID set.
+     * If the SID is a group, it recursively processes all group members.
+     *
+     * @param file the SMB file
+     * @param sid the SID to process
+     * @param sidSet the set of SIDs to add to
+     */
     protected void processAllowedSIDs(final SmbFile file, final SID sid, final Set<SID> sidSet) {
         if (logger.isDebugEnabled()) {
             logger.debug("SID:{}", sid);
@@ -412,6 +471,13 @@ public class SmbClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Preprocesses the URI before processing the request.
+     *
+     * @param uri the URI to preprocess
+     * @return the preprocessed URI
+     * @throws CrawlerSystemException if the URI is empty
+     */
     protected String preprocessUri(final String uri) {
         if (StringUtil.isEmpty(uri)) {
             throw new CrawlerSystemException("The uri is empty.");
@@ -420,6 +486,12 @@ public class SmbClient extends AbstractCrawlerClient {
         return uri;
     }
 
+    /**
+     * Returns the character set for the given SMB file.
+     *
+     * @param file the SMB file
+     * @return the character set
+     */
     protected String getCharSet(final SmbFile file) {
         return charset;
     }
@@ -440,6 +512,11 @@ public class SmbClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Copies content from an SmbFile to a File.
+     * @param src The source SmbFile.
+     * @param dest The destination File.
+     */
     private void copy(final SmbFile src, final File dest) {
         if (dest.exists() && !dest.canWrite()) {
             return;
@@ -458,21 +535,23 @@ public class SmbClient extends AbstractCrawlerClient {
     }
 
     /**
-     * @return the resolveSids
+     * Returns whether SIDs (Security Identifiers) should be resolved.
+     * @return true if SIDs should be resolved, false otherwise
      */
     public boolean isResolveSids() {
         return resolveSids;
     }
 
     /**
-     * @param resolveSids
-     *            the resolveSids to set
+     * Sets whether SIDs (Security Identifiers) should be resolved.
+     * @param resolveSids true to resolve SIDs, false otherwise
      */
     public void setResolveSids(final boolean resolveSids) {
         this.resolveSids = resolveSids;
     }
 
     /**
+     * Returns the character set used for SMB operations.
      * @return the charset
      */
     public String getCharset() {
@@ -480,8 +559,8 @@ public class SmbClient extends AbstractCrawlerClient {
     }
 
     /**
-     * @param charset
-     *            the charset to set
+     * Sets the character set used for SMB operations.
+     * @param charset the charset to set
      */
     public void setCharset(final String charset) {
         this.charset = charset;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb1/SmbAuthentication.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb1/SmbAuthentication.java
@@ -18,8 +18,21 @@ package org.codelibs.fess.crawler.client.smb1;
 import jcifs.smb1.smb1.NtlmPasswordAuthentication;
 
 /**
- * @author shinsuke
+ * Represents SMB1 authentication information, including server details,
+ * credentials, and domain. This class is used to encapsulate the necessary
+ * information for authenticating with an SMB1 server.
  *
+ * <p>
+ * It provides methods to set and retrieve the server address, port, username,
+ * password, and domain. Additionally, it offers a method to construct a path
+ * prefix for SMB1 URLs based on the configured server and port.
+ * </p>
+ *
+ * <p>
+ * The path prefix is in the format "smb1://server:port/", where the port is
+ * included only if it's greater than 0. If the server is not set, the path
+ * prefix will be "smb1://".
+ * </p>
  */
 public class SmbAuthentication {
     private String server;
@@ -32,6 +45,17 @@ public class SmbAuthentication {
 
     private String domain;
 
+    /**
+     * Creates a new SmbAuthentication instance.
+     */
+    public SmbAuthentication() {
+        super();
+    }
+
+    /**
+     * Returns the path prefix for SMB1 URLs.
+     * @return The path prefix.
+     */
     public String getPathPrefix() {
         final StringBuilder buf = new StringBuilder(100);
         buf.append("smb1://");
@@ -46,46 +70,90 @@ public class SmbAuthentication {
         return buf.toString();
     }
 
+    /**
+     * Returns the NTLM password authentication.
+     * @return The NTLM password authentication.
+     */
     public NtlmPasswordAuthentication getAuthentication() {
         return new NtlmPasswordAuthentication(domain == null ? "" : domain, username, password);
     }
 
+    /**
+     * Returns the server address.
+     * @return The server address.
+     */
     public String getServer() {
         return server;
     }
 
+    /**
+     * Sets the server address.
+     * @param server The server address.
+     */
     public void setServer(final String server) {
         this.server = server;
     }
 
+    /**
+     * Returns the port number.
+     * @return The port number.
+     */
     public int getPort() {
         return port;
     }
 
+    /**
+     * Sets the port number.
+     * @param port The port number.
+     */
     public void setPort(final int port) {
         this.port = port;
     }
 
+    /**
+     * Returns the username.
+     * @return The username.
+     */
     public String getUsername() {
         return username;
     }
 
+    /**
+     * Sets the username.
+     * @param username The username.
+     */
     public void setUsername(final String username) {
         this.username = username;
     }
 
+    /**
+     * Returns the password.
+     * @return The password.
+     */
     public String getPassword() {
         return password;
     }
 
+    /**
+     * Sets the password.
+     * @param password The password.
+     */
     public void setPassword(final String password) {
         this.password = password;
     }
 
+    /**
+     * Returns the domain.
+     * @return The domain.
+     */
     public String getDomain() {
         return domain;
     }
 
+    /**
+     * Sets the domain.
+     * @param domain The domain to set.
+     */
     public void setDomain(final String domain) {
         this.domain = domain;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb1/SmbAuthenticationHolder.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb1/SmbAuthenticationHolder.java
@@ -19,16 +19,38 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @author shinsuke
+ * Holds a map of SMB authentication configurations, allowing retrieval of the appropriate
+ * authentication based on a given path.
+ *
+ * <p>This class manages a collection of {@link SmbAuthentication} objects, each associated
+ * with a specific path prefix. When a path is provided, it iterates through the stored
+ * authentications to find the one whose path prefix matches the beginning of the given path.
+ * This allows for different SMB shares to use different authentication credentials.</p>
  *
  */
 public class SmbAuthenticationHolder {
     private final Map<String, SmbAuthentication> authMap = new HashMap<>();
 
+    /**
+     * Creates a new SmbAuthenticationHolder instance.
+     */
+    public SmbAuthenticationHolder() {
+        super();
+    }
+
+    /**
+     * Adds an SMB authentication configuration to the holder.
+     * @param auth The SMB authentication configuration to add.
+     */
     public void add(final SmbAuthentication auth) {
         authMap.put(auth.getPathPrefix(), auth);
     }
 
+    /**
+     * Retrieves an SMB authentication configuration that matches the given path.
+     * @param path The path to match.
+     * @return The matching SmbAuthentication object, or null if no match is found.
+     */
     public SmbAuthentication get(final String path) {
         if (path == null) {
             return null;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/storage/StorageClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/storage/StorageClient.java
@@ -93,14 +93,33 @@ public class StorageClient extends AbstractCrawlerClient {
 
     private static final Logger logger = LogManager.getLogger(StorageClient.class);
 
+    /**
+     * The character encoding to use for content. Defaults to UTF-8.
+     */
     protected String charset = Constants.UTF_8;
 
+    /**
+     * Helper for managing content length validation and limits.
+     */
     @Resource
     protected ContentLengthHelper contentLengthHelper;
 
+    /**
+     * Flag indicating whether the client has been initialized.
+     */
     protected volatile boolean isInit = false;
 
+    /**
+     * The MinIO client instance for interacting with object storage.
+     */
     protected MinioClient minioClient;
+
+    /**
+     * Creates a new StorageClient instance.
+     */
+    public StorageClient() {
+        super();
+    }
 
     @Override
     public synchronized void init() {
@@ -137,6 +156,12 @@ public class StorageClient extends AbstractCrawlerClient {
         isInit = true;
     }
 
+    /**
+     * Checks if a bucket exists in the object storage.
+     * @param name the name of the bucket to check
+     * @return true if the bucket exists, false otherwise
+     * @throws CrawlingAccessException if an error occurs while checking bucket existence
+     */
     protected boolean bucketExists(final String name) {
         try {
             final BucketExistsArgs args = BucketExistsArgs.builder().bucket(name).build();
@@ -146,6 +171,13 @@ public class StorageClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Processes a storage request with timeout management.
+     * @param uri the URI to process
+     * @param includeContent whether to include the actual content in the response
+     * @return the response data for the request
+     * @throws CrawlingAccessException if an error occurs while processing the request
+     */
     protected ResponseData processRequest(final String uri, final boolean includeContent) {
         if (!isInit) {
             init();
@@ -171,6 +203,12 @@ public class StorageClient extends AbstractCrawlerClient {
         }
     }
 
+    /**
+     * Parses a storage path into bucket name and object path components.
+     * @param path the storage path to parse (format: bucket/object/path)
+     * @return an array containing the bucket name and object path
+     * @throws CrawlingAccessException if the path format is invalid
+     */
     protected String[] parsePath(final String path) {
         if (StringUtil.isNotEmpty(path)) {
             final String[] values = path.split("/", 2);
@@ -184,6 +222,14 @@ public class StorageClient extends AbstractCrawlerClient {
         throw new CrawlingAccessException("Invalid path: " + path);
     }
 
+    /**
+     * Retrieves response data for the specified URI.
+     * @param uri the URI to retrieve data for
+     * @param includeContent whether to include the actual content in the response
+     * @return the response data containing metadata and optionally content
+     * @throws CrawlingAccessException if an error occurs while accessing the resource
+     * @throws ChildUrlsException if the URI represents a directory with child URLs
+     */
     protected ResponseData getResponseData(final String uri, final boolean includeContent) {
         final ResponseData responseData = new ResponseData();
         try {
@@ -268,6 +314,13 @@ public class StorageClient extends AbstractCrawlerClient {
         return responseData;
     }
 
+    /**
+     * Retrieves metadata information for an object in the specified bucket.
+     * @param bucketName the name of the bucket containing the object
+     * @param path the path to the object within the bucket
+     * @return the object metadata, or null if the object does not exist
+     * @throws CrawlingAccessException if the bucket does not exist
+     */
     protected StatObjectResponse getStatObject(final String bucketName, final String path) {
         if (StringUtil.isEmpty(path)) {
             return null;
@@ -296,6 +349,12 @@ public class StorageClient extends AbstractCrawlerClient {
         return null;
     }
 
+    /**
+     * Retrieves tags associated with an object in the specified bucket.
+     * @param bucketName the name of the bucket containing the object
+     * @param path the path to the object within the bucket
+     * @return the tags associated with the object, or null if no tags exist or object not found
+     */
     protected Tags getObjectTags(final String bucketName, final String path) {
         if (StringUtil.isEmpty(path)) {
             return null;
@@ -324,6 +383,12 @@ public class StorageClient extends AbstractCrawlerClient {
         return null;
     }
 
+    /**
+     * Preprocesses a URI to ensure it has the correct storage protocol prefix.
+     * @param uri the URI to preprocess
+     * @return the preprocessed URI with storage:// prefix
+     * @throws CrawlerSystemException if the URI is empty
+     */
     protected String preprocessUri(final String uri) {
         if (StringUtil.isEmpty(uri)) {
             throw new CrawlerSystemException("The uri is empty.");
@@ -337,10 +402,18 @@ public class StorageClient extends AbstractCrawlerClient {
         return filePath;
     }
 
+    /**
+     * Returns the character set used for content encoding.
+     * @return the charset
+     */
     public String getCharset() {
         return charset;
     }
 
+    /**
+     * Sets the character set used for content encoding.
+     * @param charset the charset to set
+     */
     public void setCharset(final String charset) {
         this.charset = charset;
     }
@@ -355,10 +428,10 @@ public class StorageClient extends AbstractCrawlerClient {
         return processRequest(uri, true);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.client.CrawlerClient#doHead(java.lang.String)
+    /**
+     * Executes a HEAD request for the given URL.
+     * @param url The URL to request.
+     * @return The ResponseData.
      */
     @Override
     public ResponseData doHead(final String url) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/container/StandardCrawlerContainer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/container/StandardCrawlerContainer.java
@@ -68,6 +68,9 @@ public class StandardCrawlerContainer implements CrawlerContainer {
 
     private boolean available = true;
 
+    /**
+     * Constructs a new StandardCrawlerContainer and initializes it.
+     */
     public StandardCrawlerContainer() {
         initialize();
     }
@@ -106,15 +109,42 @@ public class StandardCrawlerContainer implements CrawlerContainer {
         }
     }
 
+    /**
+     * Registers a prototype component with the specified name, class, and initializer.
+     * A new instance will be created each time the component is requested.
+     * @param <T> the type of the component
+     * @param name the name of the component
+     * @param cls the class of the component
+     * @param component the initializer consumer for the component
+     * @return this container instance for method chaining
+     */
     public <T> StandardCrawlerContainer prototype(final String name, final Class<T> cls, final Consumer<T> component) {
         prototypeMap.put(name, new ComponentDef<>(cls, component, this));
         return this;
     }
 
+    /**
+     * Registers a prototype component with the specified name and class.
+     * A new instance will be created each time the component is requested.
+     * @param <T> the type of the component
+     * @param name the name of the component
+     * @param cls the class of the component
+     * @return this container instance for method chaining
+     */
     public <T> StandardCrawlerContainer prototype(final String name, final Class<T> cls) {
         return prototype(name, cls, null);
     }
 
+    /**
+     * Registers a singleton component with the specified name, class, initializer, and destroyer.
+     * One instance will be shared throughout the container's lifecycle.
+     * @param <T> the type of the component
+     * @param name the name of the component
+     * @param cls the class of the component
+     * @param initializer the initializer consumer for the component
+     * @param destroyer the destroyer consumer for the component
+     * @return this container instance for method chaining
+     */
     public <T> StandardCrawlerContainer singleton(final String name, final Class<T> cls, final Consumer<T> initializer,
             final Consumer<T> destroyer) {
         final ComponentDef<T> componentDef = new ComponentDef<>(cls, initializer, this);
@@ -123,14 +153,41 @@ public class StandardCrawlerContainer implements CrawlerContainer {
         return this;
     }
 
+    /**
+     * Registers a singleton component with the specified name, class, and initializer.
+     * One instance will be shared throughout the container's lifecycle.
+     * @param <T> the type of the component
+     * @param name the name of the component
+     * @param cls the class of the component
+     * @param initializer the initializer consumer for the component
+     * @return this container instance for method chaining
+     */
     public <T> StandardCrawlerContainer singleton(final String name, final Class<T> cls, final Consumer<T> initializer) {
         return singleton(name, cls, initializer, (Consumer<T>) null);
     }
 
+    /**
+     * Registers a singleton component with the specified name and class.
+     * One instance will be shared throughout the container's lifecycle.
+     * @param <T> the type of the component
+     * @param name the name of the component
+     * @param cls the class of the component
+     * @return this container instance for method chaining
+     */
     public <T> StandardCrawlerContainer singleton(final String name, final Class<T> cls) {
         return singleton(name, cls, (Consumer<T>) null, (Consumer<T>) null);
     }
 
+    /**
+     * Registers a singleton component with the specified name, instance, initializer, and destroyer.
+     * The provided instance will be used and shared throughout the container's lifecycle.
+     * @param <T> the type of the component
+     * @param name the name of the component
+     * @param instance the component instance
+     * @param initializer the initializer consumer for the component
+     * @param destroyer the destroyer consumer for the component
+     * @return this container instance for method chaining
+     */
     public <T> StandardCrawlerContainer singleton(final String name, final T instance, final Consumer<T> initializer,
             final Consumer<T> destroyer) {
         final ComponentDef<T> componentDef = new ComponentDef<>(instance, initializer, this);
@@ -138,10 +195,27 @@ public class StandardCrawlerContainer implements CrawlerContainer {
         return this;
     }
 
+    /**
+     * Registers a singleton component with the specified name, instance, and initializer.
+     * The provided instance will be used and shared throughout the container's lifecycle.
+     * @param <T> the type of the component
+     * @param name the name of the component
+     * @param instance the component instance
+     * @param initializer the initializer consumer for the component
+     * @return this container instance for method chaining
+     */
     public <T> StandardCrawlerContainer singleton(final String name, final T instance, final Consumer<T> initializer) {
         return singleton(name, instance, initializer, null);
     }
 
+    /**
+     * Registers a singleton component with the specified name and instance.
+     * The provided instance will be used and shared throughout the container's lifecycle.
+     * @param <T> the type of the component
+     * @param name the name of the component
+     * @param instance the component instance
+     * @return this container instance for method chaining
+     */
     public <T> StandardCrawlerContainer singleton(final String name, final T instance) {
         return singleton(name, instance, null, null);
     }
@@ -153,19 +227,38 @@ public class StandardCrawlerContainer implements CrawlerContainer {
      * @param <T> the type of the component
      */
     protected static class ComponentHolder<T> {
+        /**
+         * The component instance being held.
+         */
         protected T instance;
 
+        /**
+         * The destroyer function to be called when the component is destroyed.
+         */
         protected Consumer<T> destroyer;
 
+        /**
+         * Creates a new ComponentHolder with the specified instance and destroyer.
+         * @param instance the component instance to hold
+         * @param destroyer the destroyer function for cleanup (can be null)
+         */
         protected ComponentHolder(final T instance, final Consumer<T> destroyer) {
             this.instance = instance;
             this.destroyer = destroyer;
         }
 
+        /**
+         * Returns the component instance.
+         * @return the component instance
+         */
         protected T get() {
             return instance;
         }
 
+        /**
+         * Destroys the component by calling any @PreDestroy annotated methods
+         * and the destroyer function if present.
+         */
         protected void destroy() {
             final BeanDesc beanDesc = BeanDescFactory.getBeanDesc(instance.getClass());
             for (final String methodName : beanDesc.getMethodNames()) {
@@ -185,27 +278,61 @@ public class StandardCrawlerContainer implements CrawlerContainer {
         }
     }
 
+    /**
+     * A definition for a component that can be instantiated on demand.
+     * This class handles component creation, dependency injection, and initialization.
+     *
+     * @param <T> the type of the component
+     */
     protected static class ComponentDef<T> {
+        /**
+         * The class of the component to instantiate.
+         */
         protected Class<T> cls;
 
+        /**
+         * The initializer function to be called after component creation.
+         */
         protected Consumer<T> initializer;
 
+        /**
+         * The container instance.
+         */
         protected StandardCrawlerContainer container;
 
+        /**
+         * The component instance.
+         */
         private T instance;
 
+        /**
+         * Creates a new ComponentDef for a class-based component.
+         * @param cls the class of the component
+         * @param initializer the initializer function (can be null)
+         * @param container the container instance for dependency injection
+         */
         protected ComponentDef(final Class<T> cls, final Consumer<T> initializer, final StandardCrawlerContainer container) {
             this.cls = cls;
             this.initializer = initializer;
             this.container = container;
         }
 
+        /**
+         * Creates a new ComponentDef for an instance-based component.
+         * @param instance the component instance
+         * @param initializer the initializer function (can be null)
+         * @param container the container instance for dependency injection
+         */
         protected ComponentDef(final T instance, final Consumer<T> initializer, final StandardCrawlerContainer container) {
             this.instance = instance;
             this.initializer = initializer;
             this.container = container;
         }
 
+        /**
+         * Creates and returns a component instance with dependency injection and initialization.
+         * @return the fully initialized component instance
+         */
         protected T get() {
             final T component = instance == null ? ClassUtil.newInstance(cls) : instance;
             final BeanDesc beanDesc = BeanDescFactory.getBeanDesc(component.getClass());

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/AccessResult.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/AccessResult.java
@@ -224,5 +224,10 @@ public interface AccessResult<IDTYPE> {
      *
      * @param lastModified the last modified time
      */
+    /**
+     * Sets the last modified time of the accessed resource.
+     *
+     * @param lastModified the last modified time
+     */
     void setLastModified(Long lastModified);
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/AccessResultDataImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/AccessResultDataImpl.java
@@ -21,23 +21,30 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.crawler.Constants;
 
 /**
- * @author shinsuke
+ * Implementation of the {@link AccessResultData} interface.
  *
+ * @param <IDTYPE> the type of the identifier
  */
 public class AccessResultDataImpl<IDTYPE> implements AccessResultData<IDTYPE> {
+    /** The unique identifier for the access result data. */
     protected IDTYPE id;
 
+    /** The name of the transformer associated with this access result data. */
     protected String transformerName;
 
+    /** The data as a byte array. */
     protected byte[] data;
 
+    /** The encoding used for the access result data. */
     protected String encoding;
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.entity.AccessResultData#getId()
+    /**
+     * Constructs a new AccessResultDataImpl instance.
      */
+    public AccessResultDataImpl() {
+        // NOP
+    }
+
     @Override
     public IDTYPE getId() {
         return id;
@@ -122,6 +129,10 @@ public class AccessResultDataImpl<IDTYPE> implements AccessResultData<IDTYPE> {
         }
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "AccessResultDataImpl [id=" + id + ", transformerName=" + transformerName + ", encoding=" + encoding + "]";

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/AccessResultImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/AccessResultImpl.java
@@ -19,36 +19,59 @@ import org.codelibs.core.beans.util.BeanUtil;
 import org.codelibs.fess.crawler.Constants;
 
 /**
- * @author shinsuke
+ * Implementation of the {@link AccessResult} interface.
  *
+ * @param <IDTYPE> the type of the identifier for the access result
  */
 public class AccessResultImpl<IDTYPE> implements AccessResult<IDTYPE> {
+
+    /**
+     * Creates a new instance of AccessResultImpl.
+     */
+    public AccessResultImpl() {
+        // NOP
+    }
+
+    /** The unique identifier for the access result. */
     protected IDTYPE id;
 
+    /** The session ID associated with the access result. */
     protected String sessionId;
 
+    /** The rule ID that matched the accessed resource. */
     protected String ruleId;
 
+    /** The URL of the accessed resource. */
     protected String url;
 
+    /** The parent URL of the accessed resource. */
     protected String parentUrl;
 
+    /** The status of the access result. */
     protected Integer status = Constants.OK_STATUS;
 
+    /** The HTTP status code of the access result. */
     protected Integer httpStatusCode;
 
+    /** The HTTP method used for the access. */
     protected String method;
 
+    /** The MIME type of the accessed resource. */
     protected String mimeType;
 
+    /** The creation time of the access result. */
     protected Long createTime;
 
+    /** The execution time of the access. */
     protected Integer executionTime;
 
+    /** The content length of the accessed resource. */
     protected Long contentLength;
 
+    /** The last modified time of the accessed resource. */
     protected Long lastModified;
 
+    /** The access result data. */
     protected AccessResultData<IDTYPE> accessResultData;
 
     @Override
@@ -330,6 +353,10 @@ public class AccessResultImpl<IDTYPE> implements AccessResult<IDTYPE> {
         this.lastModified = lastModified;
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "AccessResultImpl [id=" + id + ", sessionId=" + sessionId + ", ruleId=" + ruleId + ", url=" + url + ", parentUrl="

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/ExtractData.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/ExtractData.java
@@ -31,54 +31,105 @@ import org.apache.tika.metadata.TikaMimeKeys;
 import org.apache.tika.parser.pdf.PDFParser;
 
 /**
- * @author shinsuke
- *
+ * Represents extracted data from a crawled resource, including content and metadata.
  */
 public class ExtractData
         implements TikaCoreProperties, CreativeCommons, Geographic, HttpHeaders, Message, ClimateForcast, TIFF, TikaMimeKeys, Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /** Resource name key for metadata */
+    public static final String RESOURCE_NAME_KEY = "resourceName";
+
+    /** URL key for metadata */
     public static final String URL = "url";
 
+    /** File passwords key for metadata */
     public static final String FILE_PASSWORDS = "file.passwords";
 
+    /** Map containing metadata key-value pairs */
     protected Map<String, String[]> metadata = new HashMap<>();
 
+    /** The extracted content text */
     protected String content;
 
+    /**
+     * Constructs a new ExtractData.
+     */
     public ExtractData() {
-        // nothing
+        // Default constructor
     }
 
+    /**
+     * Constructs a new ExtractData with the specified content.
+     *
+     * @param content the content to set
+     */
     public ExtractData(final String content) {
         this.content = content;
     }
 
+    /**
+     * Puts multiple values for a given key in the metadata.
+     *
+     * @param key the metadata key
+     * @param values the values to associate with the key
+     */
     public void putValues(final String key, final String[] values) {
         metadata.put(key, values);
     }
 
+    /**
+     * Puts a single value for a given key in the metadata.
+     *
+     * @param key the metadata key
+     * @param value the value to associate with the key
+     */
     public void putValue(final String key, final String value) {
         metadata.put(key, new String[] { value });
     }
 
+    /**
+     * Gets the values associated with a given key from the metadata.
+     *
+     * @param key the metadata key
+     * @return the values associated with the key, or null if not found
+     */
     public String[] getValues(final String key) {
         return metadata.get(key);
     }
 
+    /**
+     * Gets the set of all metadata keys.
+     *
+     * @return the set of metadata keys
+     */
     public Set<String> getKeySet() {
         return metadata.keySet();
     }
 
+    /**
+     * Gets the extracted content.
+     *
+     * @return the extracted content
+     */
     public String getContent() {
         return content;
     }
 
+    /**
+     * Sets the extracted content.
+     *
+     * @param content the content to set
+     */
     public void setContent(final String content) {
         this.content = content;
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "ExtractData [metadata=" + metadata + ", content=" + content + "]";

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/RequestData.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/RequestData.java
@@ -20,28 +20,59 @@ import java.util.Objects;
 import org.codelibs.fess.crawler.Constants;
 
 /**
- * @author shinsuke
- *
+ * Represents a request data for crawling.
+ * This class encapsulates the HTTP method, URL, and weight associated with a crawling request.
  */
 public class RequestData {
+    /**
+     * HTTP methods supported for crawling requests.
+     */
     public enum Method {
-        GET, POST, HEAD;
+        /** HTTP GET method. */
+        GET,
+        /** HTTP POST method. */
+        POST,
+        /** HTTP HEAD method. */
+        HEAD;
     }
 
+    /** The HTTP method for this request. */
     private Method method;
 
+    /** The URL for this request. */
     private String url;
 
+    /** The weight/priority of this request (default: 1.0). */
     private float weight = 1.0f;
 
+    /**
+     * Creates a new RequestData instance.
+     */
+    public RequestData() {
+        super();
+    }
+
+    /**
+     * Gets the HTTP method for this request.
+     * @return the HTTP method
+     */
     public Method getMethod() {
         return method;
     }
 
+    /**
+     * Sets the HTTP method for this request.
+     * @param method the HTTP method
+     */
     public void setMethod(final Method method) {
         this.method = method;
     }
 
+    /**
+     * Sets the HTTP method for this request using a string value.
+     * Defaults to GET if the method is not recognized.
+     * @param method the HTTP method as a string
+     */
     public void setMethod(final String method) {
         if (Constants.GET_METHOD.equals(method)) {
             this.method = Method.GET;
@@ -54,27 +85,52 @@ public class RequestData {
         }
     }
 
+    /**
+     * Gets the URL for this request.
+     * @return the URL
+     */
     public String getUrl() {
         return url;
     }
 
+    /**
+     * Sets the URL for this request.
+     * @param url the URL
+     */
     public void setUrl(final String url) {
         this.url = url;
     }
 
+    /**
+     * Gets the weight/priority of this request.
+     * @return the weight
+     */
     public float getWeight() {
         return weight;
     }
 
+    /**
+     * Sets the weight/priority of this request.
+     * @param weight the weight
+     */
     public void setWeight(float weight) {
         this.weight = weight;
     }
 
+    /**
+     * Returns the hash code for this RequestData.
+     * @return the hash code
+     */
     @Override
     public int hashCode() {
         return Objects.hash(method, url, weight);
     }
 
+    /**
+     * Checks if this RequestData is equal to another object.
+     * @param obj the object to compare with
+     * @return true if the objects are equal, false otherwise
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
@@ -88,6 +144,10 @@ public class RequestData {
                 && Float.floatToIntBits(weight) == Float.floatToIntBits(other.weight);
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "RequestData [method=" + method + ", url=" + url + ", weight=" + weight + "]";

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/ResponseData.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/ResponseData.java
@@ -33,8 +33,10 @@ import org.codelibs.core.io.FileUtil;
 import org.codelibs.fess.crawler.Constants;
 
 /**
- * @author shinsuke
- *
+ * Represents the response data obtained from a crawled resource.
+ * This class encapsulates various details of an HTTP response, including
+ * status code, content type, content length, and the response body.
+ * It also provides methods for managing metadata, child URLs, and temporary files.
  */
 public class ResponseData implements Closeable {
 
@@ -76,18 +78,48 @@ public class ResponseData implements Closeable {
 
     private boolean noFollow = false;
 
+    /**
+     * Creates a new ResponseData instance.
+     */
+    public ResponseData() {
+        super();
+    }
+
+    /**
+     * Gets the HTTP status code of the response.
+     *
+     * @return the HTTP status code
+     */
     public int getHttpStatusCode() {
         return httpStatusCode;
     }
 
+    /**
+     * Sets the HTTP status code of the response.
+     *
+     * @param statusCode the HTTP status code to set
+     */
     public void setHttpStatusCode(final int statusCode) {
         httpStatusCode = statusCode;
     }
 
+    /**
+     * Checks if this response has a response body.
+     *
+     * @return true if the response has a body (either as bytes or file), false otherwise
+     */
     public boolean hasResponseBody() {
         return responseBodyBytes != null || responseBodyFile != null;
     }
 
+    /**
+     * Gets the response body as an InputStream.
+     * If the response body is stored as bytes, returns a ByteArrayInputStream.
+     * If the response body is stored as a file, returns a FileInputStream.
+     *
+     * @return the response body as an InputStream, or null if no response body is available
+     * @throws IORuntimeException if an I/O error occurs while reading the response body file
+     */
     public InputStream getResponseBody() {
         if (responseBodyBytes != null) {
             return new ByteArrayInputStream(responseBodyBytes);
@@ -102,139 +134,311 @@ public class ResponseData implements Closeable {
         return null;
     }
 
+    /**
+     * Sets the response body from a byte array.
+     *
+     * @param responseBody the byte array containing the response body
+     */
     public void setResponseBody(final byte[] responseBody) {
         responseBodyBytes = responseBody;
     }
 
+    /**
+     * Sets the response body from a file.
+     *
+     * @param responseBody the file containing the response body
+     * @param isTemporary true if the file is temporary and should be deleted when closing
+     */
     public void setResponseBody(final File responseBody, final boolean isTemporary) {
         responseBodyFile = responseBody;
         isTemporaryFile = isTemporary;
     }
 
+    /**
+     * Gets the character set of the response.
+     *
+     * @return the character set, or null if not specified
+     */
     public String getCharSet() {
         return charSet;
     }
 
+    /**
+     * Sets the character set of the response.
+     *
+     * @param charSet the character set to set
+     */
     public void setCharSet(final String charSet) {
         this.charSet = charSet;
     }
 
+    /**
+     * Gets the content length of the response.
+     *
+     * @return the content length in bytes
+     */
     public long getContentLength() {
         return contentLength;
     }
 
+    /**
+     * Sets the content length of the response.
+     *
+     * @param contentLength the content length in bytes
+     */
     public void setContentLength(final long contentLength) {
         this.contentLength = contentLength;
     }
 
+    /**
+     * Gets the MIME type of the response.
+     *
+     * @return the MIME type, or null if not specified
+     */
     public String getMimeType() {
         return mimeType;
     }
 
+    /**
+     * Sets the MIME type of the response.
+     *
+     * @param contentType the MIME type to set
+     */
     public void setMimeType(final String contentType) {
         mimeType = contentType;
     }
 
+    /**
+     * Gets the URL of the crawled resource.
+     *
+     * @return the URL
+     */
     public String getUrl() {
         return url;
     }
 
+    /**
+     * Sets the URL of the crawled resource.
+     *
+     * @param url the URL to set
+     */
     public void setUrl(final String url) {
         this.url = url;
     }
 
+    /**
+     * Gets the HTTP method used for the request.
+     *
+     * @return the HTTP method (e.g., GET, POST)
+     */
     public String getMethod() {
         return method;
     }
 
+    /**
+     * Sets the HTTP method used for the request.
+     *
+     * @param method the HTTP method to set (e.g., GET, POST)
+     */
     public void setMethod(final String method) {
         this.method = method;
     }
 
+    /**
+     * Gets the parent URL from which this resource was discovered.
+     *
+     * @return the parent URL, or null if this is a root URL
+     */
     public String getParentUrl() {
         return parentUrl;
     }
 
+    /**
+     * Sets the parent URL from which this resource was discovered.
+     *
+     * @param parentUrl the parent URL to set
+     */
     public void setParentUrl(final String parentUrl) {
         this.parentUrl = parentUrl;
     }
 
+    /**
+     * Gets the rule ID associated with this response.
+     *
+     * @return the rule ID, or null if not specified
+     */
     public String getRuleId() {
         return ruleId;
     }
 
+    /**
+     * Sets the rule ID associated with this response.
+     *
+     * @param ruleId the rule ID to set
+     */
     public void setRuleId(final String ruleId) {
         this.ruleId = ruleId;
     }
 
+    /**
+     * Gets the session ID associated with this crawling session.
+     *
+     * @return the session ID, or null if not specified
+     */
     public String getSessionId() {
         return sessionId;
     }
 
+    /**
+     * Sets the session ID associated with this crawling session.
+     *
+     * @param sessionId the session ID to set
+     */
     public void setSessionId(final String sessionId) {
         this.sessionId = sessionId;
     }
 
+    /**
+     * Gets the execution time for processing this response.
+     *
+     * @return the execution time in milliseconds
+     */
     public long getExecutionTime() {
         return executionTime;
     }
 
+    /**
+     * Sets the execution time for processing this response.
+     *
+     * @param executionTime the execution time in milliseconds
+     */
     public void setExecutionTime(final long executionTime) {
         this.executionTime = executionTime;
     }
 
+    /**
+     * Gets the redirect location if the response is a redirect.
+     *
+     * @return the redirect location URL, or null if not a redirect
+     */
     public String getRedirectLocation() {
         return redirectLocation;
     }
 
+    /**
+     * Sets the redirect location if the response is a redirect.
+     *
+     * @param redirectLocation the redirect location URL to set
+     */
     public void setRedirectLocation(final String redirectLocation) {
         this.redirectLocation = redirectLocation;
     }
 
+    /**
+     * Gets the last modified date of the resource.
+     *
+     * @return the last modified date, or null if not available
+     */
     public Date getLastModified() {
         return lastModified;
     }
 
+    /**
+     * Sets the last modified date of the resource.
+     *
+     * @param lastModified the last modified date to set
+     */
     public void setLastModified(final Date lastModified) {
         this.lastModified = lastModified;
     }
 
+    /**
+     * Gets the processing status of this response.
+     *
+     * @return the processing status
+     */
     public int getStatus() {
         return status;
     }
 
+    /**
+     * Sets the processing status of this response.
+     *
+     * @param status the processing status to set
+     */
     public void setStatus(final int status) {
         this.status = status;
     }
 
+    /**
+     * Sets whether this response should not be followed for further crawling.
+     *
+     * @param value true if this response should not be followed, false otherwise
+     */
     public void setNoFollow(final boolean value) {
         noFollow = value;
     }
 
+    /**
+     * Checks if this response should not be followed for further crawling.
+     *
+     * @return true if this response should not be followed, false otherwise
+     */
     public boolean isNoFollow() {
         return noFollow;
     }
 
+    /**
+     * Adds metadata to this response.
+     *
+     * @param name the name of the metadata
+     * @param value the value of the metadata
+     */
     public void addMetaData(final String name, final Object value) {
         metaDataMap.put(name, value);
     }
 
+    /**
+     * Gets the metadata map containing all metadata associated with this response.
+     *
+     * @return the metadata map
+     */
     public Map<String, Object> getMetaDataMap() {
         return metaDataMap;
     }
 
+    /**
+     * Adds a child URL discovered from this response.
+     *
+     * @param url the child URL to add
+     */
     public void addChildUrl(final RequestData url) {
         childUrlSet.add(url);
     }
 
+    /**
+     * Removes a child URL from this response.
+     *
+     * @param url the child URL to remove
+     */
     public void removeChildUrl(final RequestData url) {
         childUrlSet.remove(url);
     }
 
+    /**
+     * Gets the set of child URLs discovered from this response.
+     *
+     * @return the set of child URLs
+     */
     public Set<RequestData> getChildUrlSet() {
         return childUrlSet;
     }
 
+    /**
+     * Creates a RequestData object from this response's URL and method.
+     *
+     * @return a new RequestData object with the URL and method from this response
+     */
     public RequestData getRequestData() {
         final RequestData requestData = new RequestData();
         requestData.setMethod(method);
@@ -242,6 +446,10 @@ public class ResponseData implements Closeable {
         return requestData;
     }
 
+    /**
+     * Closes the response data, deleting temporary files if any.
+     * @throws IOException if an I/O error occurs.
+     */
     @Override
     public void close() throws IOException {
         if (isTemporaryFile) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/ResultData.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/ResultData.java
@@ -48,8 +48,15 @@ public class ResultData implements Serializable {
     protected Function<Object, byte[]> serializer;
 
     /**
+     * Creates a new ResultData instance.
+     */
+    public ResultData() {
+        super();
+    }
+
+    /**
      * Set the raw data.
-     * @param rawData
+     * @param rawData the raw data object to set
      */
     public void setRawData(final Object rawData) {
         this.rawData = rawData;
@@ -68,7 +75,7 @@ public class ResultData implements Serializable {
 
     /**
      * Set the serializer.
-     * @param serializer
+     * @param serializer the serializer function to convert raw data to byte array
      */
     public void setSerializer(final Function<Object, byte[]> serializer) {
         this.serializer = serializer;
@@ -90,7 +97,7 @@ public class ResultData implements Serializable {
 
     /**
      * Set the data.
-     * @param data
+     * @param data the byte array data to set
      */
     public void setData(final byte[] data) {
         this.data = data;
@@ -98,7 +105,7 @@ public class ResultData implements Serializable {
 
     /**
      * Add a child URL.
-     * @param url
+     * @param url the request data to add to the child URL set
      */
     public void addUrl(final RequestData url) {
         childUrlSet.add(url);
@@ -106,7 +113,7 @@ public class ResultData implements Serializable {
 
     /**
      * Add child URLs.
-     * @param c
+     * @param c the collection of request data to add to the child URL set
      */
     public void addAllUrl(final Collection<RequestData> c) {
         if (c != null) {
@@ -116,7 +123,7 @@ public class ResultData implements Serializable {
 
     /**
      * Remove a child URL.
-     * @param url
+     * @param url the request data to remove from the child URL set
      */
     public void removeUrl(final RequestData url) {
         childUrlSet.remove(url);
@@ -132,7 +139,7 @@ public class ResultData implements Serializable {
 
     /**
      * Set the transformer name.
-     * @param transformerName
+     * @param transformerName the name of the transformer to set
      */
     public void setTransformerName(final String transformerName) {
         this.transformerName = transformerName;
@@ -148,7 +155,7 @@ public class ResultData implements Serializable {
 
     /**
      * Set the child URL set.
-     * @param childUrlSet
+     * @param childUrlSet the set of request data to set as child URLs
      */
     public void setChildUrlSet(final Set<RequestData> childUrlSet) {
         this.childUrlSet = childUrlSet;
@@ -164,12 +171,16 @@ public class ResultData implements Serializable {
 
     /**
      * Set the encoding.
-     * @param encoding
+     * @param encoding the encoding to set
      */
     public void setEncoding(final String encoding) {
         this.encoding = encoding;
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "ResultData [transformerName=" + transformerName + ", encoding=" + encoding + ", childUrlSet=" + childUrlSet + "]";

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/RobotsTxt.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/RobotsTxt.java
@@ -47,9 +47,18 @@ import org.codelibs.core.lang.StringUtil;
 public class RobotsTxt {
     private static final String ALL_BOTS = "*";
 
+    /** Map of user agent patterns to their corresponding directives. */
     protected final Map<Pattern, Directive> directiveMap = new LinkedHashMap<>();
 
+    /** List of sitemap URLs found in the robots.txt file. */
     private final List<String> sitemapList = new ArrayList<>();
+
+    /**
+     * Creates a new RobotsTxt instance.
+     */
+    public RobotsTxt() {
+        // Default constructor
+    }
 
     /**
      * Checks if access to a given path is allowed for a specific user agent according to robots.txt rules.
@@ -174,30 +183,55 @@ public class RobotsTxt {
      * A directive consists of a user agent, crawl delay, allowed paths, and disallowed paths.
      */
     public static class Directive {
+        /** The user agent string this directive applies to. */
         private final String userAgent;
 
+        /** The crawl delay in seconds for this directive. */
         private int crawlDelay;
 
+        /** The list of allowed paths for this directive. */
         private final List<String> allowedPaths = new ArrayList<>();
 
+        /** The list of disallowed paths for this directive. */
         private final List<String> disallowedPaths = new ArrayList<>();
 
+        /**
+         * Constructs a new Directive with the specified user agent.
+         * @param userAgent the user agent string this directive applies to
+         */
         public Directive(final String userAgent) {
             this.userAgent = userAgent;
         }
 
+        /**
+         * Sets the crawl delay for this directive.
+         * @param crawlDelay the crawl delay in seconds
+         */
         public void setCrawlDelay(final int crawlDelay) {
             this.crawlDelay = crawlDelay;
         }
 
+        /**
+         * Gets the crawl delay for this directive.
+         * @return the crawl delay in seconds
+         */
         public int getCrawlDelay() {
             return crawlDelay;
         }
 
+        /**
+         * Gets the user agent for this directive.
+         * @return the user agent string
+         */
         public String getUserAgent() {
             return userAgent;
         }
 
+        /**
+         * Checks if the given path is allowed according to this directive.
+         * @param path the path to check
+         * @return true if the path is allowed, false otherwise
+         */
         public boolean allows(final String path) {
             for (final String allowedPath : allowedPaths) {
                 if (path.startsWith(allowedPath)) {
@@ -212,27 +246,47 @@ public class RobotsTxt {
             return true;
         }
 
+        /**
+         * Adds an allowed path to this directive.
+         * @param path the path to allow
+         */
         public void addAllow(final String path) {
             if (!allowedPaths.contains(path)) {
                 allowedPaths.add(path);
             }
         }
 
+        /**
+         * Adds a disallowed path to this directive.
+         * @param path the path to disallow
+         */
         public void addDisallow(final String path) {
             if (!disallowedPaths.contains(path)) {
                 disallowedPaths.add(path);
             }
         }
 
+        /**
+         * Gets all allowed paths for this directive.
+         * @return an array of allowed paths
+         */
         public String[] getAllows() {
             return allowedPaths.toArray(new String[allowedPaths.size()]);
         }
 
+        /**
+         * Gets all disallowed paths for this directive.
+         * @return an array of disallowed paths
+         */
         public String[] getDisallows() {
             return disallowedPaths.toArray(new String[disallowedPaths.size()]);
         }
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "RobotsTxt [directiveMap=" + directiveMap + ", sitemapList=" + sitemapList + "]";

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/SitemapFile.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/SitemapFile.java
@@ -64,6 +64,13 @@ public class SitemapFile implements Sitemap {
      */
     private String lastmod;
 
+    /**
+     * Creates a new SitemapFile instance.
+     */
+    public SitemapFile() {
+        // Default constructor
+    }
+
     /*
      * (non-Javadoc)
      *
@@ -74,6 +81,10 @@ public class SitemapFile implements Sitemap {
         return loc;
     }
 
+    /**
+     * Sets the location of the sitemap.
+     * @param loc the location URL to set
+     */
     public void setLoc(final String loc) {
         this.loc = loc;
     }
@@ -88,10 +99,19 @@ public class SitemapFile implements Sitemap {
         return lastmod;
     }
 
+    /**
+     * Sets the last modification time of the sitemap.
+     * @param lastmod the last modification time in W3C Datetime format
+     */
     public void setLastmod(final String lastmod) {
         this.lastmod = lastmod;
     }
 
+    /**
+     * Checks if this SitemapFile is equal to another object.
+     * @param obj the object to compare with
+     * @return true if the objects are equal, false otherwise
+     */
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) {
@@ -106,11 +126,19 @@ public class SitemapFile implements Sitemap {
         return false;
     }
 
+    /**
+     * Returns the hash code value for this SitemapFile.
+     * @return the hash code value
+     */
     @Override
     public int hashCode() {
         return java.util.Objects.hash(loc, lastmod);
     }
 
+    /**
+     * Returns a string representation of this SitemapFile.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "SitemapFile [loc=" + loc + ", lastmod=" + lastmod + "]";

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/SitemapSet.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/SitemapSet.java
@@ -28,38 +28,77 @@ public class SitemapSet implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /** Constant for UrlSet type. */
     public static final String URLSET = "UrlSet";
 
+    /** Constant for Index type. */
     public static final String INDEX = "Index";
 
+    /** The list of sitemaps in this set. */
     private final List<Sitemap> sitemapList = new ArrayList<>();
 
+    /** The type of this sitemap set (URLSET or INDEX). */
     private String type = URLSET;
 
+    /**
+     * Creates a new SitemapSet instance with default type URLSET.
+     */
+    public SitemapSet() {
+        // Default constructor
+    }
+
+    /**
+     * Adds a sitemap to this set.
+     * @param sitemap the sitemap to add
+     */
     public void addSitemap(final Sitemap sitemap) {
         sitemapList.add(sitemap);
     }
 
+    /**
+     * Removes a sitemap from this set.
+     * @param sitemap the sitemap to remove
+     */
     public void removeSitemap(final Sitemap sitemap) {
         sitemapList.remove(sitemap);
     }
 
+    /**
+     * Gets all sitemaps in this set as an array.
+     * @return an array of sitemaps
+     */
     public Sitemap[] getSitemaps() {
         return sitemapList.toArray(new Sitemap[sitemapList.size()]);
     }
 
+    /**
+     * Sets the type of this sitemap set.
+     * @param type the type to set (URLSET or INDEX)
+     */
     public void setType(final String type) {
         this.type = type;
     }
 
+    /**
+     * Checks if this sitemap set is of type URLSET.
+     * @return true if this is a URLSET, false otherwise
+     */
     public boolean isUrlSet() {
         return URLSET.equals(type);
     }
 
+    /**
+     * Checks if this sitemap set is of type INDEX.
+     * @return true if this is an INDEX, false otherwise
+     */
     public boolean isIndex() {
         return INDEX.equals(type);
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "SitemapSet [sitemapList=" + sitemapList + ", type=" + type + "]";

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/SitemapUrl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/SitemapUrl.java
@@ -37,6 +37,13 @@ public class SitemapUrl implements Sitemap {
     private static final long serialVersionUID = 1L;
 
     /**
+     * Creates a new SitemapUrl instance.
+     */
+    public SitemapUrl() {
+        super();
+    }
+
+    /**
      * URL of the page. This URL must begin with the protocol (such as http) and
      * end with a trailing slash, if your web server requires it. This value
      * must be less than 2,048 characters.
@@ -100,36 +107,68 @@ public class SitemapUrl implements Sitemap {
      */
     private String priority;
 
+    /**
+     * Returns the location URL of this sitemap entry.
+     * @return the location URL
+     */
     @Override
     public String getLoc() {
         return loc;
     }
 
+    /**
+     * Sets the location URL of this sitemap entry.
+     * @param loc the location URL to set
+     */
     public void setLoc(final String loc) {
         this.loc = loc;
     }
 
+    /**
+     * Returns the last modification date of this sitemap entry.
+     * @return the last modification date
+     */
     @Override
     public String getLastmod() {
         return lastmod;
     }
 
+    /**
+     * Sets the last modification date of this sitemap entry.
+     * @param lastmod the last modification date to set
+     */
     public void setLastmod(final String lastmod) {
         this.lastmod = lastmod;
     }
 
+    /**
+     * Returns the change frequency of this sitemap entry.
+     * @return the change frequency
+     */
     public String getChangefreq() {
         return changefreq;
     }
 
+    /**
+     * Sets the change frequency of this sitemap entry.
+     * @param changefreq the change frequency to set
+     */
     public void setChangefreq(final String changefreq) {
         this.changefreq = changefreq;
     }
 
+    /**
+     * Returns the priority of this sitemap entry.
+     * @return the priority
+     */
     public String getPriority() {
         return priority;
     }
 
+    /**
+     * Sets the priority of this sitemap entry.
+     * @param priority the priority to set
+     */
     public void setPriority(final String priority) {
         this.priority = priority;
     }
@@ -154,6 +193,10 @@ public class SitemapUrl implements Sitemap {
         return java.util.Objects.hash(loc, changefreq, lastmod, priority);
     }
 
+    /**
+     * Returns a string representation of this SitemapUrl.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "SitemapUrl [loc=" + loc + ", lastmod=" + lastmod + ", changefreq=" + changefreq + ", priority=" + priority + "]";

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/UrlQueueImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/UrlQueueImpl.java
@@ -21,35 +21,49 @@ package org.codelibs.fess.crawler.entity;
  * HTTP method, URL, metadata, encoding, parent URL, depth, last modified time,
  * creation time, and weight.
  *
+ * @param <IDTYPE> the type of the identifier for the URL queue entry
  */
 public class UrlQueueImpl<IDTYPE> implements UrlQueue<IDTYPE> {
+    /** The unique identifier for the URL queue entry. */
     protected IDTYPE id;
 
+    /** The session ID associated with this URL queue. */
     protected String sessionId;
 
+    /** The HTTP method used for the URL in the queue. */
     protected String method;
 
+    /** The URL from the queue. */
     protected String url;
 
+    /** The metadata associated with the URL queue. */
     protected String metaData;
 
+    /** The encoding of the URL queue. */
     protected String encoding;
 
+    /** The parent URL of the current URL in the queue. */
     protected String parentUrl;
 
+    /** The depth of the URL in the queue. */
     protected Integer depth;
 
+    /** The last modified timestamp of the URL in the queue. */
     protected Long lastModified;
 
+    /** The creation time of the URL queue entry. */
     protected Long createTime;
 
+    /** The weight of the URL queue. */
     protected float weight = 1.0f;
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.entity.UrlQueue#getId()
+    /**
+     * Constructs a new UrlQueueImpl instance.
      */
+    public UrlQueueImpl() {
+        // NOP
+    }
+
     @Override
     public IDTYPE getId() {
         return id;
@@ -235,6 +249,10 @@ public class UrlQueueImpl<IDTYPE> implements UrlQueue<IDTYPE> {
         this.weight = weight;
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "UrlQueueImpl [id=" + id + ", sessionId=" + sessionId + ", method=" + method + ", url=" + url + ", encoding=" + encoding

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/ChildUrlsException.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/ChildUrlsException.java
@@ -29,13 +29,25 @@ public class ChildUrlsException extends CrawlerSystemException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The list of child URLs.
+     */
     private final Set<RequestData> childUrlList;
 
+    /**
+     * Creates a new instance of ChildUrlsException.
+     * @param childUrlList The list of child URLs.
+     * @param description The description of the exception.
+     */
     public ChildUrlsException(final Set<RequestData> childUrlList, final String description) {
         super("Threw child urls(" + childUrlList.size() + "). " + description, false, false);
         this.childUrlList = childUrlList;
     }
 
+    /**
+     * Returns the list of child URLs.
+     * @return The list of child URLs.
+     */
     public Set<RequestData> getChildUrlList() {
         return childUrlList;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/CrawlerSystemException.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/CrawlerSystemException.java
@@ -56,6 +56,13 @@ public class CrawlerSystemException extends RuntimeException {
         super(cause);
     }
 
+    /**
+     * Constructs a new CrawlerSystemException with the specified detail message and controls suppression and stack trace writing.
+     *
+     * @param message the detail message
+     * @param enableSuppression whether or not suppression is enabled
+     * @param writableStackTrace whether or not the stack trace should be writable
+     */
     protected CrawlerSystemException(final String message, final boolean enableSuppression, final boolean writableStackTrace) {
         super(message, null, enableSuppression, writableStackTrace);
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/CrawlingAccessException.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/CrawlingAccessException.java
@@ -46,44 +46,97 @@ public class CrawlingAccessException extends CrawlerSystemException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Log level constant for debug messages.
+     */
     public static final String DEBUG = "DEBUG";
 
+    /**
+     * Log level constant for info messages.
+     */
     public static final String INFO = "INFO";
 
+    /**
+     * Log level constant for warning messages.
+     */
     public static final String WARN = "WARN";
 
+    /**
+     * Log level constant for error messages.
+     */
     public static final String ERROR = "ERROR";
 
+    /** The log level for this exception, defaults to INFO */
     private String logLevel = INFO;
 
+    /**
+     * Constructs a new CrawlingAccessException with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause the cause
+     */
     public CrawlingAccessException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * Constructs a new CrawlingAccessException with the specified detail message.
+     *
+     * @param message the detail message
+     */
     public CrawlingAccessException(final String message) {
         super(message);
     }
 
+    /**
+     * Constructs a new CrawlingAccessException with the specified cause.
+     *
+     * @param cause the cause
+     */
     public CrawlingAccessException(final Throwable cause) {
         super(cause);
     }
 
+    /**
+     * Sets the log level for this exception.
+     *
+     * @param logLevel the log level to set
+     */
     public void setLogLevel(final String logLevel) {
         this.logLevel = logLevel;
     }
 
+    /**
+     * Checks if the log level is DEBUG.
+     *
+     * @return true if DEBUG, false otherwise
+     */
     public boolean isDebugEnabled() {
         return DEBUG.equals(logLevel);
     }
 
+    /**
+     * Checks if the log level is INFO.
+     *
+     * @return true if INFO, false otherwise
+     */
     public boolean isInfoEnabled() {
         return INFO.equals(logLevel);
     }
 
+    /**
+     * Checks if the log level is WARN.
+     *
+     * @return true if WARN, false otherwise
+     */
     public boolean isWarnEnabled() {
         return WARN.equals(logLevel);
     }
 
+    /**
+     * Checks if the log level is ERROR.
+     * @return true if ERROR, false otherwise.
+     */
     public boolean isErrorEnabled() {
         return ERROR.equals(logLevel);
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/MaxLengthExceededException.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/MaxLengthExceededException.java
@@ -24,6 +24,11 @@ public class MaxLengthExceededException extends CrawlingAccessException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new MaxLengthExceededException with the specified detail message.
+     *
+     * @param message the detail message explaining the reason for the exception
+     */
     public MaxLengthExceededException(final String message) {
         super(message);
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/MimeTypeException.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/MimeTypeException.java
@@ -24,14 +24,30 @@ public class MimeTypeException extends CrawlerSystemException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new MimeTypeException with the specified detail message and cause.
+     *
+     * @param message the detail message explaining the reason for the exception
+     * @param cause the underlying cause of the exception
+     */
     public MimeTypeException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * Creates a new MimeTypeException with the specified detail message.
+     *
+     * @param message the detail message explaining the reason for the exception
+     */
     public MimeTypeException(final String message) {
         super(message);
     }
 
+    /**
+     * Creates a new MimeTypeException with the specified cause.
+     *
+     * @param cause the underlying cause of the exception
+     */
     public MimeTypeException(final Throwable cause) {
         super(cause);
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/MultipleCrawlingAccessException.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/MultipleCrawlingAccessException.java
@@ -28,8 +28,17 @@ public class MultipleCrawlingAccessException extends CrawlingAccessException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The array of throwables that caused this exception.
+     */
     private final Throwable[] throwables;
 
+    /**
+     * Creates a new MultipleCrawlingAccessException with the specified detail message and array of throwables.
+     *
+     * @param message the detail message explaining the reason for the exception
+     * @param throwables the array of throwables that caused this exception
+     */
     public MultipleCrawlingAccessException(final String message, final Throwable[] throwables) {
         super(message);
         if (throwables == null) {
@@ -63,6 +72,10 @@ public class MultipleCrawlingAccessException extends CrawlingAccessException {
         }
     }
 
+    /**
+     * Returns the array of Throwables that caused this exception.
+     * @return The array of Throwables.
+     */
     public Throwable[] getCauses() {
         return throwables;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/RobotsTxtException.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/RobotsTxtException.java
@@ -24,10 +24,19 @@ public class RobotsTxtException extends CrawlerSystemException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs a new RobotsTxtException with the specified detail message and cause.
+     * @param message the detail message
+     * @param cause the cause of the exception
+     */
     public RobotsTxtException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * Constructs a new RobotsTxtException with the specified detail message.
+     * @param message the detail message
+     */
     public RobotsTxtException(final String message) {
         super(message);
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/SitemapsException.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/SitemapsException.java
@@ -23,14 +23,27 @@ package org.codelibs.fess.crawler.exception;
 public class SitemapsException extends CrawlerSystemException {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs a new SitemapsException with the specified detail message and cause.
+     * @param message the detail message
+     * @param cause the cause of the exception
+     */
     public SitemapsException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * Constructs a new SitemapsException with the specified detail message.
+     * @param message the detail message
+     */
     public SitemapsException(final String message) {
         super(message);
     }
 
+    /**
+     * Constructs a new SitemapsException with the specified cause.
+     * @param cause the cause of the exception
+     */
     public SitemapsException(final Throwable cause) {
         super(cause);
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/UnsupportedExtractException.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/exception/UnsupportedExtractException.java
@@ -24,6 +24,10 @@ public class UnsupportedExtractException extends ExtractException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructor.
+     * @param message The error message.
+     */
     public UnsupportedExtractException(final String message) {
         super(message, false, false);
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/ExtractorBuilder.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/ExtractorBuilder.java
@@ -71,55 +71,108 @@ import org.codelibs.fess.crawler.helper.MimeTypeHelper;
  */
 public class ExtractorBuilder {
 
+    /** Logger instance for this class */
     private static final Logger logger = LogManager.getLogger(ExtractorBuilder.class);
 
+    /** Input stream to extract data from */
     private final InputStream in;
 
+    /** Parameters for the extraction process */
     private final Map<String, String> params;
 
+    /** Container for accessing crawler components */
     private final CrawlerContainer crawlerContainer;
 
+    /** MIME type of the content */
     private String mimeType;
 
+    /** Filename of the content */
     private String filename;
 
+    /** Cache file size threshold in bytes */
     private int cacheFileSize = 1_000_000;
 
+    /** Name of the extractor to use */
     private String extractorName = "tikaExtractor";
 
+    /** Maximum content length allowed */
     private long maxContentLength = -1;
 
+    /**
+     * Constructs a new ExtractorBuilder.
+     *
+     * @param crawlerContainer the crawler container
+     * @param in the input stream to extract data from
+     * @param params the parameters for the extraction process
+     */
     protected ExtractorBuilder(final CrawlerContainer crawlerContainer, final InputStream in, final Map<String, String> params) {
         this.crawlerContainer = crawlerContainer;
         this.in = in;
         this.params = params;
     }
 
+    /**
+     * Sets the MIME type of the content to extract.
+     *
+     * @param mimeType the MIME type to set
+     * @return this builder instance for method chaining
+     */
     public ExtractorBuilder mimeType(final String mimeType) {
         this.mimeType = mimeType;
         return this;
     }
 
+    /**
+     * Sets the filename of the content to extract.
+     *
+     * @param filename the filename to set
+     * @return this builder instance for method chaining
+     */
     public ExtractorBuilder filename(final String filename) {
         this.filename = filename;
         return this;
     }
 
+    /**
+     * Sets the name of the extractor to use.
+     *
+     * @param extractorName the extractor name to set
+     * @return this builder instance for method chaining
+     */
     public ExtractorBuilder extractorName(final String extractorName) {
         this.extractorName = extractorName;
         return this;
     }
 
+    /**
+     * Sets the maximum content length allowed for extraction.
+     *
+     * @param maxContentLength the maximum content length to set
+     * @return this builder instance for method chaining
+     */
     public ExtractorBuilder maxContentLength(final long maxContentLength) {
         this.maxContentLength = maxContentLength;
         return this;
     }
 
+    /**
+     * Sets the cache file size threshold in bytes.
+     *
+     * @param cacheFileSize the cache file size to set
+     * @return this builder instance for method chaining
+     */
     public ExtractorBuilder cacheFileSize(final int cacheFileSize) {
         this.cacheFileSize = cacheFileSize;
         return this;
     }
 
+    /**
+     * Extracts data from the input stream using the configured parameters.
+     *
+     * @return the extracted data
+     * @throws MaxLengthExceededException if content length exceeds maximum allowed
+     * @throws ExtractException if extraction fails
+     */
     public ExtractData extract() {
         final ExtractorFactory extractorFactory = crawlerContainer.getComponent("extractorFactory");
 
@@ -181,6 +234,13 @@ public class ExtractorBuilder {
 
     }
 
+    /**
+     * Detects the MIME type of the content.
+     *
+     * @param out the deferred file output stream
+     * @return the detected MIME type
+     * @throws IOException if an I/O error occurs
+     */
     protected String getMimeType(final DeferredFileOutputStream out) throws IOException {
         final MimeTypeHelper mimeTypeHelper = crawlerContainer.getComponent("mimeTypeHelper");
         try (InputStream is = getContentInputStream(out)) {
@@ -188,6 +248,13 @@ public class ExtractorBuilder {
         }
     }
 
+    /**
+     * Gets an input stream for the content in the deferred file output stream.
+     *
+     * @param out the deferred file output stream
+     * @return the input stream for the content
+     * @throws IOException if an I/O error occurs
+     */
     protected InputStream getContentInputStream(final DeferredFileOutputStream out) throws IOException {
         if (out.isInMemory()) {
             return new ByteArrayInputStream(out.getData());
@@ -195,6 +262,12 @@ public class ExtractorBuilder {
         return new FileInputStream(out.getFile());
     }
 
+    /**
+     * Returns the content length.
+     * @param out The DeferredFileOutputStream.
+     * @return The content length.
+     * @throws IOException if an I/O error occurs.
+     */
     protected long getContentLength(final DeferredFileOutputStream out) throws IOException {
         if (out.isInMemory()) {
             return out.getData().length;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/ExtractorFactory.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/ExtractorFactory.java
@@ -53,12 +53,22 @@ import jakarta.annotation.Resource;
  */
 public class ExtractorFactory {
 
+    /** Logger instance for this class */
     private static final Logger logger = LogManager.getLogger(ExtractorFactory.class);
 
+    /** Container for managing crawler components */
     @Resource
     protected CrawlerContainer crawlerContainer;
 
+    /** Map of keys to arrays of extractors */
     protected Map<String, Extractor[]> extractorMap = new HashMap<>();
+
+    /**
+     * Constructs a new ExtractorFactory.
+     */
+    public ExtractorFactory() {
+        // Default constructor
+    }
 
     /**
      * Adds an extractor to the factory for the specified key.
@@ -95,6 +105,13 @@ public class ExtractorFactory {
         }
     }
 
+    /**
+     * Adds an extractor to the factory for all keys in the provided list.
+     *
+     * @param keyList the list of keys to associate with the extractor
+     * @param extractor the extractor to add
+     * @throws CrawlerSystemException if the key list is null or empty, or if the extractor is null
+     */
     public void addExtractor(final List<String> keyList, final Extractor extractor) {
         if (keyList == null || keyList.isEmpty()) {
             throw new CrawlerSystemException("The key list is empty.");
@@ -102,6 +119,14 @@ public class ExtractorFactory {
         keyList.stream().distinct().forEach(key -> addExtractor(key, extractor));
     }
 
+    /**
+     * Retrieves an extractor for the specified key.
+     * If multiple extractors are associated with the key, returns a composite extractor
+     * that tries each extractor in order until one succeeds.
+     *
+     * @param key the key to look up
+     * @return the extractor for the key, or null if not found
+     */
     public Extractor getExtractor(final String key) {
         final Extractor[] extractors = extractorMap.get(key);
         if (extractors == null || extractors.length == 0) {
@@ -132,6 +157,11 @@ public class ExtractorFactory {
         };
     }
 
+    /**
+     * Retrieves all extractors for the specified key.
+     * @param key The key associated with the extractors.
+     * @return An array of Extractor instances, or an empty array if no extractors are found.
+     */
     public Extractor[] getExtractors(final String key) {
         final Extractor[] extractors = extractorMap.get(key);
         if (extractors == null || extractors.length == 0) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractExtractor.java
@@ -47,9 +47,21 @@ import jakarta.annotation.Resource;
  */
 public abstract class AbstractExtractor implements Extractor {
 
+    /** The crawler container. */
     @Resource
     protected CrawlerContainer crawlerContainer;
 
+    /**
+     * Constructs a new AbstractExtractor.
+     */
+    public AbstractExtractor() {
+        // NOP
+    }
+
+    /**
+     * Registers this extractor with the ExtractorFactory.
+     * @param keyList The list of keys to register this extractor under.
+     */
     public void register(final List<String> keyList) {
         if (keyList == null || keyList.isEmpty()) {
             throw new IllegalArgumentException("keyList must not be null or empty.");
@@ -57,6 +69,10 @@ public abstract class AbstractExtractor implements Extractor {
         getExtractorFactory().addExtractor(keyList, this);
     }
 
+    /**
+     * Returns the MimeTypeHelper instance from the CrawlerContainer.
+     * @return The MimeTypeHelper instance.
+     */
     protected MimeTypeHelper getMimeTypeHelper() {
         final MimeTypeHelper mimeTypeHelper = crawlerContainer.getComponent("mimeTypeHelper");
         if (mimeTypeHelper == null) {
@@ -65,6 +81,10 @@ public abstract class AbstractExtractor implements Extractor {
         return mimeTypeHelper;
     }
 
+    /**
+     * Returns the ExtractorFactory instance from the CrawlerContainer.
+     * @return The ExtractorFactory instance.
+     */
     protected ExtractorFactory getExtractorFactory() {
         final ExtractorFactory extractorFactory = crawlerContainer.getComponent("extractorFactory");
         if (extractorFactory == null) {
@@ -73,6 +93,13 @@ public abstract class AbstractExtractor implements Extractor {
         return extractorFactory;
     }
 
+    /**
+     * Creates a temporary file.
+     * @param prefix The prefix string to be used in generating the file's name.
+     * @param suffix The suffix string to be used in generating the file's name.
+     * @param directory The directory in which the file is to be created, or null if the default temporary-file directory is to be used.
+     * @return The created temporary file.
+     */
     protected File createTempFile(final String prefix, final String suffix, final File directory) {
         try {
             final File tempFile = File.createTempFile(prefix, suffix, directory);

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
@@ -47,22 +47,55 @@ import org.codelibs.fess.crawler.exception.ExtractException;
  */
 public abstract class AbstractXmlExtractor extends AbstractExtractor {
 
+    /**
+     * Logger for this class.
+     */
     protected static final Logger logger = LogManager.getLogger(AbstractXmlExtractor.class);
 
+    /**
+     * UTF-7 Byte Order Mark definition.
+     */
     protected static final ByteOrderMark BOM_UTF_7 = new ByteOrderMark("UTF-7", 0x2B, 0x2F, 0x76);
 
+    /**
+     * HTML4 unescape translator.
+     */
     protected static final CharSequenceTranslator UNESCAPE_HTML4 = new AggregateTranslator(
             new LookupTranslator(EntityArrays.BASIC_UNESCAPE), new LookupTranslator(EntityArrays.ISO8859_1_UNESCAPE),
             new LookupTranslator(EntityArrays.HTML40_EXTENDED_UNESCAPE), new NumericEntityUnescaper());
 
+    /**
+     * Default character encoding for content extraction.
+     */
     protected String encoding = Constants.UTF_8;
 
+    /**
+     * The preload size for charset detection.
+     */
     protected int preloadSizeForCharset = 2048;
 
+    /**
+     * Indicates whether comment tags should be ignored during extraction.
+     */
     protected boolean ignoreCommentTag = false;
 
+    /**
+     * Constructs a new AbstractXmlExtractor.
+     */
+    public AbstractXmlExtractor() {
+        // NOP
+    }
+
+    /**
+     * Returns the pattern used to extract encoding information from content.
+     * @return The encoding pattern.
+     */
     protected abstract Pattern getEncodingPattern();
 
+    /**
+     * Returns the pattern used to identify tags in the content.
+     * @return The tag pattern.
+     */
     protected abstract Pattern getTagPattern();
 
     @Override
@@ -80,10 +113,20 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Creates an ExtractData object from the extracted content.
+     * @param content The extracted content.
+     * @return The ExtractData object.
+     */
     protected ExtractData createExtractData(final String content) {
         return new ExtractData(extractString(content));
     }
 
+    /**
+     * Detects the encoding of the input stream.
+     * @param bis The buffered input stream.
+     * @return The detected encoding.
+     */
     protected String getEncoding(final BufferedInputStream bis) {
         final byte[] b = new byte[preloadSizeForCharset];
         try {
@@ -129,6 +172,11 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
         return encoding;
     }
 
+    /**
+     * Extracts text content from the given content by removing tags and processing attributes.
+     * @param content The content to extract from.
+     * @return The extracted text.
+     */
     protected String extractString(final String content) {
         String input = content.replaceAll("[\\r\\n]", " ");
         if (ignoreCommentTag) {
@@ -152,33 +200,50 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
         return sb.toString().replaceAll("\\s+", " ").trim();
     }
 
+    /**
+     * Returns the current encoding setting.
+     * @return The current encoding.
+     */
     public String getEncoding() {
         return encoding;
     }
 
+    /**
+     * Sets the encoding for content extraction.
+     * @param encoding The encoding to set.
+     */
     public void setEncoding(final String encoding) {
         this.encoding = encoding;
     }
 
     /**
-     * @return Returns the preloadSizeForCharset.
+     * Returns the preload size for charset detection.
+     * @return The preload size for charset detection.
      */
     public int getPreloadSizeForCharset() {
         return preloadSizeForCharset;
     }
 
     /**
-     * @param preloadSizeForCharset
-     *            The preloadSizeForCharset to set.
+     * Sets the preload size for charset detection.
+     * @param preloadSizeForCharset The preload size for charset detection to set.
      */
     public void setPreloadSizeForCharset(final int preloadSizeForCharset) {
         this.preloadSizeForCharset = preloadSizeForCharset;
     }
 
+    /**
+     * Returns whether comment tags are ignored during extraction.
+     * @return true if comment tags are ignored, false otherwise.
+     */
     public boolean isIgnoreCommentTag() {
         return ignoreCommentTag;
     }
 
+    /**
+     * Sets whether to ignore comment tags.
+     * @param ignoreCommentTag true to ignore comment tags, false otherwise.
+     */
     public void setIgnoreCommentTag(final boolean ignoreCommentTag) {
         this.ignoreCommentTag = ignoreCommentTag;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/ApiExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/ApiExtractor.java
@@ -66,38 +66,59 @@ import jakarta.annotation.PreDestroy;
 
 /**
  * Extract a text by using external http server.
- *
- * @author shinsuke
- *
  */
 public class ApiExtractor extends AbstractExtractor {
 
     private static final Logger logger = LogManager.getLogger(ApiExtractor.class);
 
+    /** The URL of the API endpoint. */
     protected String url;
 
+    /** The access timeout in seconds. */
     protected Integer accessTimeout; // sec
 
+    /** The HTTP client used for API calls. */
     protected CloseableHttpClient httpClient;
 
+    /** The connection timeout in milliseconds. */
     protected Integer connectionTimeout;
 
+    /** The socket timeout in milliseconds. */
     protected Integer soTimeout;
 
+    /** The map of authentication scheme providers. */
     protected Map<String, AuthSchemeProvider> authSchemeProviderMap;
 
+    /** The user agent string. */
     protected String userAgent = "Crawler";
 
+    /** The credentials provider. */
     protected CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
 
+    /** The authentication cache. */
     protected AuthCache authCache = new BasicAuthCache();
 
+    /** The HTTP client context. */
     protected HttpClientContext httpClientContext = HttpClientContext.create();
 
+    /** Map of HTTP client properties */
     private final Map<String, Object> httpClientPropertyMap = new HashMap<>();
 
+    /** List of request headers */
     private final List<Header> requestHeaderList = new ArrayList<>();
 
+    /**
+     * Constructs a new ApiExtractor.
+     */
+    public ApiExtractor() {
+        // NOP
+    }
+
+    /**
+     * Initializes the API extractor, setting up the HTTP client and configuration.
+     * This method is called after construction to initialize the HTTP client with
+     * configured timeouts, authentication, and request headers.
+     */
     @PostConstruct
     public void init() {
         if (logger.isDebugEnabled()) {
@@ -173,6 +194,9 @@ public class ApiExtractor extends AbstractExtractor {
         httpClient = closeableHttpClient;
     }
 
+    /**
+     * Destroys the HTTP client.
+     */
     @PreDestroy
     public void destroy() {
         if (httpClient != null) {
@@ -184,6 +208,14 @@ public class ApiExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Extracts text from the input stream using the API endpoint.
+     *
+     * @param in the input stream to extract text from
+     * @param params additional parameters
+     * @return the extracted data
+     * @throws ExtractException if extraction fails
+     */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
         if (logger.isDebugEnabled()) {
@@ -228,38 +260,74 @@ public class ApiExtractor extends AbstractExtractor {
         return data;
     }
 
+    /**
+     * Sets the URL of the API endpoint.
+     * @param url The URL to set.
+     */
     public void setUrl(final String url) {
         this.url = url;
     }
 
+    /**
+     * Sets the connection timeout.
+     * @param connectionTimeout The connection timeout in milliseconds.
+     */
     public void setConnectionTimeout(final Integer connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
     }
 
+    /**
+     * Sets the socket timeout.
+     * @param soTimeout The socket timeout in milliseconds.
+     */
     public void setSoTimeout(final Integer soTimeout) {
         this.soTimeout = soTimeout;
     }
 
+    /**
+     * Sets the map of authentication scheme providers.
+     * @param authSchemeProviderMap The map of authentication scheme providers.
+     */
     public void setAuthSchemeProviderMap(final Map<String, AuthSchemeProvider> authSchemeProviderMap) {
         this.authSchemeProviderMap = authSchemeProviderMap;
     }
 
+    /**
+     * Sets the user agent string.
+     * @param userAgent The user agent string.
+     */
     public void setUserAgent(final String userAgent) {
         this.userAgent = userAgent;
     }
 
+    /**
+     * Sets the credentials provider.
+     * @param credentialsProvider The credentials provider.
+     */
     public void setCredentialsProvider(final CredentialsProvider credentialsProvider) {
         this.credentialsProvider = credentialsProvider;
     }
 
+    /**
+     * Sets the authentication cache.
+     * @param authCache The authentication cache.
+     */
     public void setAuthCache(final AuthCache authCache) {
         this.authCache = authCache;
     }
 
+    /**
+     * Sets the HTTP client context.
+     * @param httpClientContext The HTTP client context.
+     */
     public void setHttpClientContext(final HttpClientContext httpClientContext) {
         this.httpClientContext = httpClientContext;
     }
 
+    /**
+     * Sets the access timeout.
+     * @param accessTimeout The access timeout to set.
+     */
     public void setAccessTimeout(final Integer accessTimeout) {
         this.accessTimeout = accessTimeout;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
@@ -42,31 +42,44 @@ import org.codelibs.fess.crawler.exception.ExecutionTimeoutException;
 import org.codelibs.fess.crawler.exception.ExtractException;
 
 /**
- * Extract a text by running a command.
- *
- * @author shinsuke
- *
+ * Extracts text content by executing an external command.
  */
 public class CommandExtractor extends AbstractExtractor {
     private static final Logger logger = LogManager.getLogger(CommandExtractor.class);
 
+    /** The encoding for the output. */
     protected String outputEncoding = Constants.UTF_8;
 
+    /** The extension for the output file. */
     protected String outputExtension = null;
 
+    /** The temporary directory for input/output files. */
     protected File tempDir = null;
 
+    /** The command to execute. */
     protected String command;
 
+    /** The timeout for command execution in milliseconds. */
     protected long executionTimeout = 30L * 1000L; // 30sec
 
+    /** The working directory for the command. */
     protected File workingDirectory = null;
 
+    /** The encoding for the command's output. */
     protected String commandOutputEncoding = Charset.defaultCharset().displayName();
 
+    /** The maximum number of lines to buffer from command output. */
     protected int maxOutputLine = 1000;
 
+    /** Whether to redirect standard output to a file. */
     protected boolean standardOutput = false;
+
+    /**
+     * Constructs a new CommandExtractor.
+     */
+    public CommandExtractor() {
+        // NOP
+    }
 
     /*
      * (non-Javadoc)
@@ -287,6 +300,9 @@ public class CommandExtractor extends AbstractExtractor {
         return value;
     }
 
+    /**
+     * Thread to monitor and terminate processes that exceed the timeout.
+     */
     protected static class MonitorThread extends Thread {
         private final Process process;
 
@@ -296,6 +312,11 @@ public class CommandExtractor extends AbstractExtractor {
 
         private boolean teminated = false;
 
+        /**
+         * Constructs a new MonitorThread.
+         * @param process The process to monitor.
+         * @param timeout The timeout for the process.
+         */
         public MonitorThread(final Process process, final long timeout) {
             this.process = process;
             this.timeout = timeout;
@@ -318,21 +339,25 @@ public class CommandExtractor extends AbstractExtractor {
         }
 
         /**
-         * @param finished
-         *            The finished to set.
+         * Sets the finished flag.
+         * @param finished The finished flag to set.
          */
         public void setFinished(final boolean finished) {
             this.finished = finished;
         }
 
         /**
-         * @return Returns the teminated.
+         * Returns whether the process was terminated.
+         * @return true if terminated, false otherwise.
          */
         public boolean isTeminated() {
             return teminated;
         }
     }
 
+    /**
+     * Thread to read and buffer output from an input stream.
+     */
     protected static class InputStreamThread extends Thread {
 
         private BufferedReader br;
@@ -341,6 +366,12 @@ public class CommandExtractor extends AbstractExtractor {
 
         private final int maxLineBuffer;
 
+        /**
+         * Constructs a new InputStreamThread.
+         * @param is The InputStream to read from.
+         * @param charset The charset to use for reading.
+         * @param maxOutputLineBuffer The maximum number of lines to buffer.
+         */
         public InputStreamThread(final InputStream is, final String charset, final int maxOutputLineBuffer) {
             try {
                 br = new BufferedReader(new InputStreamReader(is, charset));
@@ -371,6 +402,10 @@ public class CommandExtractor extends AbstractExtractor {
             }
         }
 
+        /**
+         * Returns the output as a String.
+         * @return The output string.
+         */
         public String getOutput() {
             final StringBuilder buf = new StringBuilder(100);
             for (final String value : list) {
@@ -381,38 +416,74 @@ public class CommandExtractor extends AbstractExtractor {
 
     }
 
+    /**
+     * Sets the encoding for the output.
+     * @param outputEncoding The output encoding to set.
+     */
     public void setOutputEncoding(final String outputEncoding) {
         this.outputEncoding = outputEncoding;
     }
 
+    /**
+     * Sets the output file extension.
+     * @param outputExtension The output file extension to set.
+     */
     public void setOutputExtension(final String outputExtension) {
         this.outputExtension = outputExtension;
     }
 
+    /**
+     * Sets the temporary directory for file operations.
+     * @param tempDir The temporary directory to set.
+     */
     public void setTempDir(final File tempDir) {
         this.tempDir = tempDir;
     }
 
+    /**
+     * Sets the command to execute for text extraction.
+     * @param command The command to set.
+     */
     public void setCommand(final String command) {
         this.command = command;
     }
 
+    /**
+     * Sets the timeout for command execution.
+     * @param executionTimeout The execution timeout in milliseconds.
+     */
     public void setExecutionTimeout(final long executionTimeout) {
         this.executionTimeout = executionTimeout;
     }
 
+    /**
+     * Sets the working directory for the command.
+     * @param workingDirectory The working directory.
+     */
     public void setWorkingDirectory(final File workingDirectory) {
         this.workingDirectory = workingDirectory;
     }
 
+    /**
+     * Sets the encoding for command output.
+     * @param commandOutputEncoding The command output encoding to set.
+     */
     public void setCommandOutputEncoding(final String commandOutputEncoding) {
         this.commandOutputEncoding = commandOutputEncoding;
     }
 
+    /**
+     * Sets the maximum number of output lines to process.
+     * @param maxOutputLine The maximum output lines to set.
+     */
     public void setMaxOutputLine(final int maxOutputLine) {
         this.maxOutputLine = maxOutputLine;
     }
 
+    /**
+     * Sets whether to redirect standard output.
+     * @param standardOutput true to redirect standard output, false otherwise.
+     */
     public void setStandardOutput(final boolean standardOutput) {
         this.standardOutput = standardOutput;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/EmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/EmlExtractor.java
@@ -56,11 +56,21 @@ import jakarta.mail.internet.MimeUtility;
  *
  */
 public class EmlExtractor extends AbstractExtractor {
+    /** Array of day of week abbreviations used for parsing received dates */
     private static final String[] DAY_OF_WEEK = { "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" };
 
+    /** Logger instance for this class */
     private static final Logger logger = LogManager.getLogger(EmlExtractor.class);
 
+    /** Properties used for mail processing */
     protected Properties mailProperties = new Properties();
+
+    /**
+     * Constructs a new EmlExtractor.
+     */
+    public EmlExtractor() {
+        // Default constructor
+    }
 
     /* (non-Javadoc)
      * @see org.codelibs.robot.extractor.Extractor#getText(java.io.InputStream, java.util.Map)
@@ -110,6 +120,13 @@ public class EmlExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Puts a value into the extract data with appropriate type conversion.
+     *
+     * @param data the extract data to store the value in
+     * @param key the key for the value
+     * @param value the value to store
+     */
     protected void putValue(final ExtractData data, final String key, final Object value) {
         try {
             if (value instanceof String) {
@@ -144,6 +161,12 @@ public class EmlExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Decodes MIME-encoded text.
+     *
+     * @param value the encoded text to decode
+     * @return the decoded text or empty string if decoding fails
+     */
     protected String getDecodeText(final String value) {
         if (value == null) {
             return StringUtil.EMPTY;
@@ -156,14 +179,31 @@ public class EmlExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Gets the mail properties used for email processing.
+     *
+     * @return the mail properties
+     */
     public Properties getMailProperties() {
         return mailProperties;
     }
 
+    /**
+     * Sets the mail properties used for email processing.
+     *
+     * @param mailProperties the mail properties to set
+     */
     public void setMailProperties(final Properties mailProperties) {
         this.mailProperties = mailProperties;
     }
 
+    /**
+     * Extracts the body text from a MIME message.
+     *
+     * @param message the MIME message to extract text from
+     * @return the extracted body text
+     * @throws ExtractException if extraction fails
+     */
     protected String getBodyText(final MimeMessage message) {
         final StringBuilder buf = new StringBuilder(1000);
         try {
@@ -196,6 +236,12 @@ public class EmlExtractor extends AbstractExtractor {
         return buf.toString();
     }
 
+    /**
+     * Appends attachment content to the buffer if it can be extracted.
+     *
+     * @param buf the buffer to append content to
+     * @param bodyPart the body part containing the attachment
+     */
     protected void appendAttachment(final StringBuilder buf, final BodyPart bodyPart) {
         final MimeTypeHelper mimeTypeHelper = getMimeTypeHelper();
         final ExtractorFactory extractorFactory = getExtractorFactory();
@@ -224,6 +270,13 @@ public class EmlExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Gets the received date from a message by parsing the received headers.
+     *
+     * @param message the message to get the received date from
+     * @return the received date or null if not found
+     * @throws MessagingException if message access fails
+     */
     protected static Date getReceivedDate(final Message message) throws MessagingException {
         final Date today = new Date();
         final String[] received = message.getHeader("received");
@@ -244,6 +297,12 @@ public class EmlExtractor extends AbstractExtractor {
         return null;
     }
 
+    /**
+     * Extracts a date string from the received header text.
+     *
+     * @param text the received header text
+     * @return the date string starting from the day of week, or null if not found
+     */
     private static String getDateString(final String text) {
         for (final String dow : DAY_OF_WEEK) {
             final int i = text.lastIndexOf(dow);

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/FilenameExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/FilenameExtractor.java
@@ -24,11 +24,23 @@ import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.ExtractException;
 
 /**
- * @author shinsuke
- *
+ * Extracts the filename from the parameters.
  */
 public class FilenameExtractor extends AbstractExtractor {
 
+    /**
+     * Constructs a new FilenameExtractor.
+     */
+    public FilenameExtractor() {
+        // Default constructor
+    }
+
+    /**
+     * Extracts the filename from the parameters.
+     * @param in The input stream (not used).
+     * @param params The parameters, expected to contain ExtractData.RESOURCE_NAME_KEY.
+     * @return An ExtractData object containing the filename as content.
+     */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
         if (in == null) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
@@ -41,26 +41,42 @@ import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 
 /**
- * @author shinsuke
- *
+ * Extracts text content from HTML documents.
  */
 public class HtmlExtractor extends AbstractXmlExtractor {
+    /** Logger for this class. */
     protected static final Logger logger = LogManager.getLogger(HtmlExtractor.class);
 
+    /** Pattern for extracting charset from meta tags. */
     protected Pattern metaCharsetPattern = Pattern.compile("<meta.*content\\s*=\\s*['\"].*;\\s*charset=([\\w\\d\\-_]*)['\"]\\s*/?>",
             Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 
+    /**
+     * Pattern for HTML tags.
+     */
     protected Pattern htmlTagPattern = Pattern.compile("<[^>]+>");
 
+    /** Map of parser features. */
     protected Map<String, String> featureMap = new HashMap<>();
 
+    /** Map of parser properties. */
     protected Map<String, String> propertyMap = new HashMap<>();
 
+    /** XPath expression for extracting content from the document body. */
     protected String contentXpath = "//BODY";
 
+    /** Map of metadata field names to their corresponding XPath expressions. */
     protected Map<String, String> metadataXpathMap = new HashMap<>();
 
+    /** Thread-local instance of XPathAPI for thread-safe XPath evaluation. */
     private final ThreadLocal<XPathAPI> xpathAPI = new ThreadLocal<>();
+
+    /**
+     * Creates a new HtmlExtractor instance.
+     */
+    public HtmlExtractor() {
+        super();
+    }
 
     @Override
     protected ExtractData createExtractData(final String content) {
@@ -85,6 +101,13 @@ public class HtmlExtractor extends AbstractXmlExtractor {
         }
     }
 
+    /**
+     * Extracts strings from a document using the specified XPath expression.
+     *
+     * @param document the DOM document to extract strings from
+     * @param path the XPath expression to evaluate
+     * @return an array of strings extracted from the document
+     */
     protected String[] getStringsByXPath(final Document document, final String path) {
         try {
             final XPathEvaluationResult<?> xObj = getXPathAPI().eval(document, path);
@@ -123,6 +146,12 @@ public class HtmlExtractor extends AbstractXmlExtractor {
 
     }
 
+    /**
+     * Creates and configures a DOM parser for parsing HTML content.
+     *
+     * @return a configured DOMParser instance
+     * @throws CrawlerSystemException if the parser configuration is invalid
+     */
     protected DOMParser getDomParser() {
         final DOMParser parser = new DOMParser();
         try {
@@ -142,6 +171,11 @@ public class HtmlExtractor extends AbstractXmlExtractor {
         return parser;
     }
 
+    /**
+     * Gets a thread-local XPathAPI instance for thread-safe XPath evaluation.
+     *
+     * @return the XPathAPI instance for the current thread
+     */
     protected XPathAPI getXPathAPI() {
         XPathAPI cachedXPathAPI = xpathAPI.get();
         if (cachedXPathAPI == null) {
@@ -151,6 +185,12 @@ public class HtmlExtractor extends AbstractXmlExtractor {
         return cachedXPathAPI;
     }
 
+    /**
+     * Adds a metadata field with its corresponding XPath expression for extraction.
+     *
+     * @param name the name of the metadata field
+     * @param xpath the XPath expression to extract the metadata value
+     */
     public void addMetadata(final String name, final String xpath) {
         metadataXpathMap.put(name, xpath);
     }
@@ -176,34 +216,74 @@ public class HtmlExtractor extends AbstractXmlExtractor {
         return htmlTagPattern;
     }
 
+    /**
+     * Gets the pattern used for extracting charset from meta tags.
+     *
+     * @return the meta charset pattern
+     */
     public Pattern getMetaCharsetPattern() {
         return metaCharsetPattern;
     }
 
+    /**
+     * Sets the pattern used for extracting charset from meta tags.
+     *
+     * @param metaCharsetPattern the meta charset pattern to set
+     */
     public void setMetaCharsetPattern(final Pattern metaCharsetPattern) {
         this.metaCharsetPattern = metaCharsetPattern;
     }
 
+    /**
+     * Gets the pattern used for matching HTML tags.
+     *
+     * @return the HTML tag pattern
+     */
     public Pattern getHtmlTagPattern() {
         return htmlTagPattern;
     }
 
+    /**
+     * Sets the pattern used for matching HTML tags.
+     *
+     * @param htmlTagPattern the HTML tag pattern to set
+     */
     public void setHtmlTagPattern(final Pattern htmlTagPattern) {
         this.htmlTagPattern = htmlTagPattern;
     }
 
+    /**
+     * Gets the map of parser features.
+     *
+     * @return the feature map
+     */
     public Map<String, String> getFeatureMap() {
         return featureMap;
     }
 
+    /**
+     * Sets the map of parser features.
+     *
+     * @param featureMap the feature map to set
+     */
     public void setFeatureMap(final Map<String, String> featureMap) {
         this.featureMap = featureMap;
     }
 
+    /**
+     * Gets the map of parser properties.
+     *
+     * @return the property map
+     */
     public Map<String, String> getPropertyMap() {
         return propertyMap;
     }
 
+    /**
+     * Sets the map of parser properties.
+     *
+     * @param propertyMap the property map to set
+     */
     public void setPropertyMap(final Map<String, String> propertyMap) {
         this.propertyMap = propertyMap;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlXpathExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlXpathExtractor.java
@@ -63,21 +63,37 @@ import jakarta.annotation.Resource;
  *
  */
 public class HtmlXpathExtractor extends AbstractXmlExtractor {
-    // Regular expression pattern to match the charset attribute in the meta tag of HTML documents.
-    // The pattern captures the charset value specified in the content attribute of the meta tag.
-    // Example: <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    /**
+     * Regular expression pattern to match the charset attribute in the meta tag of HTML documents.
+     * The pattern captures the charset value specified in the content attribute of the meta tag.
+     * Example: &lt;meta http-equiv="Content-Type" content="text/html; charset=UTF-8"&gt;
+     */
     protected Pattern metaCharsetPattern = Pattern.compile("<meta.*content\\s*=\\s*['\"].*;\\s*charset=([\\w\\d\\-_]*)['\"]\\s*/?>",
             Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 
+    /**
+     * Map of features for the DOM parser.
+     */
     protected Map<String, String> featureMap = new HashMap<>();
 
+    /** Map of properties for the DOM parser. */
     protected Map<String, String> propertyMap = new HashMap<>();
 
+    /** XPath expression to select target nodes for text extraction. */
     protected String targetNodePath = "//HTML/BODY | //@alt | //@title";
 
+    /** Cache for XPathAPI instances to improve performance. */
     protected LoadingCache<String, XPathAPI> xpathAPICache;
 
+    /** Cache duration in minutes for XPathAPI instances. */
     protected long cacheDuration = 10; // min
+
+    /**
+     * Creates a new HtmlXpathExtractor instance.
+     */
+    public HtmlXpathExtractor() {
+        super();
+    }
 
     /**
      * Initializes the XPathAPI cache with a specified cache duration.
@@ -130,6 +146,11 @@ public class HtmlXpathExtractor extends AbstractXmlExtractor {
         }
     }
 
+    /**
+     * Gets an XPathAPI instance from the cache for the current thread.
+     *
+     * @return the XPathAPI instance
+     */
     protected XPathAPI getXPathAPI() {
         try {
             return xpathAPICache.get(Thread.currentThread().getName());
@@ -141,6 +162,12 @@ public class HtmlXpathExtractor extends AbstractXmlExtractor {
         }
     }
 
+    /**
+     * Creates and configures a DOM parser with the specified features and properties.
+     *
+     * @return a configured DOM parser instance
+     * @throws CrawlerSystemException if the parser configuration is invalid
+     */
     protected DOMParser getDomParser() {
         final DOMParser parser = new DOMParser();
         try {
@@ -210,52 +237,83 @@ public class HtmlXpathExtractor extends AbstractXmlExtractor {
         propertyMap.put(key, value);
     }
 
+    /**
+     * Gets the map of parser features.
+     *
+     * @return the feature map
+     */
     public Map<String, String> getFeatureMap() {
         return featureMap;
     }
 
+    /**
+     * Sets the map of parser features.
+     *
+     * @param featureMap the feature map to set
+     */
     public void setFeatureMap(final Map<String, String> featureMap) {
         this.featureMap = featureMap;
     }
 
+    /**
+     * Gets the map of parser properties.
+     *
+     * @return the property map
+     */
     public Map<String, String> getPropertyMap() {
         return propertyMap;
     }
 
+    /**
+     * Sets the map of parser properties.
+     *
+     * @param propertyMap the property map to set
+     */
     public void setPropertyMap(final Map<String, String> propertyMap) {
         this.propertyMap = propertyMap;
     }
 
     /**
-     * @return Returns the metaCharsetPattern.
+     * Gets the pattern for extracting charset from meta tags.
+     *
+     * @return the meta charset pattern
      */
     public Pattern getMetaCharsetPattern() {
         return metaCharsetPattern;
     }
 
     /**
-     * @param metaCharsetPattern
-     *            The metaCharsetPattern to set.
+     * Sets the pattern for extracting charset from meta tags.
+     *
+     * @param metaCharsetPattern the meta charset pattern to set
      */
     public void setMetaCharsetPattern(final Pattern metaCharsetPattern) {
         this.metaCharsetPattern = metaCharsetPattern;
     }
 
     /**
-     * @return Returns the targetNodePath.
+     * Gets the XPath expression for selecting target nodes.
+     *
+     * @return the target node path
      */
     public String getTargetNodePath() {
         return targetNodePath;
     }
 
     /**
-     * @param targetNodePath
-     *            The targetNodePath to set.
+     * Sets the XPath expression for selecting target nodes.
+     *
+     * @param targetNodePath the target node path to set
      */
     public void setTargetNodePath(final String targetNodePath) {
         this.targetNodePath = targetNodePath;
     }
 
+    /**
+     * Sets the cache duration for XPathAPI instances.
+     *
+     * @param cacheDuration the cache duration in minutes
+     */
     public void setCacheDuration(final long cacheDuration) {
         this.cacheDuration = cacheDuration;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/JodExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/JodExtractor.java
@@ -41,22 +41,30 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 
 /**
- * @author shinsuke
- *
+ * Extracts text content from various document formats using JODConverter.
  */
 public class JodExtractor extends AbstractExtractor {
+    /** Logger for this class. */
     private static final Logger logger = LogManager.getLogger(JodExtractor.class);
 
+    /** Office manager for document conversion. */
     protected OfficeManager officeManager;
 
+    /** Temporary directory for file operations. */
     protected File tempDir = null;
 
+    /** Output encoding for extracted text. */
     protected String outputEncoding = Constants.UTF_8;
 
+    /** Map of input file extensions to output extensions. */
     private final Map<String, String> extensionMap = new HashMap<>();
 
+    /** Map of output extensions to their corresponding extractors. */
     private final Map<String, Extractor> extractorMap = new HashMap<>();
 
+    /**
+     * Constructs a new JodExtractor and initializes the extension and extractor mappings.
+     */
     public JodExtractor() {
         extensionMap.put("", "txt");
         // Text Formats
@@ -91,6 +99,11 @@ public class JodExtractor extends AbstractExtractor {
         extractorMap.put("svg", new XmlExtractor());
     }
 
+    /**
+     * Initializes the extractor by starting the office manager.
+     *
+     * @throws CrawlerSystemException if the office manager is null or fails to start
+     */
     @PostConstruct
     public void init() {
         if (officeManager == null) {
@@ -106,6 +119,11 @@ public class JodExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Destroys the extractor by stopping the office manager.
+     *
+     * @throws CrawlerSystemException if the office manager fails to stop
+     */
     @PreDestroy
     public void destroy() {
         try {
@@ -115,6 +133,12 @@ public class JodExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Adds a conversion rule for mapping input file extensions to output extensions.
+     *
+     * @param inExt the input file extension
+     * @param outExt the output file extension
+     */
     public void addConversionRule(final String inExt, final String outExt) {
         extensionMap.put(inExt, outExt);
     }
@@ -183,6 +207,14 @@ public class JodExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Gets the output content from the converted file.
+     *
+     * @param outputFile the converted output file
+     * @param outExt the output file extension
+     * @return the extracted text content
+     * @throws ExtractException if an error occurs while reading the file
+     */
     protected String getOutputContent(final File outputFile, final String outExt) {
         final Extractor extractor = getExtractor(outExt);
         if (extractor != null) {
@@ -202,19 +234,33 @@ public class JodExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Gets the extractor for the specified file extension.
+     *
+     * @param ext the file extension
+     * @return the extractor for the extension, or null if not found
+     */
     private Extractor getExtractor(final String ext) {
         return extractorMap.get(ext);
     }
 
     /**
-     * @param extension
-     * @return
+     * Gets the output extension for the specified input extension.
+     *
+     * @param extension the input file extension
+     * @return the output extension, or "txt" if not found
      */
     private String getOutputExtension(final String extension) {
         final String outExt = extensionMap.get(extension);
         return outExt == null ? "txt" : outExt;
     }
 
+    /**
+     * Extracts the file name from a resource name.
+     *
+     * @param resourceName the resource name
+     * @return the file name
+     */
     private String getFileName(final String resourceName) {
         final String name = resourceName.replaceAll("/+$", "");
         final int pos = name.lastIndexOf('/');
@@ -224,14 +270,29 @@ public class JodExtractor extends AbstractExtractor {
         return name;
     }
 
+    /**
+     * Sets the office manager for document conversion.
+     *
+     * @param officeManager the office manager to set
+     */
     public void setOfficeManager(final OfficeManager officeManager) {
         this.officeManager = officeManager;
     }
 
+    /**
+     * Sets the temporary directory for file operations.
+     *
+     * @param tempDir the temporary directory to set
+     */
     public void setTempDir(final File tempDir) {
         this.tempDir = tempDir;
     }
 
+    /**
+     * Sets the output encoding for extracted text.
+     *
+     * @param outputEncoding the output encoding to set
+     */
     public void setOutputEncoding(final String outputEncoding) {
         this.outputEncoding = outputEncoding;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/LhaExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/LhaExtractor.java
@@ -41,16 +41,36 @@ import jp.gr.java_conf.dangan.util.lha.LhaFile;
 import jp.gr.java_conf.dangan.util.lha.LhaHeader;
 
 /**
- * Extractor implementation for LHA.
+ * Extractor implementation for LHA (LZH) archive files.
+ * This extractor can extract text content from files within LHA archives
+ * by using appropriate extractors for each contained file type.
  *
  * @author shinsuke
- *
  */
 public class LhaExtractor extends AbstractExtractor {
+    /** Logger for this class. */
     private static final Logger logger = LogManager.getLogger(LhaExtractor.class);
 
+    /** Maximum content size for extraction. -1 means no limit. */
     protected long maxContentSize = -1;
 
+    /**
+     * Creates a new LhaExtractor instance.
+     */
+    public LhaExtractor() {
+        super();
+    }
+
+    /**
+     * Extracts text content from an LHA archive input stream.
+     *
+     * @param in the input stream containing the LHA archive
+     * @param params extraction parameters
+     * @return the extracted text data
+     * @throws CrawlerSystemException if the input stream is null
+     * @throws ExtractException if an error occurs during extraction
+     * @throws MaxLengthExceededException if the extracted content size exceeds the maximum limit
+     */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
         if (in == null) {
@@ -119,6 +139,11 @@ public class LhaExtractor extends AbstractExtractor {
         return new ExtractData(buf.toString().trim());
     }
 
+    /**
+     * Sets the maximum content size for extraction.
+     *
+     * @param maxContentSize the maximum content size to set (-1 for no limit)
+     */
     public void setMaxContentSize(final long maxContentSize) {
         this.maxContentSize = maxContentSize;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MsExcelExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MsExcelExtractor.java
@@ -31,12 +31,19 @@ import org.codelibs.fess.crawler.exception.ExtractException;
  *
  */
 public class MsExcelExtractor extends AbstractExtractor {
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.codelibs.fess.crawler.extractor.impl.Extractor#getText(java.io.InputStream,
-     * java.util.Map)
+
+    /**
+     * Creates a new MsExcelExtractor instance.
+     */
+    public MsExcelExtractor() {
+        super();
+    }
+
+    /**
+     * Extracts text from the Excel input stream.
+     * @param in The input stream.
+     * @param params The parameters.
+     * @return The extracted data.
      */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MsPowerPointExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MsPowerPointExtractor.java
@@ -28,16 +28,22 @@ import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.ExtractException;
 
 /**
- * @author shinsuke
- *
+ * Extracts text content from Microsoft PowerPoint documents.
  */
 public class MsPowerPointExtractor extends AbstractExtractor {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.extractor.Extractor#getText(java.io.InputStream,
-     * java.util.Map)
+    /**
+     * Creates a new MsPowerPointExtractor instance.
+     */
+    public MsPowerPointExtractor() {
+        super();
+    }
+
+    /**
+     * Extracts text from the PowerPoint input stream.
+     * @param in The input stream.
+     * @param params The parameters.
+     * @return The extracted data.
      */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MsPublisherExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MsPublisherExtractor.java
@@ -32,11 +32,18 @@ import org.codelibs.fess.crawler.exception.ExtractException;
  */
 public class MsPublisherExtractor extends AbstractExtractor {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.extractor.Extractor#getText(java.io.InputStream,
-     * java.util.Map)
+    /**
+     * Creates a new MsPublisherExtractor instance.
+     */
+    public MsPublisherExtractor() {
+        super();
+    }
+
+    /**
+     * Extracts text from the Publisher input stream.
+     * @param in The input stream.
+     * @param params The parameters.
+     * @return The extracted data.
      */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MsVisioExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MsVisioExtractor.java
@@ -32,11 +32,18 @@ import org.codelibs.fess.crawler.exception.ExtractException;
  */
 public class MsVisioExtractor extends AbstractExtractor {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.extractor.Extractor#getText(java.io.InputStream,
-     * java.util.Map)
+    /**
+     * Creates a new MsVisioExtractor instance.
+     */
+    public MsVisioExtractor() {
+        super();
+    }
+
+    /**
+     * Extracts text from the Visio input stream.
+     * @param in The input stream.
+     * @param params The parameters.
+     * @return The extracted data.
      */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MsWordExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MsWordExtractor.java
@@ -31,11 +31,18 @@ import org.codelibs.fess.crawler.exception.ExtractException;
  */
 public class MsWordExtractor extends AbstractExtractor {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.extractor.Extractor#getText(java.io.InputStream,
-     * java.util.Map)
+    /**
+     * Creates a new MsWordExtractor instance.
+     */
+    public MsWordExtractor() {
+        super();
+    }
+
+    /**
+     * Extracts text from the Word input stream.
+     * @param in The input stream.
+     * @param params The parameters.
+     * @return The extracted data.
      */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PasswordBasedExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PasswordBasedExtractor.java
@@ -32,18 +32,53 @@ import org.codelibs.fess.crawler.entity.ExtractData;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * PasswordBasedExtractor is an abstract base class for extractors that can handle password-protected files.
+ * It provides functionality to manage passwords for different file patterns using regular expressions.
+ *
+ * <p>The extractor supports two types of password management:
+ * <ul>
+ *   <li>Static passwords configured via {@link #addPassword(String, String)}</li>
+ *   <li>Dynamic passwords provided through extraction parameters</li>
+ * </ul>
+ *
+ * <p>Passwords are matched against URLs or resource names using regular expression patterns.
+ * The extractor first tries to match against the URL, then falls back to the resource name if available.
+ *
+ * @author shinsuke
+ */
 public abstract class PasswordBasedExtractor extends AbstractExtractor {
 
+    /** Logger instance for this class. */
     private static final Logger logger = LogManager.getLogger(PasswordBasedExtractor.class);
 
+    /** Map of regex patterns to passwords for static password configuration. */
     protected Map<Pattern, String> passwordMap = new HashMap<>();
 
+    /** Cache for parsed password configurations from extraction parameters. */
     private final Map<String, List<Pair<Pattern, String>>> configPasswordMap = new ConcurrentHashMap<>();
 
+    /**
+     * Creates a new PasswordBasedExtractor instance.
+     */
+    public PasswordBasedExtractor() {
+        super();
+    }
+
+    /**
+     * Adds a password for files matching the given regular expression pattern.
+     * @param regex the regular expression pattern to match against URLs or resource names
+     * @param password the password to use for matching files
+     */
     public void addPassword(final String regex, final String password) {
         passwordMap.put(Pattern.compile(regex), password);
     }
 
+    /**
+     * Returns the password for the given parameters.
+     * @param params The parameters.
+     * @return The password.
+     */
     protected String getPassword(final Map<String, String> params) {
         final String url = params != null ? params.get(ExtractData.URL) : null;
         if (!passwordMap.isEmpty()) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TarExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TarExtractor.java
@@ -37,16 +37,28 @@ import org.codelibs.fess.crawler.util.IgnoreCloseInputStream;
 import jakarta.annotation.Resource;
 
 /**
- * @author shinsuke
- *
+ * Extracts text content from TAR archives.
  */
 public class TarExtractor extends AbstractExtractor {
     private static final Logger logger = LogManager.getLogger(TarExtractor.class);
 
+    /**
+     * The archive stream factory.
+     */
     @Resource
     protected ArchiveStreamFactory archiveStreamFactory;
 
+    /**
+     * Maximum content size.
+     */
     protected long maxContentSize = -1;
+
+    /**
+     * Creates a new TarExtractor instance.
+     */
+    public TarExtractor() {
+        super();
+    }
 
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
@@ -59,6 +71,14 @@ public class TarExtractor extends AbstractExtractor {
         return new ExtractData(getTextInternal(in, mimeTypeHelper, extractorFactory));
     }
 
+    /**
+     * Returns a text from the input stream.
+     *
+     * @param in The input stream.
+     * @param mimeTypeHelper The mime type helper.
+     * @param extractorFactory The extractor factory.
+     * @return A text.
+     */
     protected String getTextInternal(final InputStream in, final MimeTypeHelper mimeTypeHelper, final ExtractorFactory extractorFactory) {
 
         final StringBuilder buf = new StringBuilder(1000);
@@ -105,6 +125,10 @@ public class TarExtractor extends AbstractExtractor {
         return buf.toString().trim();
     }
 
+    /**
+     * Sets the maximum content size.
+     * @param maxContentSize The maximum content size to set.
+     */
     public void setMaxContentSize(final long maxContentSize) {
         this.maxContentSize = maxContentSize;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TextExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TextExtractor.java
@@ -25,12 +25,21 @@ import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.ExtractException;
 
 /**
- * @author shinsuke
- *
+ * Extracts text content from an input stream as plain text.
  */
 public class TextExtractor extends AbstractExtractor {
 
+    /**
+     * The encoding for text.
+     */
     protected String encoding = Constants.UTF_8;
+
+    /**
+     * Creates a new TextExtractor instance.
+     */
+    public TextExtractor() {
+        super();
+    }
 
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
@@ -44,10 +53,18 @@ public class TextExtractor extends AbstractExtractor {
         }
     }
 
+    /**
+     * Returns the encoding used for text extraction.
+     * @return the encoding
+     */
     public String getEncoding() {
         return encoding;
     }
 
+    /**
+     * Sets the encoding.
+     * @param encoding The encoding to set.
+     */
     public void setEncoding(final String encoding) {
         this.encoding = encoding;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TikaExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TikaExtractor.java
@@ -133,40 +133,92 @@ public class TikaExtractor extends PasswordBasedExtractor {
 
     private static final Logger logger = LogManager.getLogger(TikaExtractor.class);
 
+    /**
+     * Tesseract config file path.
+     */
     public static final String TIKA_TESSERACT_CONFIG = "tika.tesseract.config";
 
+    /**
+     * PDF config file path.
+     */
     public static final String TIKA_PDF_CONFIG = "tika.pdf.config";
 
+    /**
+     * A parameter key to normalize a text.
+     */
     public static final String NORMALIZE_TEXT = "normalize_text";
 
     private static final String FILE_PASSWORD = "fess.file.password";
 
+    /**
+     * Output encoding.
+     */
     protected String outputEncoding = Constants.UTF_8;
 
+    /**
+     * If true, read a content as a text when an extraction fails.
+     */
     protected boolean readAsTextIfFailed = false;
 
+    /**
+     * Max compression ratio.
+     */
     protected long maxCompressionRatio = 100;
 
+    /**
+     * Max uncompression size.
+     */
     protected long maxUncompressionSize = 1000000;
 
+    /**
+     * Initial buffer size.
+     */
     protected int initialBufferSize = 10000;
 
+    /**
+     * If true, duplicated terms are replaced.
+     */
     protected boolean replaceDuplication = false;
 
+    /**
+     * Space characters. Default includes common space characters.
+     */
     protected int[] spaceChars = { '\u0020', '\u00a0', '\u3000', '\ufffd' };
 
+    /**
+     * Memory size.
+     */
     protected int memorySize = 1024 * 1024; //1mb
 
+    /**
+     * Max size of an alpha-numeric term.
+     */
     protected int maxAlphanumTermSize = -1;
 
+    /**
+     * Max size of a symbol term.
+     */
     protected int maxSymbolTermSize = -1;
 
+    /**
+     * Tika config.
+     */
     protected TikaConfig tikaConfig;
 
     private final Map<String, TesseractOCRConfig> tesseractOCRConfigMap = new ConcurrentHashMap<>();
 
     private final Map<String, PDFParserConfig> pdfParserConfigMap = new ConcurrentHashMap<>();
 
+    /**
+     * Creates a new TikaExtractor instance.
+     */
+    public TikaExtractor() {
+        super();
+    }
+
+    /**
+     * Initializes this component.
+     */
     @PostConstruct
     public void init() {
         if (tikaConfig == null && crawlerContainer != null) {
@@ -192,6 +244,14 @@ public class TikaExtractor extends PasswordBasedExtractor {
         return getText(inputStream, params, null);
     }
 
+    /**
+     * Returns an extracted text.
+     *
+     * @param inputStream An input stream.
+     * @param params A map of parameters.
+     * @param postFilter A post filter.
+     * @return An extracted data.
+     */
     protected ExtractData getText(final InputStream inputStream, final Map<String, String> params,
             final BiConsumer<ExtractData, InputStream> postFilter) {
         if (inputStream == null) {
@@ -426,6 +486,13 @@ public class TikaExtractor extends PasswordBasedExtractor {
         }
     }
 
+    /**
+     * Creates a parse context.
+     *
+     * @param parser A parser.
+     * @param params A map of parameters.
+     * @return a parse context.
+     */
     protected ParseContext createParseContext(final Parser parser, final Map<String, String> params) {
         final ParseContext parseContext = new ParseContext();
         parseContext.set(Parser.class, parser);
@@ -465,6 +532,13 @@ public class TikaExtractor extends PasswordBasedExtractor {
         return parseContext;
     }
 
+    /**
+     * Returns an input stream from a deferred file output stream.
+     *
+     * @param dfos A deferred file output stream.
+     * @return An input stream.
+     * @throws IOException if an I/O error occurs.
+     */
     protected InputStream getContentStream(final DeferredFileOutputStream dfos) throws IOException {
         if (dfos.isInMemory()) {
             return new ByteArrayInputStream(dfos.getData());
@@ -472,6 +546,15 @@ public class TikaExtractor extends PasswordBasedExtractor {
         return new BufferedInputStream(new FileInputStream(dfos.getFile()));
     }
 
+    /**
+     * Returns a content from a writer.
+     *
+     * @param out A content writer.
+     * @param encoding An encoding.
+     * @param normalizeText If true, normalize a text.
+     * @return a content.
+     * @throws TikaException if a Tika exception occurs.
+     */
     protected String getContent(final ContentWriter out, final String encoding, final boolean normalizeText) throws TikaException {
         File tempFile = null;
         final String enc = encoding == null ? Constants.UTF_8 : encoding;
@@ -500,6 +583,15 @@ public class TikaExtractor extends PasswordBasedExtractor {
         }
     }
 
+    /**
+     * Creates a metadata.
+     *
+     * @param resourceName A resource name.
+     * @param contentType A content type.
+     * @param contentEncoding A content encoding.
+     * @param pdfPassword A password for a PDF.
+     * @return a metadata.
+     */
     protected Metadata createMetadata(final String resourceName, final String contentType, final String contentEncoding,
             final String pdfPassword) {
         final Metadata metadata = new Metadata();
@@ -524,6 +616,9 @@ public class TikaExtractor extends PasswordBasedExtractor {
     }
 
     // workaround: Tika does not have extention points.
+    /**
+     * This class is a parser that detects the document type.
+     */
     protected class TikaDetectParser extends CompositeParser {
         private static final long serialVersionUID = 1L;
 
@@ -541,6 +636,10 @@ public class TikaExtractor extends PasswordBasedExtractor {
             this(tikaConfig);
         }
 
+        /**
+         * Constructor.
+         * @param config Tika config.
+         */
         public TikaDetectParser(final TikaConfig config) {
             super(config.getMediaTypeRegistry(), config.getParser());
             detector = config.getDetector();
@@ -592,51 +691,105 @@ public class TikaExtractor extends PasswordBasedExtractor {
         }
     }
 
+    /**
+     * This interface is for writing a content.
+     */
     @FunctionalInterface
     protected interface ContentWriter {
+        /**
+         * Accepts a writer.
+         * @param writer A writer.
+         * @throws IOException if an I/O error occurs.
+         * @throws TikaException if a Tika exception occurs.
+         * @throws SAXException if a SAX exception occurs.
+         */
         void accept(Writer writer) throws IOException, TikaException, SAXException;
     }
 
+    /**
+     * Sets the output encoding.
+     * @param outputEncoding The output encoding.
+     */
     public void setOutputEncoding(final String outputEncoding) {
         this.outputEncoding = outputEncoding;
     }
 
+    /**
+     * Sets whether to read content as text if extraction fails.
+     * @param readAsTextIfFailed If true, read a content as a text when an extraction fails.
+     */
     public void setReadAsTextIfFailed(final boolean readAsTextIfFailed) {
         this.readAsTextIfFailed = readAsTextIfFailed;
     }
 
+    /**
+     * Sets the maximum compression ratio.
+     * @param maxCompressionRatio The max compression ratio.
+     */
     public void setMaxCompressionRatio(final long maxCompressionRatio) {
         this.maxCompressionRatio = maxCompressionRatio;
     }
 
+    /**
+     * Sets the maximum uncompression size.
+     * @param maxUncompressionSize The max uncompression size.
+     */
     public void setMaxUncompressionSize(final long maxUncompressionSize) {
         this.maxUncompressionSize = maxUncompressionSize;
     }
 
+    /**
+     * Sets the initial buffer size.
+     * @param initialBufferSize The initial buffer size.
+     */
     public void setInitialBufferSize(final int initialBufferSize) {
         this.initialBufferSize = initialBufferSize;
     }
 
+    /**
+     * Sets whether duplicated terms are replaced.
+     * @param replaceDuplication If true, duplicated terms are replaced.
+     */
     public void setReplaceDuplication(final boolean replaceDuplication) {
         this.replaceDuplication = replaceDuplication;
     }
 
+    /**
+     * Sets the memory size.
+     * @param memorySize The memory size.
+     */
     public void setMemorySize(final int memorySize) {
         this.memorySize = memorySize;
     }
 
+    /**
+     * Sets the maximum size of an alpha-numeric term.
+     * @param maxAlphanumTermSize The max size of an alpha-numeric term.
+     */
     public void setMaxAlphanumTermSize(final int maxAlphanumTermSize) {
         this.maxAlphanumTermSize = maxAlphanumTermSize;
     }
 
+    /**
+     * Sets the maximum size of a symbol term.
+     * @param maxSymbolTermSize The max size of a symbol term.
+     */
     public void setMaxSymbolTermSize(final int maxSymbolTermSize) {
         this.maxSymbolTermSize = maxSymbolTermSize;
     }
 
+    /**
+     * Sets the space characters.
+     * @param spaceChars The space characters.
+     */
     public void setSpaceChars(final int[] spaceChars) {
         this.spaceChars = spaceChars;
     }
 
+    /**
+     * Sets the Tika configuration.
+     * @param tikaConfig The Tika config.
+     */
     public void setTikaConfig(final TikaConfig tikaConfig) {
         this.tikaConfig = tikaConfig;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/XmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/XmlExtractor.java
@@ -18,37 +18,76 @@ package org.codelibs.fess.crawler.extractor.impl;
 import java.util.regex.Pattern;
 
 /**
- * @author shinsuke
- *
+ * Extracts text content from XML documents.
  */
 public class XmlExtractor extends AbstractXmlExtractor {
+
+    /**
+     * Creates a new XmlExtractor instance.
+     */
+    public XmlExtractor() {
+        super();
+    }
+
+    /**
+     * Pattern for XML encoding.
+     */
     protected Pattern xmlEncodingPattern =
             Pattern.compile("<\\?xml.*encoding\\s*=\\s*['\"]([\\w\\d\\-_]*)['\"]\\s*\\?>", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 
+    /**
+     * Pattern for XML tags.
+     */
     protected Pattern xmlTagPattern = Pattern.compile("<[^>]+>");
 
+    /**
+     * Returns the encoding pattern.
+     * @return The encoding pattern.
+     */
     @Override
     protected Pattern getEncodingPattern() {
         return xmlEncodingPattern;
     }
 
+    /**
+     * Returns the precompiled {@link Pattern} used to match XML tags within the content.
+     * This pattern is utilized by the extractor to identify and process XML elements.
+     *
+     * @return the {@link Pattern} instance for XML tag matching
+     */
     @Override
     protected Pattern getTagPattern() {
         return xmlTagPattern;
     }
 
+    /**
+     * Returns the XML encoding pattern.
+     * @return The XML encoding pattern.
+     */
     public Pattern getXmlEncodingPattern() {
         return xmlEncodingPattern;
     }
 
+    /**
+     * Sets the XML encoding pattern.
+     * @param metaCharsetPattern The XML encoding pattern.
+     */
     public void setXmlEncodingPattern(final Pattern metaCharsetPattern) {
         xmlEncodingPattern = metaCharsetPattern;
     }
 
+    /**
+     * Returns the XML tag pattern.
+     * @return The XML tag pattern.
+     */
     public Pattern getXmlTagPattern() {
         return xmlTagPattern;
     }
 
+    /**
+     * Sets the XML tag pattern.
+     * @param htmlTagPattern The XML tag pattern.
+     */
     public void setXmlTagPattern(final Pattern htmlTagPattern) {
         xmlTagPattern = htmlTagPattern;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/ZipExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/ZipExtractor.java
@@ -37,16 +37,28 @@ import org.codelibs.fess.crawler.util.IgnoreCloseInputStream;
 import jakarta.annotation.Resource;
 
 /**
- * @author shinsuke
- *
+ * Extracts text content from ZIP archives.
  */
 public class ZipExtractor extends AbstractExtractor {
     private static final Logger logger = LogManager.getLogger(ZipExtractor.class);
 
+    /**
+     * The archive stream factory.
+     */
     @Resource
     protected ArchiveStreamFactory archiveStreamFactory;
 
+    /**
+     * The maximum content size.
+     */
     protected long maxContentSize = -1;
+
+    /**
+     * Creates a new ZipExtractor instance.
+     */
+    public ZipExtractor() {
+        super();
+    }
 
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
@@ -96,6 +108,10 @@ public class ZipExtractor extends AbstractExtractor {
         return new ExtractData(buf.toString().trim());
     }
 
+    /**
+     * Sets the maximum content size.
+     * @param maxContentSize The maximum content size to set.
+     */
     public void setMaxContentSize(final long maxContentSize) {
         this.maxContentSize = maxContentSize;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/filter/impl/UrlFilterImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/filter/impl/UrlFilterImpl.java
@@ -40,25 +40,59 @@ import jakarta.annotation.Resource;
  * match a URL against the defined patterns, and process a URL to add include or exclude patterns based on predefined filtering patterns.
  *
  */
+/**
+ * This class is an implementation of a URL filter.
+ */
 public class UrlFilterImpl implements UrlFilter {
+
+    /**
+     * Creates a new UrlFilterImpl instance.
+     */
+    public UrlFilterImpl() {
+        // NOP
+    }
 
     private static final Logger logger = LogManager.getLogger(UrlFilterImpl.class);
 
+    /**
+     * The crawler container.
+     */
     @Resource
     protected CrawlerContainer crawlerContainer;
 
+    /**
+     * The URL pattern.
+     */
     protected String urlPattern = "^(.*:/+)([^/]*)(.*)$";
 
+    /**
+     * The include filtering pattern.
+     */
     protected String includeFilteringPattern;
 
+    /**
+     * The exclude filtering pattern.
+     */
     protected String excludeFilteringPattern;
 
+    /**
+     * The cached include set.
+     */
     protected Set<String> cachedIncludeSet = new LinkedHashSet<>();
 
+    /**
+     * The cached exclude set.
+     */
     protected Set<String> cachedExcludeSet = new LinkedHashSet<>();
 
+    /**
+     * The session ID.
+     */
     protected String sessionId;
 
+    /**
+     * The URL filter service.
+     */
     protected UrlFilterService urlFilterService;
 
     /*
@@ -199,30 +233,58 @@ public class UrlFilterImpl implements UrlFilter {
         }
     }
 
+    /**
+     * Returns the URL pattern.
+     * @return The URL pattern.
+     */
     public String getUrlPattern() {
         return urlPattern;
     }
 
+    /**
+     * Sets the URL pattern.
+     * @param urlPattern The URL pattern.
+     */
     public void setUrlPattern(final String urlPattern) {
         this.urlPattern = urlPattern;
     }
 
+    /**
+     * Returns the include filtering pattern.
+     * @return The include filtering pattern.
+     */
     public String getIncludeFilteringPattern() {
         return includeFilteringPattern;
     }
 
+    /**
+     * Sets the include filtering pattern.
+     * @param includeFilteringPattern The include filtering pattern.
+     */
     public void setIncludeFilteringPattern(final String includeFilteringPattern) {
         this.includeFilteringPattern = includeFilteringPattern;
     }
 
+    /**
+     * Returns the exclude filtering pattern.
+     * @return The exclude filtering pattern.
+     */
     public String getExcludeFilteringPattern() {
         return excludeFilteringPattern;
     }
 
+    /**
+     * Sets the exclude filtering pattern.
+     * @param excludeFilteringPattern The exclude filtering pattern.
+     */
     public void setExcludeFilteringPattern(final String excludeFilteringPattern) {
         this.excludeFilteringPattern = excludeFilteringPattern;
     }
 
+    /**
+     * Returns the URL filter service.
+     * @return The URL filter service.
+     */
     public UrlFilterService getUrlFilterService() {
         if (urlFilterService == null) {
             urlFilterService = crawlerContainer.getComponent("urlFilterService");
@@ -233,6 +295,10 @@ public class UrlFilterImpl implements UrlFilter {
         return urlFilterService;
     }
 
+    /**
+     * Returns a string representation of this object.
+     * @return A string representation.
+     */
     @Override
     public String toString() {
         return "UrlFilterImpl [urlPattern=" + urlPattern + ", includeFilteringPattern=" + includeFilteringPattern

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/ContentLengthHelper.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/ContentLengthHelper.java
@@ -27,11 +27,25 @@ import org.codelibs.fess.crawler.exception.CrawlerSystemException;
  * The class provides methods to add, retrieve, and manage these limits.
  */
 public class ContentLengthHelper {
+    /**
+     * Constructs a new ContentLengthHelper.
+     */
+    public ContentLengthHelper() {
+        // Default constructor
+    }
 
-    protected long defaultMaxLength = 10L * 1024L * 1024L; // Default maximum content length set to 10MB
+    /** Default maximum content length set to 10MB */
+    protected long defaultMaxLength = 10L * 1024L * 1024L;
 
+    /** Map to store maximum content lengths for specific MIME types */
     protected Map<String, Long> maxLengthMap = new HashMap<>();
 
+    /**
+     * Adds a maximum content length for a specific MIME type.
+     * @param mimeType The MIME type for which to set the maximum length
+     * @param maxLength The maximum content length in bytes
+     * @throws CrawlerSystemException if the MIME type is blank or maxLength is negative
+     */
     public void addMaxLength(final String mimeType, final long maxLength) {
         if (StringUtil.isBlank(mimeType)) {
             throw new CrawlerSystemException("MIME type is a blank.");
@@ -42,6 +56,12 @@ public class ContentLengthHelper {
         maxLengthMap.put(mimeType, maxLength);
     }
 
+    /**
+     * Gets the maximum content length for a specific MIME type.
+     * If no specific length is set for the MIME type, returns the default maximum length.
+     * @param mimeType The MIME type to get the maximum length for
+     * @return The maximum content length in bytes
+     */
     public long getMaxLength(final String mimeType) {
         if (StringUtil.isBlank(mimeType)) {
             return defaultMaxLength;
@@ -53,10 +73,18 @@ public class ContentLengthHelper {
         return defaultMaxLength;
     }
 
+    /**
+     * Returns the default maximum content length.
+     * @return The default maximum content length in bytes.
+     */
     public long getDefaultMaxLength() {
         return defaultMaxLength;
     }
 
+    /**
+     * Sets the default maximum content length.
+     * @param defaultMaxLength The default maximum content length to set.
+     */
     public void setDefaultMaxLength(final long defaultMaxLength) {
         if (defaultMaxLength < 0) {
             throw new CrawlerSystemException("The value of defaultMaxLength is invalid.");

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/EncodingHelper.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/EncodingHelper.java
@@ -28,10 +28,25 @@ import org.codelibs.core.lang.StringUtil;
  */
 public class EncodingHelper {
 
+    /** The default encoding to use when no mapping is found */
     protected String defaultEncoding;
 
+    /** Map of encoding names to their preferred forms */
     protected Map<String, String> encodingMap = new HashMap<>();
 
+    /**
+     * Constructs a new EncodingHelper.
+     */
+    public EncodingHelper() {
+        // Default constructor
+    }
+
+    /**
+     * Normalizes an encoding string to its preferred form.
+     *
+     * @param enc the encoding string to normalize
+     * @return the normalized encoding or the default encoding if the input is blank
+     */
     public String normalize(final String enc) {
         if (StringUtil.isBlank(enc)) {
             return defaultEncoding;
@@ -44,6 +59,12 @@ public class EncodingHelper {
         return newEnc;
     }
 
+    /**
+     * Sets the default encoding to use when no mapping is found.
+     *
+     * @param defaultEncoding the default encoding to set
+     * @throws IllegalArgumentException if the default encoding is blank
+     */
     public void setDefaultEncoding(final String defaultEncoding) {
         if (StringUtil.isBlank(defaultEncoding)) {
             throw new IllegalArgumentException("Default encoding must not be blank.");
@@ -51,6 +72,13 @@ public class EncodingHelper {
         this.defaultEncoding = defaultEncoding;
     }
 
+    /**
+     * Adds an encoding mapping from source to target encoding.
+     *
+     * @param source the source encoding name
+     * @param target the target encoding name
+     * @throws IllegalArgumentException if source or target is blank
+     */
     public void addEncodingMapping(final String source, final String target) {
         if (StringUtil.isBlank(source) || StringUtil.isBlank(target)) {
             throw new IllegalArgumentException("Source and target encodings must not be blank.");
@@ -58,6 +86,11 @@ public class EncodingHelper {
         encodingMap.put(toLowerCase(source), target);
     }
 
+    /**
+     * Converts the given encoding string to lowercase.
+     * @param enc The encoding string.
+     * @return The lowercase encoding string.
+     */
     protected String toLowerCase(final String enc) {
         return enc.toLowerCase(Locale.ROOT);
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/MemoryDataHelper.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/MemoryDataHelper.java
@@ -42,19 +42,39 @@ import org.codelibs.fess.crawler.entity.UrlQueueImpl;
  * are stored as {@code Pattern} objects.
  */
 public class MemoryDataHelper {
+    /** Map of session IDs to URL queues for managing crawling queues. */
     protected volatile Map<String, Queue<UrlQueueImpl<Long>>> urlQueueMap = new HashMap<>();
 
+    /** Map of session IDs to access result maps for storing crawling results. */
     protected volatile Map<String, Map<String, AccessResultImpl<Long>>> sessionMap = new HashMap<>();
 
+    /** Map of session IDs to include URL patterns for filtering URLs. */
     protected volatile Map<String, List<Pattern>> includeUrlPatternMap = new HashMap<>();
 
+    /** Map of session IDs to exclude URL patterns for filtering URLs. */
     protected volatile Map<String, List<Pattern>> excludeUrlPatternMap = new HashMap<>();
 
+    /**
+     * Creates a new MemoryDataHelper instance.
+     */
+    public MemoryDataHelper() {
+        super();
+    }
+
+    /**
+     * Clears all URL queues and session data.
+     */
     public void clear() {
         urlQueueMap.clear();
         sessionMap.clear();
     }
 
+    /**
+     * Returns the URL queue for the specified session ID.
+     * Creates a new queue if one doesn't exist.
+     * @param sessionId the session ID
+     * @return the URL queue for the session
+     */
     public synchronized Queue<UrlQueueImpl<Long>> getUrlQueueList(final String sessionId) {
         Queue<UrlQueueImpl<Long>> urlQueueList = urlQueueMap.get(sessionId);
         if (urlQueueList == null) {
@@ -64,20 +84,38 @@ public class MemoryDataHelper {
         return urlQueueList;
     }
 
+    /**
+     * Adds the provided URL queue to the existing queue for the specified session.
+     * @param sessionId the session ID
+     * @param urlQueueList the URL queue to add
+     */
     public synchronized void addUrlQueueList(final String sessionId, final Queue<UrlQueueImpl<Long>> urlQueueList) {
         final Queue<UrlQueueImpl<Long>> uqList = getUrlQueueList(sessionId);
         uqList.addAll(urlQueueList);
         urlQueueMap.put(sessionId, uqList);
     }
 
+    /**
+     * Removes the URL queue for the specified session ID.
+     * @param sessionId the session ID
+     */
     public synchronized void removeUrlQueueList(final String sessionId) {
         urlQueueMap.remove(sessionId);
     }
 
+    /**
+     * Clears all URL queues for all sessions.
+     */
     public synchronized void clearUrlQueueList() {
         urlQueueMap.clear();
     }
 
+    /**
+     * Returns the access result map for the specified session ID.
+     * Creates a new map if one doesn't exist.
+     * @param sessionId the session ID
+     * @return the access result map for the session
+     */
     public synchronized Map<String, AccessResultImpl<Long>> getAccessResultMap(final String sessionId) {
         Map<String, AccessResultImpl<Long>> arMap = sessionMap.get(sessionId);
         if (arMap == null) {
@@ -87,14 +125,26 @@ public class MemoryDataHelper {
         return arMap;
     }
 
+    /**
+     * Deletes the access result map for the specified session ID.
+     * @param sessionId the session ID
+     */
     public synchronized void deleteAccessResultMap(final String sessionId) {
         sessionMap.remove(sessionId);
     }
 
+    /**
+     * Deletes all access result maps for all sessions.
+     */
     public synchronized void deleteAllAccessResultMap() {
         sessionMap.clear();
     }
 
+    /**
+     * Returns a list of access results for the specified URL across all sessions.
+     * @param url the URL to search for
+     * @return the list of access results for the URL
+     */
     public synchronized List<AccessResultImpl<Long>> getAccessResultList(final String url) {
         final List<AccessResultImpl<Long>> acList = new ArrayList<>();
         for (final Map.Entry<String, Map<String, AccessResultImpl<Long>>> entry : sessionMap.entrySet()) {
@@ -109,11 +159,22 @@ public class MemoryDataHelper {
         return acList;
     }
 
+    /**
+     * Adds an include URL pattern for the specified session.
+     * @param sessionId the session ID
+     * @param url the URL pattern to include
+     */
     public synchronized void addIncludeUrlPattern(final String sessionId, final String url) {
         final List<Pattern> patternList = getIncludeUrlPatternList(sessionId);
         patternList.add(Pattern.compile(url));
     }
 
+    /**
+     * Returns the list of include URL patterns for the specified session.
+     * Creates a new list if one doesn't exist.
+     * @param sessionId the session ID
+     * @return the list of include URL patterns
+     */
     public List<Pattern> getIncludeUrlPatternList(final String sessionId) {
         List<Pattern> patternList = includeUrlPatternMap.get(sessionId);
         if (patternList == null) {
@@ -123,11 +184,22 @@ public class MemoryDataHelper {
         return patternList;
     }
 
+    /**
+     * Adds an exclude URL pattern for the specified session.
+     * @param sessionId the session ID
+     * @param url the URL pattern to exclude
+     */
     public synchronized void addExcludeUrlPattern(final String sessionId, final String url) {
         final List<Pattern> patternList = getExcludeUrlPatternList(sessionId);
         patternList.add(Pattern.compile(url));
     }
 
+    /**
+     * Returns the list of exclude URL patterns for the specified session.
+     * Creates a new list if one doesn't exist.
+     * @param sessionId the session ID
+     * @return the list of exclude URL patterns
+     */
     public List<Pattern> getExcludeUrlPatternList(final String sessionId) {
         List<Pattern> patternList = excludeUrlPatternMap.get(sessionId);
         if (patternList == null) {
@@ -137,11 +209,18 @@ public class MemoryDataHelper {
         return patternList;
     }
 
+    /**
+     * Clears all URL patterns for the specified session.
+     * @param sessionId the session ID
+     */
     public synchronized void clearUrlPattern(final String sessionId) {
         includeUrlPatternMap.remove(sessionId);
         excludeUrlPatternMap.remove(sessionId);
     }
 
+    /**
+     * Clears all URL patterns.
+     */
     public synchronized void clearUrlPattern() {
         includeUrlPatternMap.clear();
         excludeUrlPatternMap.clear();

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/MimeTypeHelper.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/MimeTypeHelper.java
@@ -23,7 +23,19 @@ import java.util.Map;
  * It allows content type detection based on the stream's content and/or filename.
  */
 public interface MimeTypeHelper {
+    /**
+     * Determines the content type of the given input stream and filename.
+     * @param is the input stream to analyze
+     * @param filename the filename to help determine the content type
+     * @return the detected content type
+     */
     String getContentType(InputStream is, String filename);
 
+    /**
+     * Determines the content type of the given input stream using the provided parameters.
+     * @param is the input stream to analyze
+     * @param params the parameters containing additional information like filename
+     * @return the detected content type
+     */
     String getContentType(InputStream is, Map<String, String> params);
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/RobotsTxtHelper.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/RobotsTxtHelper.java
@@ -46,23 +46,49 @@ import org.codelibs.fess.crawler.exception.RobotsTxtException;
  */
 public class RobotsTxtHelper {
 
+    /** Pattern for parsing user-agent records. */
     protected static final Pattern USER_AGENT_RECORD =
             Pattern.compile("^user-agent:\\s*([^\\t\\n\\x0B\\f\\r]+)\\s*$", Pattern.CASE_INSENSITIVE);
 
+    /** Pattern for parsing disallow records. */
     protected static final Pattern DISALLOW_RECORD = Pattern.compile("^disallow:\\s*([^\\s]*)\\s*$", Pattern.CASE_INSENSITIVE);
 
+    /** Pattern for parsing allow records. */
     protected static final Pattern ALLOW_RECORD = Pattern.compile("^allow:\\s*([^\\s]*)\\s*$", Pattern.CASE_INSENSITIVE);
 
+    /** Pattern for parsing crawl-delay records. */
     protected static final Pattern CRAWL_DELAY_RECORD = Pattern.compile("^crawl-delay:\\s*([^\\s]+)\\s*$", Pattern.CASE_INSENSITIVE);
 
+    /**
+     * Pattern for Sitemap record.
+     */
     protected static final Pattern SITEMAP_RECORD = Pattern.compile("^sitemap:\\s*([^\\s]+)\\s*$", Pattern.CASE_INSENSITIVE);
 
+    /** Whether robots.txt processing is enabled. */
     protected boolean enabled = true;
 
+    /**
+     * Creates a new RobotsTxtHelper instance.
+     */
+    public RobotsTxtHelper() {
+        // Default constructor
+    }
+
+    /**
+     * Parses a robots.txt file from the given input stream using UTF-8 encoding.
+     * @param stream the input stream to parse
+     * @return the parsed RobotsTxt object, or null if disabled
+     */
     public RobotsTxt parse(final InputStream stream) {
         return parse(stream, Constants.UTF_8);
     }
 
+    /**
+     * Parses a robots.txt file from the given input stream using the specified character encoding.
+     * @param stream the input stream to parse
+     * @param charsetName the character encoding to use
+     * @return the parsed RobotsTxt object, or null if disabled
+     */
     public RobotsTxt parse(final InputStream stream, final String charsetName) {
         if (!enabled) {
             return null;
@@ -133,6 +159,12 @@ public class RobotsTxtHelper {
         }
     }
 
+    /**
+     * Extracts the value from a line using the given pattern.
+     * @param pattern the pattern to match against
+     * @param line the line to extract the value from
+     * @return the extracted value, or null if no match
+     */
     protected String getValue(final Pattern pattern, final String line) {
         final Matcher m = pattern.matcher(line);
         if (m.matches() && m.groupCount() > 0) {
@@ -141,6 +173,11 @@ public class RobotsTxtHelper {
         return null;
     }
 
+    /**
+     * Strips comments from a line (everything after '#' character).
+     * @param line the line to strip comments from
+     * @return the line without comments
+     */
     protected String stripComment(final String line) {
         final int commentIndex = line.indexOf('#');
         if (commentIndex != -1) {
@@ -149,10 +186,18 @@ public class RobotsTxtHelper {
         return line;
     }
 
+    /**
+     * Checks if robots.txt processing is enabled.
+     * @return true if enabled, false otherwise
+     */
     public boolean isEnabled() {
         return enabled;
     }
 
+    /**
+     * Sets whether robots.txt processing is enabled.
+     * @param enabled true to enable, false to disable
+     */
     public void setEnabled(final boolean enabled) {
         this.enabled = enabled;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/SitemapsHelper.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/SitemapsHelper.java
@@ -52,12 +52,31 @@ import org.xml.sax.helpers.DefaultHandler;
 public class SitemapsHelper {
     private static final Logger logger = LogManager.getLogger(SitemapsHelper.class);
 
+    /** The size of the preload buffer for checking file format. */
     protected int preloadSize = 512;
 
+    /**
+     * Creates a new SitemapsHelper instance.
+     */
+    public SitemapsHelper() {
+        // Default constructor
+    }
+
+    /**
+     * Checks if the given input stream contains valid sitemap data.
+     * @param in the input stream to validate
+     * @return true if the stream contains valid sitemap data, false otherwise
+     */
     public boolean isValid(final InputStream in) {
         return isValid(in, true);
     }
 
+    /**
+     * Checks if the given input stream contains valid sitemap data.
+     * @param in the input stream to validate
+     * @param recursive whether to recursively check compressed files
+     * @return true if the stream contains valid sitemap data, false otherwise
+     */
     protected boolean isValid(final InputStream in, final boolean recursive) {
         final BufferedInputStream bis = new BufferedInputStream(in);
         bis.mark(preloadSize);
@@ -97,6 +116,12 @@ public class SitemapsHelper {
         return parse(in, true);
     }
 
+    /**
+     * Parses a sitemap from the given input stream.
+     * @param in the input stream to parse
+     * @param recursive whether to recursively parse compressed files
+     * @return the parsed sitemap set
+     */
     protected SitemapSet parse(final InputStream in, final boolean recursive) {
         final BufferedInputStream bis = new BufferedInputStream(in);
         bis.mark(preloadSize);
@@ -134,6 +159,11 @@ public class SitemapsHelper {
         }
     }
 
+    /**
+     * Parses a text-based sitemap from the given input stream.
+     * @param in the input stream to parse
+     * @return the parsed sitemap set
+     */
     protected SitemapSet parseTextSitemaps(final InputStream in) {
         final SitemapSet sitemapSet = new SitemapSet();
         sitemapSet.setType(SitemapSet.URLSET);
@@ -156,6 +186,11 @@ public class SitemapsHelper {
 
     }
 
+    /**
+     * Parses an XML sitemap from the given input stream.
+     * @param in the input stream to parse
+     * @return the parsed sitemap set
+     */
     protected SitemapSet parseXmlSitemaps(final InputStream in) {
         final XmlSitemapsHandler handler = new XmlSitemapsHandler();
         try {
@@ -172,6 +207,12 @@ public class SitemapsHelper {
         return handler.getSitemapSet();
     }
 
+    /**
+     * Disables external resources for the SAX parser to prevent XXE attacks.
+     * @param parser the SAX parser to configure
+     * @throws SAXNotRecognizedException if the parser doesn't recognize the feature
+     * @throws SAXNotSupportedException if the parser doesn't support the feature
+     */
     protected void disableExternalResources(final SAXParser parser) throws SAXNotRecognizedException, SAXNotSupportedException {
         try {
             parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, StringUtil.EMPTY);
@@ -183,6 +224,9 @@ public class SitemapsHelper {
         }
     }
 
+    /**
+     * SAX handler for parsing XML sitemaps.
+     */
     protected static class XmlSitemapsHandler extends DefaultHandler {
 
         private static final String PRIORITY_ELEMENT = "priority";
@@ -200,6 +244,13 @@ public class SitemapsHelper {
         private SitemapUrl sitemapUrl;
 
         private StringBuilder buf;
+
+        /**
+         * Creates a new XmlSitemapsHandler instance.
+         */
+        public XmlSitemapsHandler() {
+            // Default constructor
+        }
 
         @Override
         public void startDocument() {
@@ -257,12 +308,21 @@ public class SitemapsHelper {
             // nothing
         }
 
+        /**
+         * Gets the parsed sitemap set.
+         * @return the sitemap set
+         */
         public SitemapSet getSitemapSet() {
             return sitemapSet;
         }
 
     }
 
+    /**
+     * Parses an XML sitemap index from the given input stream.
+     * @param in the input stream to parse
+     * @return the parsed sitemap set
+     */
     protected SitemapSet parseXmlSitemapsIndex(final InputStream in) {
         final XmlSitemapsIndexHandler handler = new XmlSitemapsIndexHandler();
         try {
@@ -279,6 +339,9 @@ public class SitemapsHelper {
         return handler.getSitemapSet();
     }
 
+    /**
+     * SAX handler for parsing XML sitemap indexes.
+     */
     protected static class XmlSitemapsIndexHandler extends DefaultHandler {
 
         private SitemapSet sitemapSet;
@@ -286,6 +349,13 @@ public class SitemapsHelper {
         private SitemapFile sitemapFile;
 
         private StringBuilder buf;
+
+        /**
+         * Creates a new XmlSitemapsIndexHandler instance.
+         */
+        public XmlSitemapsIndexHandler() {
+            // Default constructor
+        }
 
         @Override
         public void startDocument() {
@@ -332,12 +402,20 @@ public class SitemapsHelper {
             // nothing
         }
 
+        /**
+         * Gets the parsed sitemap set.
+         * @return the sitemap set
+         */
         public SitemapSet getSitemapSet() {
             return sitemapSet;
         }
 
     }
 
+    /**
+     * Sets the preload size for checking file format.
+     * @param preloadSize the preload size in bytes
+     */
     public void setPreloadSize(final int preloadSize) {
         this.preloadSize = preloadSize;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/UrlConvertHelper.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/UrlConvertHelper.java
@@ -41,10 +41,29 @@ import org.codelibs.fess.crawler.exception.CrawlerSystemException;
  * // convertedUrl will be "http://new-domain.com/path"
  * }</pre>
  */
+/**
+ * This class is a helper for URL conversion.
+ */
 public class UrlConvertHelper {
 
+    /**
+     * Creates a new UrlConvertHelper instance.
+     */
+    public UrlConvertHelper() {
+        // NOP
+    }
+
+    /**
+     * A map for URL conversion.
+     */
     protected Map<String, String> convertMap = new LinkedHashMap<>();
 
+    /**
+     * Converts a URL.
+     *
+     * @param url The URL.
+     * @return A converted URL.
+     */
     public String convert(final String url) {
         if (url == null) {
             return null;
@@ -56,6 +75,12 @@ public class UrlConvertHelper {
         return convertedUrl;
     }
 
+    /**
+     * Adds a conversion rule.
+     *
+     * @param target The target string.
+     * @param replacement The replacement string.
+     */
     public void add(final String target, final String replacement) {
         if (target == null || replacement == null) {
             throw new CrawlerSystemException("Target or replacement cannot be null.");
@@ -63,6 +88,10 @@ public class UrlConvertHelper {
         convertMap.put(target, replacement);
     }
 
+    /**
+     * Sets the conversion map.
+     * @param convertMap The conversion map to set.
+     */
     public void setConvertMap(final Map<String, String> convertMap) {
         if (convertMap == null) {
             throw new CrawlerSystemException("convertMap is null.");

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/impl/LogHelperImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/impl/LogHelperImpl.java
@@ -56,7 +56,15 @@ import org.codelibs.fess.crawler.log.LogType;
  */
 public class LogHelperImpl implements LogHelper {
 
+    /** Logger for this class. */
     private static final Logger logger = LogManager.getLogger(LogHelperImpl.class);
+
+    /**
+     * Creates a new LogHelperImpl instance.
+     */
+    public LogHelperImpl() {
+        super();
+    }
 
     /*
      * (non-Javadoc)
@@ -130,9 +138,19 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes default log events (no specific handling).
+     *
+     * @param objs the log objects
+     */
     protected void processDefault(final Object... objs) {
     }
 
+    /**
+     * Processes system error log events.
+     *
+     * @param objs the log objects (should contain a Throwable)
+     */
     protected void processSystemError(final Object... objs) {
         final Throwable t = (Throwable) objs[0];
         if (logger.isErrorEnabled()) {
@@ -140,6 +158,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes no rule found log events.
+     *
+     * @param objs the log objects (should contain ResponseData)
+     */
     protected void processNoRule(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         // UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -149,6 +172,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes no response processor found log events.
+     *
+     * @param objs the log objects (should contain ResponseData)
+     */
     protected void processNoResponseProcessor(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         // UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -160,10 +188,20 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes finished thread log events.
+     *
+     * @param objs the log objects
+     */
     protected void processFinishedThread(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
     }
 
+    /**
+     * Processes no URL in queue log events.
+     *
+     * @param objs the log objects (should contain UrlQueue and thread check count)
+     */
     protected void processNoUrlInQueue(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -177,6 +215,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes crawling exception log events.
+     *
+     * @param objs the log objects (should contain UrlQueue and Throwable)
+     */
     protected void processCrawlingException(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -184,6 +227,11 @@ public class LogHelperImpl implements LogHelper {
         logger.error("Crawling Exception at " + urlQueue.getUrl(), e);
     }
 
+    /**
+     * Processes crawling access exception log events.
+     *
+     * @param objs the log objects (should contain UrlQueue and CrawlingAccessException)
+     */
     protected void processCrawlingAccessException(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -199,6 +247,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes child URL processing exception log events.
+     *
+     * @param objs the log objects (should contain UrlQueue, URL string, and Throwable)
+     */
     protected void processProcessChildUrlByException(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -209,6 +262,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes child URLs processing exception log events.
+     *
+     * @param objs the log objects (should contain UrlQueue and Set of RequestData)
+     */
     protected void processProcessChildUrlsByException(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -221,6 +279,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes finished crawling log events.
+     *
+     * @param objs the log objects (should contain UrlQueue)
+     */
     protected void processFinishedCrawling(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -229,6 +292,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes response processing log events.
+     *
+     * @param objs the log objects (should contain ResponseData)
+     */
     protected void processProcessResponse(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         // UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -239,6 +307,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes redirect location log events.
+     *
+     * @param objs the log objects (should contain ResponseData)
+     */
     protected void processRedirectLocation(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         // final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -248,6 +321,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes get content log events.
+     *
+     * @param objs the log objects (should contain UrlQueue)
+     */
     protected void processGetContent(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -256,6 +334,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes not modified log events.
+     *
+     * @param objs the log objects (should contain UrlQueue)
+     */
     protected void processNotModified(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -264,6 +347,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes check last modified log events.
+     *
+     * @param objs the log objects (should contain UrlQueue)
+     */
     protected void processCheckLastModified(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -272,6 +360,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes unsupported URL log events.
+     *
+     * @param objs the log objects (should contain UrlQueue)
+     */
     protected void processUnsupportedUrlAtCrawlingStarted(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -280,10 +373,20 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes cleanup crawling log events.
+     *
+     * @param objs the log objects
+     */
     protected void processCleanupCrawling(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
     }
 
+    /**
+     * Processes start crawling log events.
+     *
+     * @param objs the log objects (should contain UrlQueue)
+     */
     protected void processStartCrawling(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
         final UrlQueue<?> urlQueue = (UrlQueue<?>) objs[1];
@@ -292,6 +395,11 @@ public class LogHelperImpl implements LogHelper {
         }
     }
 
+    /**
+     * Processes start thread log events.
+     *
+     * @param objs the log objects
+     */
     protected void processStartThread(final Object... objs) {
         // CrawlerContext crawlerContext = (CrawlerContext) objs[0];
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/impl/MimeTypeHelperImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/impl/MimeTypeHelperImpl.java
@@ -58,14 +58,23 @@ import org.codelibs.fess.crawler.helper.MimeTypeHelper;
  * </pre>
  */
 public class MimeTypeHelperImpl implements MimeTypeHelper {
+    /** The resource name for the MIME types configuration file. */
     protected static final String MIME_TYPES_RESOURCE_NAME = "/org/codelibs/fess/crawler/mime/tika-mimetypes.xml";
 
+    /** The MimeTypes instance for detecting MIME types. */
     protected MimeTypes mimeTypes;
 
+    /** Whether to use the filename for MIME type detection. */
     protected boolean useFilename = false;
 
+    /** Whether to use the filename for MIME type detection when the stream is detected as octet-stream. */
     protected boolean useFilenameOnOctetStream = true;
 
+    /**
+     * Creates a new MimeTypeHelperImpl instance.
+     * Initializes the MimeTypes instance using the default configuration.
+     * @throws CrawlerSystemException if the MIME types configuration cannot be loaded
+     */
     public MimeTypeHelperImpl() {
         try {
             mimeTypes = MimeTypesFactory.create(MIME_TYPES_RESOURCE_NAME);
@@ -110,6 +119,11 @@ public class MimeTypeHelperImpl implements MimeTypeHelper {
         }
     }
 
+    /**
+     * Normalizes the filename by replacing special characters.
+     * @param filename The filename to normalize.
+     * @return The normalized filename.
+     */
     protected String normalizeFilename(final String filename) {
         if (StringUtil.isBlank(filename)) {
             return filename;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/interval/IntervalController.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/interval/IntervalController.java
@@ -31,12 +31,16 @@ package org.codelibs.fess.crawler.interval;
  * </ul>
  */
 public interface IntervalController {
+    /** Constant representing the pre-processing state. */
     int PRE_PROCESSING = 1;
 
+    /** Constant representing the post-processing state. */
     int POST_PROCESSING = 2;
 
+    /** Constant indicating that there are no URLs in the queue. */
     int NO_URL_IN_QUEUE = 4;
 
+    /** Constant indicating that the crawler is waiting for new URLs. */
     int WAIT_NEW_URL = 8;
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/interval/impl/AbstractIntervalController.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/interval/impl/AbstractIntervalController.java
@@ -56,6 +56,13 @@ public abstract class AbstractIntervalController implements IntervalController {
      */
     protected boolean ignoreException = true;
 
+    /**
+     * Constructs a new AbstractIntervalController.
+     */
+    public AbstractIntervalController() {
+        // NOP
+    }
+
     /*
      * (non-Javadoc)
      *
@@ -92,18 +99,38 @@ public abstract class AbstractIntervalController implements IntervalController {
         }
     }
 
+    /**
+     * Delays the crawling process before processing a URL.
+     */
     protected abstract void delayBeforeProcessing();
 
+    /**
+     * Delays the crawling process after processing a URL.
+     */
     protected abstract void delayAfterProcessing();
 
+    /**
+     * Delays the crawling process when there are no URLs in the queue.
+     */
     protected abstract void delayAtNoUrlInQueue();
 
+    /**
+     * Delays the crawling process while waiting for new URLs to be added to the queue.
+     */
     protected abstract void delayForWaitingNewUrl();
 
+    /**
+     * Checks if exceptions during the delay process should be ignored.
+     * @return true if exceptions should be ignored, false otherwise.
+     */
     public boolean isIgnoreException() {
         return ignoreException;
     }
 
+    /**
+     * Sets whether to ignore exceptions.
+     * @param ignoreException true to ignore exceptions, false otherwise.
+     */
     public void setIgnoreException(final boolean ignoreException) {
         this.ignoreException = ignoreException;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/interval/impl/DefaultIntervalController.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/interval/impl/DefaultIntervalController.java
@@ -29,17 +29,29 @@ import org.codelibs.core.lang.ThreadUtil;
  */
 public class DefaultIntervalController extends AbstractIntervalController {
 
+    /** Delay in milliseconds after processing a URL */
     protected long delayMillisAfterProcessing = 0L;
 
+    /** Delay in milliseconds when no URL is in the queue */
     protected long delayMillisAtNoUrlInQueue = 500L;
 
+    /** Delay in milliseconds before processing a URL */
     protected long delayMillisBeforeProcessing = 0L;
 
+    /** Delay in milliseconds for waiting for new URLs */
     protected long delayMillisForWaitingNewUrl = 1000L;
 
+    /**
+     * Default constructor with default delay values.
+     */
     public DefaultIntervalController() {
     }
 
+    /**
+     * Constructor with configurable delay parameters.
+     *
+     * @param params map containing delay parameters
+     */
     public DefaultIntervalController(final Map<String, Long> params) {
         Long millis = params.get("delayMillisAfterProcessing");
         if (millis != null) {
@@ -63,11 +75,8 @@ public class DefaultIntervalController extends AbstractIntervalController {
 
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.interval.impl.AbstractIntervalController#
-     * delayAfterProcessing()
+    /**
+     * Delays after processing a URL.
      */
     @Override
     protected void delayAfterProcessing() {
@@ -76,12 +85,8 @@ public class DefaultIntervalController extends AbstractIntervalController {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.codelibs.fess.crawler.interval.impl.AbstractIntervalController#delayAtNoUrlInQueue
-     * ()
+    /**
+     * Delays when no URL is in the queue.
      */
     @Override
     protected void delayAtNoUrlInQueue() {
@@ -90,11 +95,8 @@ public class DefaultIntervalController extends AbstractIntervalController {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.interval.impl.AbstractIntervalController#
-     * delayBeforeProcessing()
+    /**
+     * Delays before processing a URL.
      */
     @Override
     protected void delayBeforeProcessing() {
@@ -103,11 +105,8 @@ public class DefaultIntervalController extends AbstractIntervalController {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.interval.impl.AbstractIntervalController#
-     * delayForWaitingNewUrl()
+    /**
+     * Delays for waiting for new URLs.
      */
     @Override
     protected void delayForWaitingNewUrl() {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/interval/impl/HostIntervalController.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/interval/impl/HostIntervalController.java
@@ -41,20 +41,31 @@ import org.codelibs.fess.crawler.util.CrawlingParameterUtil;
  */
 public class HostIntervalController extends DefaultIntervalController {
 
+    /** Map storing the last access time for each host. */
     private final ConcurrentMap<String, AtomicLong> lastTimes = new ConcurrentHashMap<>();
 
+    /**
+     * Constructs a new HostIntervalController with default parameters.
+     */
     public HostIntervalController() {
     }
 
+    /**
+     * Constructs a new HostIntervalController with the specified parameters.
+     *
+     * @param params the parameters to configure the interval controller
+     */
     public HostIntervalController(final Map<String, Long> params) {
         super(params);
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Delays before processing a URL, ensuring that requests to the same host are not made too frequently.
+     * This method extracts the host from the URL and enforces a delay based on the configured
+     * delayMillisBeforeProcessing parameter.
      *
-     * @see org.codelibs.fess.crawler.interval.impl.AbstractIntervalController#
-     * delayBeforeProcessing()
+     * @throws InterruptedRuntimeException if the thread is interrupted during the delay
+     * @throws CrawlerSystemException if an error occurs while processing the URL
      */
     @Override
     protected void delayBeforeProcessing() {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/log/LogType.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/log/LogType.java
@@ -20,23 +20,42 @@ package org.codelibs.fess.crawler.log;
  * Each enum constant represents a specific event or state in the crawler's execution.
  */
 public enum LogType {
-    START_CRAWLING, //
-    CLEANUP_CRAWLING, //
-    UNSUPPORTED_URL_AT_CRAWLING_STARTED, //
-    CHECK_LAST_MODIFIED, //
-    NOT_MODIFIED, //
-    GET_CONTENT, //
-    REDIRECT_LOCATION, //
-    PROCESS_RESPONSE, //
-    FINISHED_CRAWLING, //
-    PROCESS_CHILD_URLS_BY_EXCEPTION, //
-    PROCESS_CHILD_URL_BY_EXCEPTION, //
-    CRAWLING_ACCESS_EXCEPTION, //
-    CRAWLING_EXCEPTION, //
-    NO_URL_IN_QUEUE, //
-    START_THREAD, //
-    FINISHED_THREAD, //
-    NO_RESPONSE_PROCESSOR, //
-    NO_RULE, //
+    /** Indicates the start of a crawling process. */
+    START_CRAWLING,
+    /** Indicates the cleanup phase of crawling. */
+    CLEANUP_CRAWLING,
+    /** Indicates an unsupported URL was encountered when crawling started. */
+    UNSUPPORTED_URL_AT_CRAWLING_STARTED,
+    /** Indicates checking the last modified date of a resource. */
+    CHECK_LAST_MODIFIED,
+    /** Indicates the resource has not been modified. */
+    NOT_MODIFIED,
+    /** Indicates getting content from a resource. */
+    GET_CONTENT,
+    /** Indicates a redirect location was found. */
+    REDIRECT_LOCATION,
+    /** Indicates processing a response. */
+    PROCESS_RESPONSE,
+    /** Indicates the crawling process has finished. */
+    FINISHED_CRAWLING,
+    /** Indicates processing child URLs due to an exception. */
+    PROCESS_CHILD_URLS_BY_EXCEPTION,
+    /** Indicates processing a child URL due to an exception. */
+    PROCESS_CHILD_URL_BY_EXCEPTION,
+    /** Indicates an access exception during crawling. */
+    CRAWLING_ACCESS_EXCEPTION,
+    /** Indicates a general exception during crawling. */
+    CRAWLING_EXCEPTION,
+    /** Indicates no URL is available in the queue. */
+    NO_URL_IN_QUEUE,
+    /** Indicates the start of a crawler thread. */
+    START_THREAD,
+    /** Indicates the finish of a crawler thread. */
+    FINISHED_THREAD,
+    /** Indicates no response processor is available. */
+    NO_RESPONSE_PROCESSOR,
+    /** Indicates no rule is available for processing. */
+    NO_RULE,
+    /** Indicates a system error occurred. */
     SYSTEM_ERROR
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/pool/CrawlerPooledObjectFactory.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/pool/CrawlerPooledObjectFactory.java
@@ -28,9 +28,16 @@ import jakarta.annotation.Resource;
  * methods for creating, wrapping, and destroying crawler components
  * obtained from a {@link CrawlerContainer}.
  *
- *
+ * @param <T> the type of the pooled object
  */
 public class CrawlerPooledObjectFactory<T> extends BasePooledObjectFactory<T> {
+    /**
+     * Constructs a new CrawlerPooledObjectFactory.
+     */
+    public CrawlerPooledObjectFactory() {
+        // Default constructor
+    }
+
     /**
      * The container that provides crawler components.
      */
@@ -47,27 +54,31 @@ public class CrawlerPooledObjectFactory<T> extends BasePooledObjectFactory<T> {
      */
     protected OnDestroyListener<T> onDestroyListener;
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.apache.commons.pool2.BasePooledObjectFactory#create()
+    /**
+     * Creates a new object instance from the crawler container.
+     * @return A new instance of the component specified by componentName
+     * @throws Exception if the component cannot be created
      */
     @Override
     public T create() throws Exception {
         return (T) crawlerContainer.getComponent(componentName);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.apache.commons.pool2.BasePooledObjectFactory#wrap(java.lang.Object)
+    /**
+     * Wraps an object instance into a pooled object.
+     * @param obj The object to wrap
+     * @return A PooledObject wrapping the given object
      */
     @Override
     public PooledObject<T> wrap(final T obj) {
         return new DefaultPooledObject<>(obj);
     }
 
+    /**
+     * Destroys a pooled object and notifies the destroy listener if set.
+     * @param p The pooled object to destroy
+     * @throws Exception if destruction fails
+     */
     @Override
     public void destroyObject(final PooledObject<T> p) throws Exception {
         if (onDestroyListener != null) {
@@ -75,22 +86,46 @@ public class CrawlerPooledObjectFactory<T> extends BasePooledObjectFactory<T> {
         }
     }
 
+    /**
+     * Listener interface for handling object destruction events.
+     * @param <T> The type of the pooled object
+     */
     public interface OnDestroyListener<T> {
+        /**
+         * Called when a pooled object is being destroyed.
+         * @param p The pooled object being destroyed
+         */
         void onDestroy(PooledObject<T> p);
     }
 
+    /**
+     * Gets the component name.
+     * @return The component name
+     */
     public String getComponentName() {
         return componentName;
     }
 
+    /**
+     * Sets the component name.
+     * @param componentName The component name to set
+     */
     public void setComponentName(final String componentName) {
         this.componentName = componentName;
     }
 
+    /**
+     * Returns the onDestroy listener.
+     * @return The onDestroy listener.
+     */
     public OnDestroyListener<T> getOnDestroyListener() {
         return onDestroyListener;
     }
 
+    /**
+     * Sets the onDestroy listener.
+     * @param onDestroyListener The OnDestroyListener to set.
+     */
     public void setOnDestroyListener(final OnDestroyListener<T> onDestroyListener) {
         this.onDestroyListener = onDestroyListener;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/DefaultResponseProcessor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/DefaultResponseProcessor.java
@@ -66,17 +66,34 @@ import jakarta.annotation.Resource;
  *
  */
 public class DefaultResponseProcessor implements ResponseProcessor {
+    /** Logger instance for this class */
     private static final Logger logger = LogManager.getLogger(DefaultResponseProcessor.class);
 
+    /** Container for managing crawler components */
     @Resource
     protected CrawlerContainer crawlerContainer;
 
+    /** Transformer used to transform response data */
     protected Transformer transformer;
 
+    /** HTTP status codes considered successful */
     protected int[] successfulHttpCodes;
 
+    /** HTTP status codes considered not modified */
     protected int[] notModifiedHttpCodes;
 
+    /**
+     * Constructs a new DefaultResponseProcessor.
+     */
+    public DefaultResponseProcessor() {
+        // Default constructor
+    }
+
+    /**
+     * Processes response data based on HTTP status code and configured transformer.
+     *
+     * @param responseData the response data to process
+     */
     @Override
     public void process(final ResponseData responseData) {
         if (isNotModified(responseData)) {
@@ -105,6 +122,12 @@ public class DefaultResponseProcessor implements ResponseProcessor {
         }
     }
 
+    /**
+     * Checks if the response is successful based on configured HTTP status codes.
+     *
+     * @param responseData the response data to check
+     * @return true if successful, false otherwise
+     */
     protected boolean isSuccessful(final ResponseData responseData) {
         if (successfulHttpCodes == null) {
             return true;
@@ -118,6 +141,12 @@ public class DefaultResponseProcessor implements ResponseProcessor {
         return false;
     }
 
+    /**
+     * Checks if the response is not modified based on configured HTTP status codes.
+     *
+     * @param responseData the response data to check
+     * @return true if not modified, false otherwise
+     */
     protected boolean isNotModified(final ResponseData responseData) {
         if (notModifiedHttpCodes == null) {
             return false;
@@ -131,6 +160,13 @@ public class DefaultResponseProcessor implements ResponseProcessor {
         return false;
     }
 
+    /**
+     * Processes the result data and stores it along with child URLs.
+     *
+     * @param urlQueue the URL queue entry
+     * @param responseData the response data
+     * @param resultData the result data
+     */
     protected void processResult(final UrlQueue<?> urlQueue, final ResponseData responseData, final ResultData resultData) {
         final CrawlerContext crawlerContext = CrawlingParameterUtil.getCrawlerContext();
         final UrlQueueService<UrlQueue<?>> urlQueueService = CrawlingParameterUtil.getUrlQueueService();
@@ -177,12 +213,25 @@ public class DefaultResponseProcessor implements ResponseProcessor {
         }
     }
 
+    /**
+     * Creates an access result from response data and result data.
+     *
+     * @param responseData the response data
+     * @param resultData the result data
+     * @return the created access result
+     */
     protected AccessResult<?> createAccessResult(final ResponseData responseData, final ResultData resultData) {
         final AccessResult<?> accessResult = crawlerContainer.getComponent("accessResult");
         accessResult.init(responseData, resultData);
         return accessResult;
     }
 
+    /**
+     * Checks if the access count is within the allowed limit.
+     *
+     * @param crawlerContext the crawler context
+     * @return true if access count is within limit, false otherwise
+     */
     protected boolean checkAccessCount(final CrawlerContext crawlerContext) {
         if (crawlerContext.getMaxAccessCount() > 0) {
             return crawlerContext.incrementAndGetAccessCount() <= crawlerContext.getMaxAccessCount();
@@ -190,6 +239,15 @@ public class DefaultResponseProcessor implements ResponseProcessor {
         return true;
     }
 
+    /**
+     * Stores child URLs found in the response data.
+     *
+     * @param crawlerContext the crawler context
+     * @param childUrlList the set of child URLs
+     * @param url the parent URL
+     * @param depth the depth of the child URLs
+     * @param encoding the encoding of the child URLs
+     */
     protected void storeChildUrls(final CrawlerContext crawlerContext, final Set<RequestData> childUrlList, final String url,
             final int depth, final String encoding) {
         // add url and filter
@@ -214,26 +272,55 @@ public class DefaultResponseProcessor implements ResponseProcessor {
         }
     }
 
+    /**
+     * Gets the transformer.
+     *
+     * @return the transformer
+     */
     public Transformer getTransformer() {
         return transformer;
     }
 
+    /**
+     * Sets the transformer.
+     *
+     * @param transformer the transformer to set
+     */
     public void setTransformer(final Transformer transformer) {
         this.transformer = transformer;
     }
 
+    /**
+     * Gets the successful HTTP codes.
+     *
+     * @return the successful HTTP codes
+     */
     public int[] getSuccessfulHttpCodes() {
         return successfulHttpCodes;
     }
 
+    /**
+     * Sets the successful HTTP codes.
+     *
+     * @param successfulHttpCodes the successful HTTP codes to set
+     */
     public void setSuccessfulHttpCodes(final int[] successfulHttpCodes) {
         this.successfulHttpCodes = successfulHttpCodes;
     }
 
+    /**
+     * Gets the not modified HTTP codes.
+     *
+     * @return the not modified HTTP codes
+     */
     public int[] getNotModifiedHttpCodes() {
         return notModifiedHttpCodes;
     }
 
+    /**
+     * Sets the not modified HTTP codes.
+     * @param notModifiedHttpCodes The not modified HTTP codes to set.
+     */
     public void setNotModifiedHttpCodes(final int[] notModifiedHttpCodes) {
         this.notModifiedHttpCodes = notModifiedHttpCodes;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/NullResponseProcessor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/NullResponseProcessor.java
@@ -28,6 +28,13 @@ import org.codelibs.fess.crawler.processor.ResponseProcessor;
 public class NullResponseProcessor implements ResponseProcessor {
 
     /**
+     * Creates a new NullResponseProcessor instance.
+     */
+    public NullResponseProcessor() {
+        super();
+    }
+
+    /**
      * Processes the given response data.
      * This implementation does nothing.
      *

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/SitemapsResponseProcessor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/SitemapsResponseProcessor.java
@@ -52,9 +52,21 @@ import jakarta.annotation.Resource;
  * </p>
  */
 public class SitemapsResponseProcessor implements ResponseProcessor {
+    /** The crawler container for component lookup. */
     @Resource
     protected CrawlerContainer crawlerContainer;
 
+    /**
+     * Creates a new SitemapsResponseProcessor instance.
+     */
+    public SitemapsResponseProcessor() {
+        super();
+    }
+
+    /**
+     * Processes the given response data, extracting URLs from sitemaps.
+     * @param responseData The response data.
+     */
     @Override
     public void process(final ResponseData responseData) {
         final SitemapsHelper sitemapsHelper = crawlerContainer.getComponent("sitemapsHelper");

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/RuleManager.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/RuleManager.java
@@ -44,6 +44,12 @@ public interface RuleManager {
      * @param index the position at which the rule should be added
      * @param rule the rule to be added
      */
+    /**
+     * Adds a rule to the specified index.
+     *
+     * @param index the position at which the rule should be added
+     * @param rule the rule to be added
+     */
     void addRule(int index, Rule rule);
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/impl/AbstractRule.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/impl/AbstractRule.java
@@ -42,12 +42,22 @@ public abstract class AbstractRule implements Rule {
 
     private static final long serialVersionUID = 1L;
 
+    /** The rule ID. */
     protected String ruleId;
 
+    /** The response processor. */
     protected ResponseProcessor responseProcessor;
 
+    /** The crawler container. */
     @Resource
     protected CrawlerContainer crawlerContainer;
+
+    /**
+     * Constructs a new AbstractRule.
+     */
+    public AbstractRule() {
+        // NOP
+    }
 
     /**
      * Registers this rule with the {@link RuleManager}.

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/impl/RegexRule.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/impl/RegexRule.java
@@ -58,13 +58,24 @@ import org.codelibs.fess.crawler.entity.ResponseData;
  */
 public class RegexRule extends AbstractRule {
 
+    /** Serial version UID for serialization. */
     private static final long serialVersionUID = 1L;
 
+    /** Whether this rule should match all responses by default. */
     protected boolean defaultRule = false;
 
+    /** Whether all regular expressions must match (true) or just one (false). */
     protected boolean allRequired = true;
 
+    /** Map of field names to regular expression patterns. */
     protected Map<String, Pattern> regexMap = new HashMap<>();
+
+    /**
+     * Creates a new RegexRule instance.
+     */
+    public RegexRule() {
+        super();
+    }
 
     /*
      * (non-Javadoc)
@@ -98,26 +109,52 @@ public class RegexRule extends AbstractRule {
         return allRequired;
     }
 
+    /**
+     * Adds a regular expression rule for the specified field.
+     * @param key the field name to match against
+     * @param regex the regular expression pattern
+     */
     public void addRule(final String key, final String regex) {
         regexMap.put(key, Pattern.compile(regex));
     }
 
+    /**
+     * Adds a compiled regular expression rule for the specified field.
+     * @param key the field name to match against
+     * @param pattern the compiled regular expression pattern
+     */
     public void addRule(final String key, final Pattern pattern) {
         regexMap.put(key, pattern);
     }
 
+    /**
+     * Returns whether this rule is a default rule that matches all responses.
+     * @return true if this is a default rule, false otherwise
+     */
     public boolean isDefaultRule() {
         return defaultRule;
     }
 
+    /**
+     * Sets whether this rule should be a default rule that matches all responses.
+     * @param defaultRule true to make this a default rule, false otherwise
+     */
     public void setDefaultRule(final boolean defaultRule) {
         this.defaultRule = defaultRule;
     }
 
+    /**
+     * Returns whether all regular expressions must match for this rule to match.
+     * @return true if all patterns must match, false if only one needs to match
+     */
     public boolean isAllRequired() {
         return allRequired;
     }
 
+    /**
+     * Sets whether all regular expressions must match for this rule to match.
+     * @param allRequired true if all patterns must match, false if only one needs to match
+     */
     public void setAllRequired(final boolean allRequired) {
         this.allRequired = allRequired;
     }
@@ -131,6 +168,10 @@ public class RegexRule extends AbstractRule {
         return false;
     }
 
+    /**
+     * Returns the hash code for this RegexRule.
+     * @return The hash code.
+     */
     @Override
     public int hashCode() {
         int hash = regexMap.hashCode();

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/impl/RuleManagerImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/impl/RuleManagerImpl.java
@@ -30,12 +30,25 @@ import org.codelibs.fess.crawler.rule.RuleManager;
  */
 public class RuleManagerImpl implements RuleManager {
 
+    /** The list of rules managed by this rule manager. */
     protected final List<Rule> ruleList = new ArrayList<>();
+
+    /**
+     * Creates a new RuleManagerImpl instance.
+     */
+    public RuleManagerImpl() {
+        // Default constructor
+    }
 
     /*
      * (non-Javadoc)
      *
      * @see org.codelibs.fess.crawler.rule.RuleManager#getRule(org.codelibs.fess.crawler.entity.ResponseData)
+     */
+    /**
+     * Gets the first rule that matches the given response data.
+     * @param responseData the response data to match against
+     * @return the first matching rule, or null if no rule matches
      */
     @Override
     public Rule getRule(final ResponseData responseData) {
@@ -53,11 +66,20 @@ public class RuleManagerImpl implements RuleManager {
      * @see
      * org.codelibs.fess.crawler.rule.RuleManager#addRule(org.codelibs.fess.crawler.rule.Rule)
      */
+    /**
+     * Adds a rule to the end of the rule list.
+     * @param rule the rule to add
+     */
     @Override
     public void addRule(final Rule rule) {
         ruleList.add(rule);
     }
 
+    /**
+     * Adds a rule at the specified position in the rule list.
+     * @param index the position to insert the rule
+     * @param rule the rule to add
+     */
     @Override
     public void addRule(final int index, final Rule rule) {
         ruleList.add(index, rule);
@@ -69,6 +91,11 @@ public class RuleManagerImpl implements RuleManager {
      * @see
      * org.codelibs.fess.crawler.rule.RuleManager#hasRule(org.codelibs.fess.crawler.rule.Rule)
      */
+    /**
+     * Checks if the rule manager contains the specified rule.
+     * @param rule the rule to check for
+     * @return true if the rule is present, false otherwise
+     */
     @Override
     public boolean hasRule(final Rule rule) {
         return ruleList.contains(rule);
@@ -79,6 +106,11 @@ public class RuleManagerImpl implements RuleManager {
      *
      * @see
      * org.codelibs.fess.crawler.rule.RuleManager#removeRule(org.codelibs.fess.crawler.rule.Rule)
+     */
+    /**
+     * Removes the specified rule from the rule manager.
+     * @param rule The rule to be removed.
+     * @return true if the rule was successfully removed, false otherwise.
      */
     @Override
     public boolean removeRule(final Rule rule) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/impl/SitemapsRule.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/impl/SitemapsRule.java
@@ -38,6 +38,18 @@ public class SitemapsRule extends RegexRule {
 
     private static final Logger logger = LogManager.getLogger(SitemapsRule.class);
 
+    /**
+     * Creates a new SitemapsRule instance.
+     */
+    public SitemapsRule() {
+        super();
+    }
+
+    /**
+     * Matches the given response data against the sitemaps rule.
+     * @param responseData The response data.
+     * @return true if the response data matches the sitemaps rule, false otherwise.
+     */
     @Override
     public boolean match(final ResponseData responseData) {
         if (super.match(responseData)) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/service/UrlQueueService.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/service/UrlQueueService.java
@@ -23,26 +23,81 @@ import org.codelibs.fess.crawler.entity.UrlQueue;
  * Service interface for managing URL queues.
  * Provides methods for adding, retrieving, and managing URLs within a crawling session.
  *
+ * @param <QUEUE> the type of URL queue
  */
 public interface UrlQueueService<QUEUE extends UrlQueue<?>> {
 
+    /**
+     * Updates the session ID.
+     *
+     * @param oldSessionId The old session ID.
+     * @param newSessionId The new session ID.
+     */
     void updateSessionId(String oldSessionId, String newSessionId);
 
+    /**
+     * Adds a URL to the queue.
+     *
+     * @param sessionId The session ID.
+     * @param url The URL.
+     */
     void add(String sessionId, String url);
 
+    /**
+     * Inserts a URL queue.
+     *
+     * @param urlQueue The URL queue.
+     */
     void insert(QUEUE urlQueue);
 
+    /**
+     * Deletes a URL queue.
+     *
+     * @param sessionId The session ID.
+     */
     void delete(String sessionId);
 
+    /**
+     * Deletes all URL queues.
+     */
     void deleteAll();
 
+    /**
+     * Offers all URL queues.
+     *
+     * @param sessionId The session ID.
+     * @param newUrlQueueList The list of new URL queues.
+     */
     void offerAll(String sessionId, List<QUEUE> newUrlQueueList);
 
+    /**
+     * Polls a URL queue.
+     *
+     * @param sessionId The session ID.
+     * @return The URL queue.
+     */
     QUEUE poll(String sessionId);
 
+    /**
+     * Saves the session.
+     *
+     * @param sessionId The session ID.
+     */
     void saveSession(String sessionId);
 
+    /**
+     * Checks if a URL has been visited.
+     *
+     * @param urlQueue The URL queue.
+     * @return true if the URL has been visited, otherwise false.
+     */
     boolean visited(QUEUE urlQueue);
 
+    /**
+     * Generates URL queues.
+     *
+     * @param previousSessionId The previous session ID.
+     * @param sessionId The session ID.
+     */
     void generateUrlQueues(String previousSessionId, String sessionId);
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/service/impl/DataServiceImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/service/impl/DataServiceImpl.java
@@ -52,18 +52,28 @@ import jakarta.annotation.Resource;
  */
 public class DataServiceImpl implements DataService<AccessResultImpl<Long>> {
 
+    /** Counter for generating unique IDs */
     protected static volatile long idCount = 0L;
 
+    /** Lock object for synchronizing access to idCount */
     private static Object idCountLock = new Object();
 
+    /** Helper for managing access result data in memory */
     @Resource
     protected MemoryDataHelper dataHelper;
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Constructs a new DataServiceImpl.
+     */
+    public DataServiceImpl() {
+        // Default constructor
+    }
+
+    /**
+     * Stores an access result in the data store.
      *
-     * @see org.codelibs.fess.crawler.service.DataService#store(org.codelibs.fess.crawler.entity.
-     * AccessResult)
+     * @param accessResult the access result to store
+     * @throws CrawlerSystemException if the access result is null or already exists
      */
     @Override
     public void store(final AccessResultImpl<Long> accessResult) {
@@ -91,65 +101,64 @@ public class DataServiceImpl implements DataService<AccessResultImpl<Long>> {
 
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Gets the count of access results for the specified session.
      *
-     * @see org.codelibs.fess.crawler.service.DataService#getCount(java.lang.String)
+     * @param sessionId the session ID
+     * @return the count of access results
      */
     @Override
     public int getCount(final String sessionId) {
         return dataHelper.getAccessResultMap(sessionId).size();
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Deletes all access results for the specified session.
      *
-     * @see org.codelibs.fess.crawler.service.DataService#delete(java.lang.String)
+     * @param sessionId the session ID
      */
     @Override
     public void delete(final String sessionId) {
         dataHelper.deleteAccessResultMap(sessionId);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.service.DataService#deleteAll()
+    /**
+     * Deletes all access results from all sessions.
      */
     @Override
     public void deleteAll() {
         dataHelper.clearUrlQueueList();
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Gets an access result for the specified session and URL.
      *
-     * @see
-     * org.codelibs.fess.crawler.service.DataService#getAccessResult(java.lang.String,
-     * java.lang.String)
+     * @param sessionId the session ID
+     * @param url the URL
+     * @return the access result or null if not found
      */
     @Override
     public AccessResultImpl<Long> getAccessResult(final String sessionId, final String url) {
         return dataHelper.getAccessResultMap(sessionId).get(url);
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Gets a list of access results for the specified URL.
      *
-     * @see
-     * org.codelibs.fess.crawler.service.DataService#getAccessResultList(java.lang.String
-     * , boolean)
+     * @param url the URL
+     * @param hasData whether the result should have data
+     * @return the list of access results
      */
     @Override
     public List<AccessResultImpl<Long>> getAccessResultList(final String url, final boolean hasData) {
         return dataHelper.getAccessResultList(url);
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Iterates over all access results for the specified session.
      *
-     * @see org.codelibs.fess.crawler.service.DataService#iterate(java.lang.String,
-     * org.codelibs.fess.crawler.util.AccessResultCallback)
+     * @param sessionId the session ID
+     * @param accessResultCallback the callback to invoke for each access result
      */
     @Override
     public void iterate(final String sessionId, final AccessResultCallback<AccessResultImpl<Long>> accessResultCallback) {
@@ -159,11 +168,11 @@ public class DataServiceImpl implements DataService<AccessResultImpl<Long>> {
         }
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Updates an access result in the data store.
      *
-     * @see org.codelibs.fess.crawler.service.DataService#update(org.codelibs.fess.crawler.entity.
-     * AccessResult)
+     * @param accessResult the access result to update
+     * @throws CrawlerSystemException if the access result is not found
      */
     @Override
     public void update(final AccessResultImpl<Long> accessResult) {
@@ -174,10 +183,9 @@ public class DataServiceImpl implements DataService<AccessResultImpl<Long>> {
         arMap.put(accessResult.getUrl(), accessResult);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.codelibs.fess.crawler.service.DataService#update(java.util.List)
+    /**
+     * Updates the given list of access results.
+     * @param accessResultList The list of access results to update.
      */
     @Override
     public void update(final List<AccessResultImpl<Long>> accessResultList) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/service/impl/UrlFilterServiceImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/service/impl/UrlFilterServiceImpl.java
@@ -33,6 +33,16 @@ import jakarta.annotation.Resource;
  */
 public class UrlFilterServiceImpl implements UrlFilterService {
 
+    /**
+     * Creates a new UrlFilterServiceImpl instance.
+     */
+    public UrlFilterServiceImpl() {
+        // NOP
+    }
+
+    /**
+     * The memory data helper.
+     */
     @Resource
     protected MemoryDataHelper dataHelper;
 
@@ -127,6 +137,11 @@ public class UrlFilterServiceImpl implements UrlFilterService {
      * @see
      * org.codelibs.fess.crawler.service.impl.UrlFilterService#getExcludeUrlPatternList
      * (java.lang.String)
+     */
+    /**
+     * Retrieves a list of URL patterns to be excluded for a given session.
+     * @param sessionId The ID of the session.
+     * @return A list of compiled regular expression patterns.
      */
     @Override
     public List<Pattern> getExcludeUrlPatternList(final String sessionId) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/service/impl/UrlQueueServiceImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/service/impl/UrlQueueServiceImpl.java
@@ -63,10 +63,23 @@ import jakarta.annotation.Resource;
  * </p>
  *
  */
+/**
+ * This class is an implementation of {@link UrlQueueService}.
+ */
 public class UrlQueueServiceImpl implements UrlQueueService<UrlQueueImpl<Long>> {
+
+    /**
+     * Creates a new UrlQueueServiceImpl instance.
+     */
+    public UrlQueueServiceImpl() {
+        // NOP
+    }
 
     private static final Logger logger = LogManager.getLogger(UrlQueueServiceImpl.class);
 
+    /**
+     * The memory data helper.
+     */
     @Resource
     protected MemoryDataHelper dataHelper;
 
@@ -162,6 +175,13 @@ public class UrlQueueServiceImpl implements UrlQueueService<UrlQueueImpl<Long>> 
 
     }
 
+    /**
+     * Checks if a URL is new.
+     *
+     * @param urlQueue The URL queue.
+     * @param urlQueueList The list of URL queues.
+     * @return true if the URL is new, otherwise false.
+     */
     protected boolean isNewUrl(final UrlQueueImpl<Long> urlQueue, final Queue<UrlQueueImpl<Long>> urlQueueList) {
 
         final String url = urlQueue.getUrl();
@@ -232,6 +252,11 @@ public class UrlQueueServiceImpl implements UrlQueueService<UrlQueueImpl<Long>> 
         }
     }
 
+    /**
+     * Generates URL queues from a previous session's access results.
+     * @param previousSessionId The previous session ID.
+     * @param sessionId The current session ID.
+     */
     @Override
     public void generateUrlQueues(final String previousSessionId, final String sessionId) {
         final Queue<UrlQueueImpl<Long>> urlQueueList = dataHelper.getUrlQueueList(sessionId);

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/AbstractTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/AbstractTransformer.java
@@ -24,6 +24,16 @@ import org.codelibs.fess.crawler.transformer.Transformer;
  */
 public abstract class AbstractTransformer implements Transformer {
 
+    /**
+     * Creates a new instance of AbstractTransformer.
+     */
+    public AbstractTransformer() {
+        // NOP
+    }
+
+    /**
+     * The name of the transformer.
+     */
     protected String name;
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/BinaryTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/BinaryTransformer.java
@@ -50,12 +50,17 @@ import org.codelibs.fess.crawler.exception.CrawlingAccessException;
  */
 public class BinaryTransformer extends AbstractTransformer {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.codelibs.fess.crawler.transformer.Transformer#getData(org.codelibs.fess.crawler.entity
-     * .AccessResultData)
+    /**
+     * Constructs a new BinaryTransformer.
+     */
+    public BinaryTransformer() {
+        // NOP
+    }
+
+    /**
+     * Transforms the given ResponseData into a ResultData containing binary content.
+     * @param responseData The response data to be transformed.
+     * @return The transformed ResultData.
      */
     @Override
     public ResultData transform(final ResponseData responseData) {
@@ -76,12 +81,10 @@ public class BinaryTransformer extends AbstractTransformer {
 
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.codelibs.fess.crawler.transformer.Transformer#getData(org.codelibs.fess.crawler.entity
-     * .AccessResultData)
+    /**
+     * Retrieves data from the given AccessResultData object as a ByteArrayInputStream.
+     * @param accessResultData The AccessResultData object.
+     * @return A ByteArrayInputStream containing the data.
      */
     @Override
     public Object getData(final AccessResultData<?> accessResultData) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/FileTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/FileTransformer.java
@@ -62,7 +62,15 @@ import org.codelibs.fess.crawler.exception.CrawlerSystemException;
  * </p>
  */
 public class FileTransformer extends HtmlTransformer {
+    /** Logger instance for this class */
     private static final Logger logger = LogManager.getLogger(FileTransformer.class);
+
+    /**
+     * Constructs a new FileTransformer.
+     */
+    public FileTransformer() {
+        // Default constructor
+    }
 
     /**
      * A path to store downloaded files. The default path is a current
@@ -90,8 +98,10 @@ public class FileTransformer extends HtmlTransformer {
      */
     protected String ampersandStr = "_AMP_";
 
+    /** Maximum number of duplicated paths to attempt */
     protected int maxDuplicatedPath = 100;
 
+    /** Character set name for encoding file paths */
     protected String charsetName = Constants.UTF_8;
 
     /**
@@ -99,6 +109,13 @@ public class FileTransformer extends HtmlTransformer {
      */
     protected File baseDir;
 
+    /**
+     * Creates a file with the specified path, handling directory creation and duplicate names.
+     *
+     * @param path the file path to create
+     * @return the created file
+     * @throws CrawlerSystemException if directory creation fails
+     */
     protected File createFile(final String path) {
         final String[] paths = path.split("/");
         File targetFile = baseDir;
@@ -140,6 +157,13 @@ public class FileTransformer extends HtmlTransformer {
         return targetFile;
     }
 
+    /**
+     * Stores response data as a file on the file system.
+     *
+     * @param responseData the response data to store
+     * @param resultData the result data to populate with file information
+     * @throws CrawlerSystemException if file storage fails
+     */
     @Override
     public void storeData(final ResponseData responseData, final ResultData resultData) {
         resultData.setTransformerName(getName());
@@ -171,6 +195,11 @@ public class FileTransformer extends HtmlTransformer {
         resultData.setEncoding(charsetName);
     }
 
+    /**
+     * Initializes the base directory for storing files.
+     *
+     * @throws CrawlerSystemException if directory creation fails
+     */
     private void initBaseDir() {
         if (baseDir == null) {
             if (path == null) {
@@ -222,58 +251,127 @@ public class FileTransformer extends HtmlTransformer {
         return new File(baseDir, filePath);
     }
 
+    /**
+     * Gets the base path for storing files.
+     *
+     * @return the base path
+     */
     public String getPath() {
         return path;
     }
 
+    /**
+     * Sets the base path for storing files.
+     *
+     * @param path the base path to set
+     */
     public void setPath(final String path) {
         this.path = path;
     }
 
+    /**
+     * Gets the replacement string for question marks in URLs.
+     *
+     * @return the question mark replacement string
+     */
     public String getQuestionStr() {
         return questionStr;
     }
 
+    /**
+     * Sets the replacement string for question marks in URLs.
+     *
+     * @param questionStr the question mark replacement string to set
+     */
     public void setQuestionStr(final String questionStr) {
         this.questionStr = questionStr;
     }
 
+    /**
+     * Gets the replacement string for colons in URLs.
+     *
+     * @return the colon replacement string
+     */
     public String getColonStr() {
         return colonStr;
     }
 
+    /**
+     * Sets the replacement string for colons in URLs.
+     *
+     * @param colonStr the colon replacement string to set
+     */
     public void setColonStr(final String colonStr) {
         this.colonStr = colonStr;
     }
 
+    /**
+     * Gets the replacement string for semicolons in URLs.
+     *
+     * @return the semicolon replacement string
+     */
     public String getSemicolonStr() {
         return semicolonStr;
     }
 
+    /**
+     * Sets the replacement string for semicolons in URLs.
+     *
+     * @param semicolonStr the semicolon replacement string to set
+     */
     public void setSemicolonStr(final String semicolonStr) {
         this.semicolonStr = semicolonStr;
     }
 
+    /**
+     * Gets the replacement string for ampersands in URLs.
+     *
+     * @return the ampersand replacement string
+     */
     public String getAmpersandStr() {
         return ampersandStr;
     }
 
+    /**
+     * Sets the replacement string for ampersands in URLs.
+     *
+     * @param ampersandStr the ampersand replacement string to set
+     */
     public void setAmpersandStr(final String ampersandStr) {
         this.ampersandStr = ampersandStr;
     }
 
+    /**
+     * Gets the maximum number of duplicated paths to attempt.
+     *
+     * @return the maximum duplicated path count
+     */
     public int getMaxDuplicatedPath() {
         return maxDuplicatedPath;
     }
 
+    /**
+     * Sets the maximum number of duplicated paths to attempt.
+     *
+     * @param maxDuplicatedPath the maximum duplicated path count to set
+     */
     public void setMaxDuplicatedPath(final int maxDuplicatedPath) {
         this.maxDuplicatedPath = maxDuplicatedPath;
     }
 
+    /**
+     * Gets the character set name used for encoding file paths.
+     *
+     * @return the character set name
+     */
     public String getCharsetName() {
         return charsetName;
     }
 
+    /**
+     * Sets the charset name.
+     * @param charsetName The charset name to set.
+     */
     public void setCharsetName(final String charsetName) {
         this.charsetName = charsetName;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/TextTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/TextTransformer.java
@@ -58,10 +58,23 @@ import jakarta.annotation.Resource;
 public class TextTransformer extends AbstractTransformer {
     private static final Logger logger = LogManager.getLogger(TextTransformer.class);
 
+    /**
+     * The crawler container.
+     */
     @Resource
     protected CrawlerContainer crawlerContainer;
 
+    /**
+     * The name of the charset.
+     */
     protected String charsetName = Constants.UTF_8;
+
+    /**
+     * Creates a new TextTransformer instance.
+     */
+    public TextTransformer() {
+        super();
+    }
 
     /*
      * (non-Javadoc)
@@ -153,10 +166,18 @@ public class TextTransformer extends AbstractTransformer {
         }
     }
 
+    /**
+     * Returns the charset name.
+     * @return the charsetName
+     */
     public String getCharsetName() {
         return charsetName;
     }
 
+    /**
+     * Sets the charset name.
+     * @param charsetName The charset name to set.
+     */
     public void setCharsetName(final String charsetName) {
         this.charsetName = charsetName;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/XmlTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/XmlTransformer.java
@@ -118,29 +118,62 @@ public class XmlTransformer extends AbstractTransformer {
 
     private static final Pattern SPACE_PATTERN = Pattern.compile("\\s+", Pattern.MULTILINE);
 
+    /**
+     * If true, the parser will be namespace aware.
+     */
     protected boolean namespaceAware;
 
+    /**
+     * If true, the parser will convert CDATA nodes to Text nodes and append them to the adjacent Text node.
+     */
     protected boolean coalescing;
 
+    /**
+     * If true, the parser will expand entity reference nodes.
+     */
     protected boolean expandEntityRef = false;
 
+    /**
+     * If true, the parser will ignore comments.
+     */
     protected boolean ignoringComments;
 
+    /**
+     * If true, the parser will ignore ignorable whitespace in element content.
+     */
     protected boolean ignoringElementContentWhitespace;
 
+    /**
+     * If true, the parser will validate the document against its grammar.
+     */
     protected boolean validating;
 
+    /**
+     * If true, the parser will be XInclude aware.
+     */
     protected boolean includeAware;
 
+    /**
+     * A map of attributes.
+     */
     protected final Map<String, Object> attributeMap = new HashMap<>();
 
+    /**
+     * A map of features.
+     */
     protected final Map<String, String> featureMap = new HashMap<>();
 
+    /**
+     * A map of field rules.
+     */
     protected Map<String, String> fieldRuleMap = new LinkedHashMap<>();
 
     /** a flag to trim a space characters. */
     protected boolean trimSpaceEnabled = true;
 
+    /**
+     * The charset name.
+     */
     protected String charsetName = Constants.UTF_8;
 
     /**
@@ -149,10 +182,27 @@ public class XmlTransformer extends AbstractTransformer {
      */
     protected Class<?> dataClass = null;
 
+    /**
+     * The XPathAPI cache.
+     */
     protected LoadingCache<String, XPathAPI> xpathAPICache;
 
+    /**
+     * The cache duration in minutes.
+     */
     protected long cacheDuration = 10; // min
 
+    /**
+     * Constructs a new instance of {@code XmlTransformer}.
+     * This constructor initializes the transformer with default settings.
+     */
+    public XmlTransformer() {
+        super();
+    }
+
+    /**
+     * Initializes this component.
+     */
     @Resource
     public void init() {
         xpathAPICache =
@@ -294,12 +344,24 @@ public class XmlTransformer extends AbstractTransformer {
         }
     }
 
+    /**
+     * Retrieves a list of XPath nodes from the document.
+     *
+     * @param doc The XML document.
+     * @param xpath The XPath expression.
+     * @return A list of XPath nodes.
+     * @throws XPathExpressionException if an XPath expression error occurs.
+     */
     protected XPathNodes getNodeList(final Document doc, final String xpath) throws XPathExpressionException {
         final XPath xPathApi = getXPathAPI().createXPath(f -> {});
         xPathApi.setNamespaceContext(new DefaultNamespaceContext(doc.getNodeType() == Node.DOCUMENT_NODE ? doc.getDocumentElement() : doc));
         return xPathApi.evaluateExpression(xpath, doc, XPathNodes.class);
     }
 
+    /**
+     * Retrieves an XPathAPI instance from the cache or creates a new one.
+     * @return An XPathAPI instance.
+     */
     protected XPathAPI getXPathAPI() {
         try {
             return xpathAPICache.get(Thread.currentThread().getName());
@@ -311,17 +373,33 @@ public class XmlTransformer extends AbstractTransformer {
         }
     }
 
+    /**
+     * Returns the header for the result data.
+     * @return The result data header.
+     */
     protected String getResultDataHeader() {
         // TODO support other type
         return "<?xml version=\"1.0\"?>\n<doc>\n";
     }
 
+    /**
+     * Returns the body of the result data for a single value.
+     * @param name The name of the field.
+     * @param value The value of the field.
+     * @return The result data body.
+     */
     protected String getResultDataBody(final String name, final String value) {
         // TODO support other type
         // TODO trim(default)
         return "<field name=\"" + XmlUtil.escapeXml(name) + "\">" + trimSpace(XmlUtil.escapeXml(value != null ? value : "")) + "</field>\n";
     }
 
+    /**
+     * Returns the body of the result data for multiple values.
+     * @param name The name of the field.
+     * @param values The list of values for the field.
+     * @return The result data body.
+     */
     protected String getResultDataBody(final String name, final List<String> values) {
         final StringBuilder buf = new StringBuilder();
         buf.append("<list>");
@@ -338,15 +416,30 @@ public class XmlTransformer extends AbstractTransformer {
         return "<field name=\"" + XmlUtil.escapeXml(name) + "\">" + buf.toString().trim() + "</field>\n";
     }
 
+    /**
+     * Returns additional data for the result.
+     * @param responseData The response data.
+     * @param document The XML document.
+     * @return Additional data as a string.
+     */
     protected String getAdditionalData(final ResponseData responseData, final Document document) {
         return "";
     }
 
+    /**
+     * Returns the footer for the result data.
+     * @return The result data footer.
+     */
     protected String getResultDataFooter() {
         // TODO support other type
         return "</doc>";
     }
 
+    /**
+     * Trims space characters from the value.
+     * @param value The value to trim.
+     * @return The trimmed value.
+     */
     protected String trimSpace(final String value) {
         if (trimSpaceEnabled) {
             final Matcher matcher = SPACE_PATTERN.matcher(value);
@@ -355,19 +448,36 @@ public class XmlTransformer extends AbstractTransformer {
         return value;
     }
 
+    /**
+     * Adds an attribute to the factory.
+     * @param name The name of the attribute.
+     * @param value The value of the attribute.
+     */
     public void addAttribute(final String name, final Object value) {
         attributeMap.put(name, value);
     }
 
+    /**
+     * Adds a feature to the factory.
+     * @param key The key of the feature.
+     * @param value The value of the feature.
+     */
     public void addFeature(final String key, final String value) {
         featureMap.put(key, value);
     }
 
+    /**
+     * Adds a field rule.
+     * @param name The name of the field.
+     * @param xpath The XPath expression for the field.
+     */
     public void addFieldRule(final String name, final String xpath) {
         fieldRuleMap.put(name, xpath);
     }
 
     /**
+     * Returns the fieldRuleMap.
+     *
      * @return the fieldRuleMap
      */
     public Map<String, String> getFieldRuleMap() {
@@ -375,6 +485,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the fieldRuleMap.
+     *
      * @param fieldRuleMap the fieldRuleMap to set
      */
     public void setFieldRuleMap(final Map<String, String> fieldRuleMap) {
@@ -382,6 +494,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Returns the trimSpace.
+     *
      * @return the trimSpace
      */
     public boolean isTrimSpace() {
@@ -389,6 +503,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the trimSpace.
+     *
      * @param trimSpace the trimSpace to set
      */
     public void setTrimSpace(final boolean trimSpace) {
@@ -396,6 +512,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Returns the charsetName.
+     *
      * @return the charsetName
      */
     public String getCharsetName() {
@@ -403,6 +521,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the charsetName.
+     *
      * @param charsetName the charsetName to set
      */
     public void setCharsetName(final String charsetName) {
@@ -410,6 +530,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Returns the dataClass.
+     *
      * @return the dataClass
      */
     public Class<?> getDataClass() {
@@ -417,6 +539,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the dataClass.
+     *
      * @param dataClass the dataClass to set
      */
     public void setDataClass(final Class<?> dataClass) {
@@ -424,6 +548,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Returns the namespaceAware.
+     *
      * @return the namespaceAware
      */
     public boolean isNamespaceAware() {
@@ -431,6 +557,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the namespaceAware.
+     *
      * @param namespaceAware the namespaceAware to set
      */
     public void setNamespaceAware(final boolean namespaceAware) {
@@ -438,6 +566,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Returns the coalescing.
+     *
      * @return the coalescing
      */
     public boolean isCoalescing() {
@@ -445,6 +575,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the coalescing.
+     *
      * @param coalescing the coalescing to set
      */
     public void setCoalescing(final boolean coalescing) {
@@ -452,6 +584,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Returns the expandEntityRef.
+     *
      * @return the expandEntityRef
      */
     public boolean isExpandEntityRef() {
@@ -459,6 +593,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the expandEntityRef.
+     *
      * @param expandEntityRef the expandEntityRef to set
      */
     public void setExpandEntityRef(final boolean expandEntityRef) {
@@ -466,6 +602,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Returns the ignoringComments.
+     *
      * @return the ignoringComments
      */
     public boolean isIgnoringComments() {
@@ -473,6 +611,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the ignoringComments.
+     *
      * @param ignoringComments the ignoringComments to set
      */
     public void setIgnoringComments(final boolean ignoringComments) {
@@ -480,6 +620,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Returns the ignoringElementContentWhitespace.
+     *
      * @return the ignoringElementContentWhitespace
      */
     public boolean isIgnoringElementContentWhitespace() {
@@ -487,6 +629,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the ignoringElementContentWhitespace.
+     *
      * @param ignoringElementContentWhitespace the ignoringElementContentWhitespace to set
      */
     public void setIgnoringElementContentWhitespace(final boolean ignoringElementContentWhitespace) {
@@ -494,6 +638,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Returns the validating.
+     *
      * @return the validating
      */
     public boolean isValidating() {
@@ -501,6 +647,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the validating.
+     *
      * @param validating the validating to set
      */
     public void setValidating(final boolean validating) {
@@ -508,6 +656,8 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Returns the includeAware.
+     *
      * @return the includeAware
      */
     public boolean isIncludeAware() {
@@ -515,12 +665,18 @@ public class XmlTransformer extends AbstractTransformer {
     }
 
     /**
+     * Sets the includeAware.
+     *
      * @param includeAware the includeAware to set
      */
     public void setIncludeAware(final boolean includeAware) {
         this.includeAware = includeAware;
     }
 
+    /**
+     * Sets the cache duration.
+     * @param cacheDuration The cache duration in minutes.
+     */
     public void setCacheDuration(final long cacheDuration) {
         this.cacheDuration = cacheDuration;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/XpathTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/XpathTransformer.java
@@ -93,15 +93,29 @@ import org.xml.sax.InputSource;
  *
  */
 public class XpathTransformer extends HtmlTransformer {
+
+    /**
+     * Creates a new XpathTransformer instance.
+     */
+    public XpathTransformer() {
+        super();
+    }
+
     private static final Logger logger = LogManager.getLogger(XpathTransformer.class);
 
     private static final Pattern SPACE_PATTERN = Pattern.compile("\\s+", Pattern.MULTILINE);
 
+    /**
+     * A map of field rules, where the key is the field name and the value is the XPath expression.
+     */
     protected Map<String, String> fieldRuleMap = new LinkedHashMap<>();
 
     /** Flag to enable or disable trimming of whitespace characters. */
     protected boolean trimSpaceEnabled = true;
 
+    /**
+     * The charset name for the output.
+     */
     protected String charsetName = Constants.UTF_8;
 
     /**
@@ -184,17 +198,33 @@ public class XpathTransformer extends HtmlTransformer {
         resultData.setEncoding(charsetName);
     }
 
+    /**
+     * Returns the result data header.
+     * @return The result data header.
+     */
     protected String getResultDataHeader() {
         // TODO: Support other XML header types
         return "<?xml version=\"1.0\"?>\n<doc>\n";
     }
 
+    /**
+     * Returns the result data body for a single value.
+     * @param name The name of the field.
+     * @param value The value of the field.
+     * @return The result data body.
+     */
     protected String getResultDataBody(final String name, final String value) {
         // TODO: Support other XML footer types
         // TODO: Support other field types and trimming options
         return "<field name=\"" + XmlUtil.escapeXml(name) + "\">" + trimSpace(XmlUtil.escapeXml(value != null ? value : "")) + "</field>\n";
     }
 
+    /**
+     * Returns the result data body for multiple values.
+     * @param name The name of the field.
+     * @param values The list of values for the field.
+     * @return The result data body.
+     */
     protected String getResultDataBody(final String name, final List<String> values) {
         final StringBuilder buf = new StringBuilder();
         buf.append("<list>");
@@ -211,15 +241,30 @@ public class XpathTransformer extends HtmlTransformer {
         return "<field name=\"" + XmlUtil.escapeXml(name) + "\">" + buf.toString().trim() + "</field>\n";
     }
 
+    /**
+     * Returns the additional data for the response.
+     * @param responseData The response data.
+     * @param document The document.
+     * @return The additional data.
+     */
     protected String getAdditionalData(final ResponseData responseData, final Document document) {
         return "";
     }
 
+    /**
+     * Returns the result data footer.
+     * @return The result data footer.
+     */
     protected String getResultDataFooter() {
         // TODO support other type
         return "</doc>";
     }
 
+    /**
+     * Trims space characters from the value.
+     * @param value The value to trim.
+     * @return The trimmed value.
+     */
     protected String trimSpace(final String value) {
         if (trimSpaceEnabled) {
             final Matcher matcher = SPACE_PATTERN.matcher(value);
@@ -228,6 +273,11 @@ public class XpathTransformer extends HtmlTransformer {
         return value;
     }
 
+    /**
+     * Adds a field rule to the transformer.
+     * @param name The name of the field.
+     * @param xpath The XPath expression for the field.
+     */
     public void addFieldRule(final String name, final String xpath) {
         fieldRuleMap.put(name, xpath);
     }
@@ -257,34 +307,66 @@ public class XpathTransformer extends HtmlTransformer {
         }
     }
 
+    /**
+     * Returns the field rule map.
+     * @return The field rule map.
+     */
     public Map<String, String> getFieldRuleMap() {
         return fieldRuleMap;
     }
 
+    /**
+     * Sets the field rule map.
+     * @param fieldRuleMap The field rule map to set.
+     */
     public void setFieldRuleMap(final Map<String, String> fieldRuleMap) {
         this.fieldRuleMap = fieldRuleMap;
     }
 
+    /**
+     * Returns whether space trimming is enabled.
+     * @return True if space trimming is enabled, false otherwise.
+     */
     public boolean isTrimSpace() {
         return trimSpaceEnabled;
     }
 
+    /**
+     * Sets whether space trimming is enabled.
+     * @param trimSpace The trim space flag to set.
+     */
     public void setTrimSpace(final boolean trimSpace) {
         trimSpaceEnabled = trimSpace;
     }
 
+    /**
+     * Returns the charset name.
+     * @return The charset name.
+     */
     public String getCharsetName() {
         return charsetName;
     }
 
+    /**
+     * Sets the charset name.
+     * @param charsetName The charset name to set.
+     */
     public void setCharsetName(final String charsetName) {
         this.charsetName = charsetName;
     }
 
+    /**
+     * Returns the data class.
+     * @return The data class.
+     */
     public Class<?> getDataClass() {
         return dataClass;
     }
 
+    /**
+     * Sets the data class.
+     * @param dataClass The data class to set.
+     */
     public void setDataClass(final Class<?> dataClass) {
         this.dataClass = dataClass;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/AccessResultCallback.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/AccessResultCallback.java
@@ -28,5 +28,10 @@ public interface AccessResultCallback<RESULT extends AccessResult<?>> {
      *
      * @param accessResult the result of the access operation to be processed
      */
+    /**
+     * Processes the given access result.
+     *
+     * @param accessResult the result of the access operation to be processed
+     */
     void iterate(RESULT accessResult);
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/CharUtil.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/CharUtil.java
@@ -19,6 +19,9 @@ package org.codelibs.fess.crawler.util;
  * Utility class for character-related operations.
  */
 public final class CharUtil {
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
     private CharUtil() {
     }
 

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/IgnoreCloseInputStream.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/IgnoreCloseInputStream.java
@@ -27,67 +27,145 @@ import java.io.InputStream;
  */
 public class IgnoreCloseInputStream extends InputStream {
 
+    /** The wrapped input stream. */
     private transient InputStream inputStream;
 
+    /**
+     * Constructs a new IgnoreCloseInputStream that wraps the specified input stream.
+     *
+     * @param inputStream the input stream to wrap
+     */
     public IgnoreCloseInputStream(final InputStream inputStream) {
         this.inputStream = inputStream;
     }
 
+    /**
+     * Overrides the close method to ignore the close operation.
+     * The underlying input stream will not be closed.
+     *
+     * @throws IOException if an I/O error occurs (not thrown in this implementation)
+     */
     @Override
     public void close() throws IOException {
         // inputStream.close();
     }
 
+    /**
+     * Returns the number of bytes that can be read from this input stream without blocking.
+     *
+     * @return the number of bytes available
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public int available() throws IOException {
         return inputStream.available();
     }
 
+    /**
+     * Indicates whether some other object is equal to this one.
+     *
+     * @param obj the reference object with which to compare
+     * @return true if this object is the same as the obj argument; false otherwise
+     */
     @Override
     public boolean equals(final Object obj) {
         return inputStream.equals(obj);
     }
 
+    /**
+     * Returns a hash code value for the object.
+     *
+     * @return a hash code value for this object
+     */
     @Override
     public int hashCode() {
         return inputStream.hashCode();
     }
 
+    /**
+     * Marks the current position in this input stream.
+     *
+     * @param readlimit the maximum limit of bytes that can be read before the mark position becomes invalid
+     */
     @Override
     public synchronized void mark(final int readlimit) {
         inputStream.mark(readlimit);
     }
 
+    /**
+     * Tests if this input stream supports the mark and reset methods.
+     *
+     * @return true if this stream instance supports the mark and reset methods; false otherwise
+     */
     @Override
     public boolean markSupported() {
         return inputStream.markSupported();
     }
 
+    /**
+     * Reads the next byte of data from the input stream.
+     *
+     * @return the next byte of data, or -1 if the end of the stream is reached
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public int read() throws IOException {
         return inputStream.read();
     }
 
+    /**
+     * Reads up to len bytes of data from the input stream into an array of bytes.
+     *
+     * @param b the buffer into which the data is read
+     * @param off the start offset in array b at which the data is written
+     * @param len the maximum number of bytes to read
+     * @return the total number of bytes read into the buffer, or -1 if there is no more data
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public int read(final byte[] b, final int off, final int len) throws IOException {
         return inputStream.read(b, off, len);
     }
 
+    /**
+     * Reads some number of bytes from the input stream and stores them into the buffer array b.
+     *
+     * @param b the buffer into which the data is read
+     * @return the total number of bytes read into the buffer, or -1 if there is no more data
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public int read(final byte[] b) throws IOException {
         return inputStream.read(b);
     }
 
+    /**
+     * Repositions this stream to the position at the time the mark method was last called.
+     *
+     * @throws IOException if this stream has not been marked or if the mark has been invalidated
+     */
     @Override
     public synchronized void reset() throws IOException {
         inputStream.reset();
     }
 
+    /**
+     * Skips over and discards n bytes of data from this input stream.
+     *
+     * @param n the number of bytes to be skipped
+     * @return the actual number of bytes skipped
+     * @throws IOException if an I/O error occurs
+     */
     @Override
     public long skip(final long n) throws IOException {
         return inputStream.skip(n);
     }
 
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return a string representation of the object
+     */
     @Override
     public String toString() {
         return inputStream.toString();

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/ResponseDataUtil.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/ResponseDataUtil.java
@@ -30,6 +30,9 @@ import org.codelibs.fess.crawler.exception.CrawlingAccessException;
  */
 public final class ResponseDataUtil {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
     private ResponseDataUtil() {
     }
 

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/TemporaryFileInputStream.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/TemporaryFileInputStream.java
@@ -72,6 +72,10 @@ public class TemporaryFileInputStream extends InputStream {
         return fileInputStream.available();
     }
 
+    /**
+     * Closes this input stream and releases any system resources associated with the stream.
+     * @throws IOException if an I/O error occurs.
+     */
     @Override
     public void close() throws IOException {
         try {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/TextUtil.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/TextUtil.java
@@ -68,6 +68,9 @@ public final class TextUtil {
     private TextUtil() {
     }
 
+    /**
+     * This class provides a context for normalizing text.
+     */
     public static class TextNormalizeContext {
 
         private final Reader reader;
@@ -80,8 +83,15 @@ public final class TextUtil {
 
         private boolean duplicateTermRemoved = false;
 
+        /**
+         * Array of space characters. Default includes common space characters.
+         */
         private int[] spaceChars = { '\u0020', '\u00a0', '\u3000', '\ufffd' };
 
+        /**
+         * Constructor.
+         * @param reader The reader.
+         */
         public TextNormalizeContext(final Reader reader) {
             this.reader = reader;
         }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/XPathAPI.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/XPathAPI.java
@@ -50,6 +50,9 @@ public class XPathAPI {
 
     private final XPath xPath;
 
+    /**
+     * Creates a new XPathAPI instance.
+     */
     public XPathAPI() {
         xPath = createXPath(f -> {});
     }
@@ -79,7 +82,7 @@ public class XPathAPI {
      *  @param expression A valid XPath string.
      *  @return A XPathNodes, should never be null.
      *
-     * @throws XPathExpressionException
+     * @throws XPathExpressionException if an XPath expression error occurs.
      */
     public XPathNodes selectNodeList(final Node contextNode, final String expression) throws XPathExpressionException {
         return xPath.evaluateExpression(expression, contextNode, XPathNodes.class);
@@ -96,7 +99,7 @@ public class XPathAPI {
      *  @param expression A valid XPath string.
      *  @return An XPathEvaluationResult, which can be used to obtain a string, number, nodelist, etc, should never be null.
      *
-     * @throws XPathExpressionException
+     * @throws XPathExpressionException if an XPath expression error occurs.
      */
     public XPathEvaluationResult<?> eval(final Node contextNode, final String expression) throws XPathExpressionException {
         return xPath.evaluateExpression(expression, contextNode);
@@ -109,7 +112,7 @@ public class XPathAPI {
      * @param expression A valid XPath string.
      * @return The first node found that matches the XPath, or null.
      *
-     * @throws XPathExpressionException
+     * @throws XPathExpressionException if an XPath expression error occurs.
      */
     public Node selectSingleNode(final Node contextNode, final String expression) throws XPathExpressionException {
         return xPath.evaluateExpression(expression, contextNode, Node.class);

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/XmlUtil.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/XmlUtil.java
@@ -253,6 +253,10 @@ public final class XmlUtil {
             // nothing
         }
 
+        /**
+         * Returns the data map.
+         * @return The data map.
+         */
         public Map<String, Object> getDataMap() {
             return dataMap;
         }

--- a/fess-crawler/src/main/java/org/codelibs/fess/net/protocol/storage/Handler.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/net/protocol/storage/Handler.java
@@ -63,18 +63,53 @@ import io.minio.errors.XmlParserException;
  */
 public class Handler extends URLStreamHandler {
 
+    /**
+     * Constructs a new Handler.
+     */
+    public Handler() {
+        // Default constructor
+    }
+
+    /**
+     * Opens a connection to the storage URL.
+     *
+     * @param u The URL to open a connection to
+     * @return A new StorageURLConnection instance
+     * @throws IOException If the connection cannot be opened
+     */
     @Override
     protected URLConnection openConnection(final URL u) throws IOException {
         return new StorageURLConnection(u);
     }
 
+    /**
+     * StorageURLConnection is a URL connection implementation for accessing storage objects.
+     * It extends URLConnection to provide connectivity to MinIO-compatible storage services.
+     * This class handles the authentication, connection management, and data retrieval
+     * from storage buckets and objects.
+     *
+     * <p>
+     * The connection extracts bucket and object names from the URL and uses environment
+     * variables for authentication and endpoint configuration.
+     * </p>
+     */
     public class StorageURLConnection extends URLConnection {
 
+        /** The MinIO client for storage operations */
         private MinioClient minioClient;
+        /** The name of the storage bucket */
         private String bucketName;
+        /** The name of the storage object */
         private String objectName;
+        /** Cached object statistics response */
         private StatObjectResponse statObject;
 
+        /**
+         * Constructs a new StorageURLConnection for the specified URL.
+         * This constructor parses the URL to extract bucket and object names.
+         *
+         * @param url The storage URL to connect to
+         */
         protected StorageURLConnection(final URL url) {
             super(url);
             final String[] values = url.toExternalForm().split("/", 2);
@@ -91,6 +126,12 @@ public class Handler extends URLStreamHandler {
             }
         }
 
+        /**
+         * Establishes a connection to the storage service.
+         * This method creates a MinIO client using environment variables for configuration.
+         *
+         * @throws IOException If the connection cannot be established
+         */
         @Override
         public void connect() throws IOException {
             final String endpoint = System.getenv().get("STORAGE_ENDPOINT");
@@ -114,6 +155,12 @@ public class Handler extends URLStreamHandler {
             }
         }
 
+        /**
+         * Gets an input stream to read from the storage object.
+         *
+         * @return An input stream for reading the object content
+         * @throws IOException If the object cannot be accessed
+         */
         @Override
         public InputStream getInputStream() throws IOException {
             if (minioClient == null) {
@@ -128,6 +175,22 @@ public class Handler extends URLStreamHandler {
             }
         }
 
+        /**
+         * Gets the object statistics from the storage service.
+         * This method caches the response to avoid repeated calls.
+         *
+         * @return The object statistics response
+         * @throws InvalidKeyException If the access key is invalid
+         * @throws ErrorResponseException If the server returns an error
+         * @throws IllegalArgumentException If the arguments are invalid
+         * @throws InsufficientDataException If insufficient data is available
+         * @throws InternalException If an internal error occurs
+         * @throws InvalidResponseException If the response is invalid
+         * @throws NoSuchAlgorithmException If the algorithm is not available
+         * @throws XmlParserException If XML parsing fails
+         * @throws IOException If an I/O error occurs
+         * @throws ServerException If a server error occurs
+         */
         private StatObjectResponse getStatObject()
                 throws InvalidKeyException, ErrorResponseException, IllegalArgumentException, InsufficientDataException, InternalException,
                 InvalidResponseException, NoSuchAlgorithmException, XmlParserException, IOException, ServerException {
@@ -138,6 +201,11 @@ public class Handler extends URLStreamHandler {
             return statObject;
         }
 
+        /**
+         * Gets the content length of the storage object.
+         *
+         * @return The content length in bytes, or -1 if unavailable
+         */
         @Override
         public long getContentLengthLong() {
             if (minioClient == null) {
@@ -151,6 +219,11 @@ public class Handler extends URLStreamHandler {
             }
         }
 
+        /**
+         * Gets the content type of the storage object.
+         *
+         * @return The content type, or null if unavailable
+         */
         @Override
         public String getContentType() {
             if (minioClient == null) {
@@ -164,11 +237,21 @@ public class Handler extends URLStreamHandler {
             }
         }
 
+        /**
+         * Gets the date of the storage object.
+         * This method returns the same value as getLastModified().
+         *
+         * @return The date in milliseconds since epoch
+         */
         @Override
         public long getDate() {
             return getLastModified();
         }
 
+        /**
+         * Returns the last modified date of the storage object.
+         * @return The last modified date.
+         */
         @Override
         public long getLastModified() {
             if (minioClient == null) {


### PR DESCRIPTION
This pull request introduces extensive documentation and enhancements to classes related to OpenSearch integration within the `fess-crawler` project. The primary changes include the addition of JavaDoc comments to improve code readability, the definition of constants for field names, and the implementation of methods for converting entities to OpenSearch-compatible formats. Below is a summary of the most important changes grouped by themes.

### Documentation Improvements

* Added comprehensive JavaDoc comments to the `LastaCrawlerContainer` class, describing its purpose and method functionalities. (`[fess-crawler-lasta/src/main/java/org/codelibs/fess/crawler/container/LastaCrawlerContainer.javaR20-R30](diffhunk://#diff-8525a904d8284b9b71d6c12d62d770629cca5ac437efc1b54c0f940feb977f10R20-R30)`)
* Enhanced the `FesenClient` class with detailed JavaDoc comments for constants, methods, and fields, improving clarity on OpenSearch client functionalities. (`[[1]](diffhunk://#diff-8d27d1f72bbb5bfba562c16b9ba247289a704c9b067ace750a1ace764bd9e724R103-R183)`, `[[2]](diffhunk://#diff-8d27d1f72bbb5bfba562c16b9ba247289a704c9b067ace750a1ace764bd9e724R192-R221)`, `[[3]](diffhunk://#diff-8d27d1f72bbb5bfba562c16b9ba247289a704c9b067ace750a1ace764bd9e724R243-R261)`, `[[4]](diffhunk://#diff-8d27d1f72bbb5bfba562c16b9ba247289a704c9b067ace750a1ace764bd9e724R284-R286)`, `[[5]](diffhunk://#diff-8d27d1f72bbb5bfba562c16b9ba247289a704c9b067ace750a1ace764bd9e724R300-R346)`, `[[6]](diffhunk://#diff-8d27d1f72bbb5bfba562c16b9ba247289a704c9b067ace750a1ace764bd9e724R457-R462)`, `[[7]](diffhunk://#diff-8d27d1f72bbb5bfba562c16b9ba247289a704c9b067ace750a1ace764bd9e724R595-R603)`, `[[8]](diffhunk://#diff-8d27d1f72bbb5bfba562c16b9ba247289a704c9b067ace750a1ace764bd9e724R641-R711)`)
* Updated the `OpenSearchAccessResult` class with JavaDoc comments for fields and methods, detailing its role in handling OpenSearch access results. (`[[1]](diffhunk://#diff-914384ab390816816bb89e5beb7bc6c55cce7ab4909523d790c685437178134dR26-R121)`, `[[2]](diffhunk://#diff-914384ab390816816bb89e5beb7bc6c55cce7ab4909523d790c685437178134dR137-R141)`, `[[3]](diffhunk://#diff-914384ab390816816bb89e5beb7bc6c55cce7ab4909523d790c685437178134dR156-R174)`)
* Added JavaDoc comments to the `OpenSearchAccessResultData` class, explaining its fields and methods for handling OpenSearch access result data. (`[[1]](diffhunk://#diff-9642243a609f5bcb090c59f5053cd9c17b23fcf47c80638de43c538888fc02b6R26-R63)`, `[[2]](diffhunk://#diff-9642243a609f5bcb090c59f5053cd9c17b23fcf47c80638de43c538888fc02b6R77-R84)`)
* Documented the `OpenSearchUrlFilter` class to describe its purpose and methods for URL filtering in OpenSearch. (`[fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/entity/OpenSearchUrlFilter.javaR23-R141](diffhunk://#diff-96837c0838826a66c0156f994e2b79be5b2bb41401de1a1ba9356f13bbb00778R23-R141)`)
* Improved the `OpenSearchUrlQueue` class documentation, describing its fields and methods for managing URL queues in OpenSearch. (`[fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/entity/OpenSearchUrlQueue.javaR23-R87](diffhunk://#diff-ed56a88100a0d03faf424efa5427399a6ce1d56afa70e3d71337aadd373196f6R23-R87)`)

### OpenSearch Integration Enhancements

* Defined constants for field names in `OpenSearchAccessResult`, `OpenSearchAccessResultData`, `OpenSearchUrlFilter`, and `OpenSearchUrlQueue` classes, standardizing field references for OpenSearch operations. (`[[1]](diffhunk://#diff-914384ab390816816bb89e5beb7bc6c55cce7ab4909523d790c685437178134dR26-R121)`, `[[2]](diffhunk://#diff-9642243a609f5bcb090c59f5053cd9c17b23fcf47c80638de43c538888fc02b6R26-R63)`, `[[3]](diffhunk://#diff-96837c0838826a66c0156f994e2b79be5b2bb41401de1a1ba9356f13bbb00778R23-R141)`, `[[4]](diffhunk://#diff-ed56a88100a0d03faf424efa5427399a6ce1d56afa70e3d71337aadd373196f6R23-R87)`)
* Implemented methods for converting entities (`OpenSearchAccessResult`, `OpenSearchAccessResultData`, `OpenSearchUrlFilter`, and `OpenSearchUrlQueue`) to OpenSearch-compatible formats using `XContentBuilder`. (`[[1]](diffhunk://#diff-914384ab390816816bb89e5beb7bc6c55cce7ab4909523d790c685437178134dR156-R174)`, `[[2]](diffhunk://#diff-9642243a609f5bcb090c59f5053cd9c17b23fcf47c80638de43c538888fc02b6R77-R84)`, `[[3]](diffhunk://#diff-96837c0838826a66c0156f994e2b79be5b2bb41401de1a1ba9356f13bbb00778R23-R141)`, `[[4]](diffhunk://#diff-ed56a88100a0d03faf424efa5427399a6ce1d56afa70e3d71337aadd373196f6R23-R87)`)