### PR TITLE
Update project and parent version to 15.2.0-SNAPSHOT

### DIFF
--- a/fess-crawler-lasta/pom.xml
+++ b/fess-crawler-lasta/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-crawler-parent</artifactId>
-		<version>15.1.1-SNAPSHOT</version>
+		<version>15.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<build>

--- a/fess-crawler-opensearch/pom.xml
+++ b/fess-crawler-opensearch/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-crawler-parent</artifactId>
-		<version>15.1.1-SNAPSHOT</version>
+		<version>15.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<build>

--- a/fess-crawler/pom.xml
+++ b/fess-crawler/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-crawler-parent</artifactId>
-		<version>15.1.1-SNAPSHOT</version>
+		<version>15.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.fess</groupId>
 	<artifactId>fess-crawler-parent</artifactId>
-	<version>15.1.1-SNAPSHOT</version>
+	<version>15.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Fess Crawler Project</name>
 	<description>Fess Crawler is Crawler Framework.</description>
@@ -42,7 +42,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0</version>
+		<version>15.2.0-SNAPSHOT</version>
 	</parent>
 	<modules>
 		<module>fess-crawler</module>


### PR DESCRIPTION
This pull request updates the Maven project version of fess-suggest from 15.1.1-SNAPSHOT to 15.2.0-SNAPSHOT. Additionally, it updates the parent POM version from 15.1.0 to 15.2.0-SNAPSHOT to align with the new development cycle.
