### PR TITLE
Add comprehensive unit tests for crawler components and update AbstractRule serialization

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/impl/AbstractRule.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/rule/impl/AbstractRule.java
@@ -50,7 +50,7 @@ public abstract class AbstractRule implements Rule {
 
     /** The crawler container. */
     @Resource
-    protected CrawlerContainer crawlerContainer;
+    protected transient CrawlerContainer crawlerContainer;
 
     /**
      * Constructs a new AbstractRule.

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerContextTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerContextTest.java
@@ -1,0 +1,738 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.codelibs.core.collection.LruHashSet;
+import org.codelibs.fess.crawler.entity.ResponseData;
+import org.codelibs.fess.crawler.filter.UrlFilter;
+import org.codelibs.fess.crawler.interval.IntervalController;
+import org.codelibs.fess.crawler.rule.Rule;
+import org.codelibs.fess.crawler.rule.RuleManager;
+import org.dbflute.utflute.core.PlainTestCase;
+
+/**
+ * Test class for CrawlerContext.
+ * Tests all functionality including thread safety and concurrent operations.
+ */
+public class CrawlerContextTest extends PlainTestCase {
+
+    private CrawlerContext crawlerContext;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        crawlerContext = new CrawlerContext();
+    }
+
+    /**
+     * Test implementation of UrlFilter for testing
+     */
+    private static class TestUrlFilter implements UrlFilter {
+        @Override
+        public void init(String sessionId) {
+        }
+
+        @Override
+        public void addInclude(String urlPattern) {
+        }
+
+        @Override
+        public void addExclude(String urlPattern) {
+        }
+
+        @Override
+        public boolean match(String url) {
+            return true;
+        }
+
+        @Override
+        public void processUrl(String url) {
+        }
+
+        @Override
+        public void clear() {
+        }
+    }
+
+    /**
+     * Test implementation of RuleManager for testing
+     */
+    private static class TestRuleManager implements RuleManager {
+        @Override
+        public Rule getRule(ResponseData responseData) {
+            return null;
+        }
+
+        @Override
+        public void addRule(Rule rule) {
+        }
+
+        @Override
+        public void addRule(int index, Rule rule) {
+        }
+
+        @Override
+        public boolean removeRule(Rule rule) {
+            return false;
+        }
+
+        @Override
+        public boolean hasRule(Rule rule) {
+            return false;
+        }
+    }
+
+    /**
+     * Test implementation of IntervalController for testing
+     */
+    private static class TestIntervalController implements IntervalController {
+        @Override
+        public void delay(int type) {
+        }
+
+        public void delayBeforeProcessing() {
+        }
+
+        public void delayAfterProcessing() {
+        }
+
+        public void delayAtNoUrlInQueue() {
+        }
+
+        public void delayForWaitingNewUrl() {
+        }
+    }
+
+    /**
+     * Test default constructor
+     */
+    public void test_constructor() {
+        CrawlerContext context = new CrawlerContext();
+        assertNotNull(context);
+        assertNull(context.getSessionId());
+        assertEquals(0, context.getActiveThreadCount().intValue());
+        assertEquals(0L, context.getAccessCount());
+        assertEquals(CrawlerStatus.INITIALIZING, context.getStatus());
+        assertNull(context.getUrlFilter());
+        assertNull(context.getRuleManager());
+        assertNull(context.getIntervalController());
+        assertNotNull(context.getRobotsTxtUrlSet());
+        assertEquals(10, context.getNumOfThread());
+        assertEquals(20, context.getMaxThreadCheckCount());
+        assertEquals(-1, context.getMaxDepth());
+        assertEquals(0L, context.getMaxAccessCount());
+    }
+
+    /**
+     * Test sessionId getter and setter
+     */
+    public void test_sessionId() {
+        assertNull(crawlerContext.getSessionId());
+
+        crawlerContext.setSessionId("test-session-001");
+        assertEquals("test-session-001", crawlerContext.getSessionId());
+
+        crawlerContext.setSessionId(null);
+        assertNull(crawlerContext.getSessionId());
+
+        crawlerContext.setSessionId("");
+        assertEquals("", crawlerContext.getSessionId());
+
+        // Test with special characters
+        crawlerContext.setSessionId("session-with-特殊文字-#123");
+        assertEquals("session-with-特殊文字-#123", crawlerContext.getSessionId());
+    }
+
+    /**
+     * Test activeThreadCount getter and setter
+     */
+    public void test_activeThreadCount() {
+        assertEquals(0, crawlerContext.getActiveThreadCount().intValue());
+
+        crawlerContext.setActiveThreadCount(5);
+        assertEquals(5, crawlerContext.getActiveThreadCount().intValue());
+
+        crawlerContext.setActiveThreadCount(0);
+        assertEquals(0, crawlerContext.getActiveThreadCount().intValue());
+
+        crawlerContext.setActiveThreadCount(-1);
+        assertEquals(-1, crawlerContext.getActiveThreadCount().intValue());
+
+        crawlerContext.setActiveThreadCount(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, crawlerContext.getActiveThreadCount().intValue());
+
+        crawlerContext.setActiveThreadCount(null);
+        assertNull(crawlerContext.getActiveThreadCount());
+    }
+
+    /**
+     * Test accessCount operations
+     */
+    public void test_accessCount() {
+        assertEquals(0L, crawlerContext.getAccessCount());
+
+        // Test increment
+        assertEquals(1L, crawlerContext.incrementAndGetAccessCount());
+        assertEquals(1L, crawlerContext.getAccessCount());
+
+        assertEquals(2L, crawlerContext.incrementAndGetAccessCount());
+        assertEquals(2L, crawlerContext.getAccessCount());
+
+        // Test decrement
+        assertEquals(1L, crawlerContext.decrementAndGetAccessCount());
+        assertEquals(1L, crawlerContext.getAccessCount());
+
+        assertEquals(0L, crawlerContext.decrementAndGetAccessCount());
+        assertEquals(0L, crawlerContext.getAccessCount());
+
+        // Test decrement below zero
+        assertEquals(-1L, crawlerContext.decrementAndGetAccessCount());
+        assertEquals(-1L, crawlerContext.getAccessCount());
+    }
+
+    /**
+     * Test concurrent access count operations
+     */
+    public void test_accessCount_concurrent() throws Exception {
+        final int threadCount = 100;
+        final int operationsPerThread = 1000;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        startLatch.await();
+                        for (int j = 0; j < operationsPerThread; j++) {
+                            crawlerContext.incrementAndGetAccessCount();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }
+            });
+        }
+
+        startLatch.countDown();
+        endLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals(threadCount * operationsPerThread, crawlerContext.getAccessCount());
+    }
+
+    /**
+     * Test status getter and setter
+     */
+    public void test_status() {
+        assertEquals(CrawlerStatus.INITIALIZING, crawlerContext.getStatus());
+
+        crawlerContext.setStatus(CrawlerStatus.RUNNING);
+        assertEquals(CrawlerStatus.RUNNING, crawlerContext.getStatus());
+
+        crawlerContext.setStatus(CrawlerStatus.DONE);
+        assertEquals(CrawlerStatus.DONE, crawlerContext.getStatus());
+
+        crawlerContext.setStatus(null);
+        assertNull(crawlerContext.getStatus());
+    }
+
+    /**
+     * Test urlFilter getter and setter
+     */
+    public void test_urlFilter() {
+        assertNull(crawlerContext.getUrlFilter());
+
+        TestUrlFilter filter = new TestUrlFilter();
+        crawlerContext.setUrlFilter(filter);
+        assertSame(filter, crawlerContext.getUrlFilter());
+
+        crawlerContext.setUrlFilter(null);
+        assertNull(crawlerContext.getUrlFilter());
+    }
+
+    /**
+     * Test ruleManager getter and setter
+     */
+    public void test_ruleManager() {
+        assertNull(crawlerContext.getRuleManager());
+
+        TestRuleManager manager = new TestRuleManager();
+        crawlerContext.setRuleManager(manager);
+        assertSame(manager, crawlerContext.getRuleManager());
+
+        crawlerContext.setRuleManager(null);
+        assertNull(crawlerContext.getRuleManager());
+    }
+
+    /**
+     * Test intervalController getter and setter
+     */
+    public void test_intervalController() {
+        assertNull(crawlerContext.getIntervalController());
+
+        TestIntervalController controller = new TestIntervalController();
+        crawlerContext.setIntervalController(controller);
+        assertSame(controller, crawlerContext.getIntervalController());
+
+        crawlerContext.setIntervalController(null);
+        assertNull(crawlerContext.getIntervalController());
+    }
+
+    /**
+     * Test robotsTxtUrlSet getter and setter
+     */
+    public void test_robotsTxtUrlSet() {
+        Set<String> urlSet = crawlerContext.getRobotsTxtUrlSet();
+        assertNotNull(urlSet);
+        assertTrue(urlSet instanceof LruHashSet);
+        assertTrue(urlSet.isEmpty());
+
+        // Add URLs to default set
+        urlSet.add("http://example.com/robots.txt");
+        urlSet.add("http://test.com/robots.txt");
+        assertEquals(2, crawlerContext.getRobotsTxtUrlSet().size());
+
+        // Set new set
+        Set<String> newSet = new HashSet<>();
+        newSet.add("http://new.com/robots.txt");
+        crawlerContext.setRobotsTxtUrlSet(newSet);
+        assertSame(newSet, crawlerContext.getRobotsTxtUrlSet());
+        assertEquals(1, crawlerContext.getRobotsTxtUrlSet().size());
+
+        // Set null
+        crawlerContext.setRobotsTxtUrlSet(null);
+        assertNull(crawlerContext.getRobotsTxtUrlSet());
+    }
+
+    /**
+     * Test LRU behavior of robotsTxtUrlSet
+     */
+    public void test_robotsTxtUrlSet_lru() {
+        Set<String> urlSet = crawlerContext.getRobotsTxtUrlSet();
+
+        // Add URLs up to capacity (10000)
+        for (int i = 0; i < 10000; i++) {
+            urlSet.add("http://example" + i + ".com/robots.txt");
+        }
+        assertEquals(10000, urlSet.size());
+
+        // Add one more should maintain size at 10000 (LRU eviction)
+        urlSet.add("http://overflow.com/robots.txt");
+        assertEquals(10000, urlSet.size());
+        assertTrue(urlSet.contains("http://overflow.com/robots.txt"));
+        assertFalse(urlSet.contains("http://example0.com/robots.txt")); // First one should be evicted
+    }
+
+    /**
+     * Test activeThreadCountLock getter
+     */
+    public void test_activeThreadCountLock() {
+        Object lock = crawlerContext.getActiveThreadCountLock();
+        assertNotNull(lock);
+
+        // Should return same instance
+        Object sameLock = crawlerContext.getActiveThreadCountLock();
+        assertSame(lock, sameLock);
+    }
+
+    /**
+     * Test numOfThread getter and setter
+     */
+    public void test_numOfThread() {
+        assertEquals(10, crawlerContext.getNumOfThread());
+
+        crawlerContext.setNumOfThread(5);
+        assertEquals(5, crawlerContext.getNumOfThread());
+
+        crawlerContext.setNumOfThread(0);
+        assertEquals(0, crawlerContext.getNumOfThread());
+
+        crawlerContext.setNumOfThread(-1);
+        assertEquals(-1, crawlerContext.getNumOfThread());
+
+        crawlerContext.setNumOfThread(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, crawlerContext.getNumOfThread());
+    }
+
+    /**
+     * Test maxThreadCheckCount getter and setter
+     */
+    public void test_maxThreadCheckCount() {
+        assertEquals(20, crawlerContext.getMaxThreadCheckCount());
+
+        crawlerContext.setMaxThreadCheckCount(50);
+        assertEquals(50, crawlerContext.getMaxThreadCheckCount());
+
+        crawlerContext.setMaxThreadCheckCount(0);
+        assertEquals(0, crawlerContext.getMaxThreadCheckCount());
+
+        crawlerContext.setMaxThreadCheckCount(-1);
+        assertEquals(-1, crawlerContext.getMaxThreadCheckCount());
+
+        crawlerContext.setMaxThreadCheckCount(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, crawlerContext.getMaxThreadCheckCount());
+    }
+
+    /**
+     * Test maxDepth getter and setter
+     */
+    public void test_maxDepth() {
+        assertEquals(-1, crawlerContext.getMaxDepth());
+
+        crawlerContext.setMaxDepth(5);
+        assertEquals(5, crawlerContext.getMaxDepth());
+
+        crawlerContext.setMaxDepth(0);
+        assertEquals(0, crawlerContext.getMaxDepth());
+
+        crawlerContext.setMaxDepth(-1);
+        assertEquals(-1, crawlerContext.getMaxDepth());
+
+        crawlerContext.setMaxDepth(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, crawlerContext.getMaxDepth());
+    }
+
+    /**
+     * Test maxAccessCount getter and setter
+     */
+    public void test_maxAccessCount() {
+        assertEquals(0L, crawlerContext.getMaxAccessCount());
+
+        crawlerContext.setMaxAccessCount(1000L);
+        assertEquals(1000L, crawlerContext.getMaxAccessCount());
+
+        crawlerContext.setMaxAccessCount(0L);
+        assertEquals(0L, crawlerContext.getMaxAccessCount());
+
+        crawlerContext.setMaxAccessCount(-1L);
+        assertEquals(-1L, crawlerContext.getMaxAccessCount());
+
+        crawlerContext.setMaxAccessCount(Long.MAX_VALUE);
+        assertEquals(Long.MAX_VALUE, crawlerContext.getMaxAccessCount());
+    }
+
+    /**
+     * Test sitemaps add and remove operations
+     */
+    public void test_sitemaps() {
+        // Initial state
+        assertNull(crawlerContext.removeSitemaps());
+
+        // Add sitemaps
+        String[] sitemaps = new String[] { "http://example.com/sitemap.xml", "http://test.com/sitemap.xml" };
+        crawlerContext.addSitemaps(sitemaps);
+
+        // Remove and verify
+        String[] removedSitemaps = crawlerContext.removeSitemaps();
+        assertNotNull(removedSitemaps);
+        assertEquals(2, removedSitemaps.length);
+        assertEquals("http://example.com/sitemap.xml", removedSitemaps[0]);
+        assertEquals("http://test.com/sitemap.xml", removedSitemaps[1]);
+
+        // Should be null after removal
+        assertNull(crawlerContext.removeSitemaps());
+
+        // Test with null
+        crawlerContext.addSitemaps(null);
+        assertNull(crawlerContext.removeSitemaps());
+
+        // Test with empty array
+        crawlerContext.addSitemaps(new String[0]);
+        String[] emptyArray = crawlerContext.removeSitemaps();
+        assertNotNull(emptyArray);
+        assertEquals(0, emptyArray.length);
+    }
+
+    /**
+     * Test thread-local nature of sitemaps
+     */
+    public void test_sitemaps_threadLocal() throws Exception {
+        final String[] thread1Sitemaps = new String[] { "http://thread1.com/sitemap.xml" };
+        final String[] thread2Sitemaps = new String[] { "http://thread2.com/sitemap.xml" };
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(2);
+        final AtomicInteger successCount = new AtomicInteger(0);
+
+        Thread thread1 = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    startLatch.await();
+                    crawlerContext.addSitemaps(thread1Sitemaps);
+                    String[] retrieved = crawlerContext.removeSitemaps();
+                    if (retrieved != null && retrieved.length == 1 && "http://thread1.com/sitemap.xml".equals(retrieved[0])) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            }
+        });
+
+        Thread thread2 = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    startLatch.await();
+                    crawlerContext.addSitemaps(thread2Sitemaps);
+                    String[] retrieved = crawlerContext.removeSitemaps();
+                    if (retrieved != null && retrieved.length == 1 && "http://thread2.com/sitemap.xml".equals(retrieved[0])) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+        startLatch.countDown();
+        endLatch.await(5, TimeUnit.SECONDS);
+
+        assertEquals(2, successCount.get());
+    }
+
+    /**
+     * Test concurrent operations on different fields
+     */
+    public void test_concurrentOperations() throws Exception {
+        final int threadCount = 10;
+        final int operationsPerThread = 100;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+        final List<Exception> exceptions = new ArrayList<>();
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        startLatch.await();
+                        for (int j = 0; j < operationsPerThread; j++) {
+                            // Perform various operations
+                            crawlerContext.setSessionId("session-" + threadId + "-" + j);
+                            crawlerContext.setActiveThreadCount(threadId);
+                            crawlerContext.incrementAndGetAccessCount();
+                            crawlerContext.setStatus(CrawlerStatus.RUNNING);
+                            crawlerContext.setNumOfThread(threadId);
+                            crawlerContext.setMaxDepth(j);
+                            crawlerContext.setMaxAccessCount(threadId * 1000L + j);
+
+                            // Add and remove sitemaps
+                            String[] sitemaps = new String[] { "http://thread" + threadId + ".com/sitemap" + j + ".xml" };
+                            crawlerContext.addSitemaps(sitemaps);
+                            crawlerContext.removeSitemaps();
+
+                            // Access robots.txt URL set
+                            crawlerContext.getRobotsTxtUrlSet().add("http://thread" + threadId + ".com/robots.txt");
+                        }
+                    } catch (Exception e) {
+                        synchronized (exceptions) {
+                            exceptions.add(e);
+                        }
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }
+            });
+        }
+
+        startLatch.countDown();
+        endLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertTrue(exceptions.isEmpty());
+        assertEquals(threadCount * operationsPerThread, crawlerContext.getAccessCount());
+    }
+
+    /**
+     * Test complete workflow scenario
+     */
+    public void test_completeWorkflow() {
+        // Initialize context
+        crawlerContext.setSessionId("workflow-session");
+        crawlerContext.setStatus(CrawlerStatus.INITIALIZING);
+        crawlerContext.setNumOfThread(5);
+        crawlerContext.setMaxDepth(3);
+        crawlerContext.setMaxAccessCount(1000L);
+        crawlerContext.setMaxThreadCheckCount(30);
+
+        // Set components
+        crawlerContext.setUrlFilter(new TestUrlFilter());
+        crawlerContext.setRuleManager(new TestRuleManager());
+        crawlerContext.setIntervalController(new TestIntervalController());
+
+        // Start crawling
+        crawlerContext.setStatus(CrawlerStatus.RUNNING);
+        crawlerContext.setActiveThreadCount(5);
+
+        // Simulate crawling progress
+        for (int i = 0; i < 100; i++) {
+            crawlerContext.incrementAndGetAccessCount();
+            crawlerContext.getRobotsTxtUrlSet().add("http://site" + i + ".com/robots.txt");
+        }
+
+        // Add sitemaps
+        crawlerContext.addSitemaps(new String[] { "http://example.com/sitemap.xml" });
+
+        // Complete crawling
+        crawlerContext.setActiveThreadCount(0);
+        crawlerContext.setStatus(CrawlerStatus.DONE);
+
+        // Verify final state
+        assertEquals("workflow-session", crawlerContext.getSessionId());
+        assertEquals(CrawlerStatus.DONE, crawlerContext.getStatus());
+        assertEquals(0, crawlerContext.getActiveThreadCount().intValue());
+        assertEquals(100L, crawlerContext.getAccessCount());
+        assertEquals(100, crawlerContext.getRobotsTxtUrlSet().size());
+        assertNotNull(crawlerContext.removeSitemaps());
+    }
+
+    /**
+     * Test boundary values
+     */
+    public void test_boundaryValues() {
+        // Test with maximum values
+        crawlerContext.setActiveThreadCount(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, crawlerContext.getActiveThreadCount().intValue());
+
+        crawlerContext.setNumOfThread(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, crawlerContext.getNumOfThread());
+
+        crawlerContext.setMaxThreadCheckCount(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, crawlerContext.getMaxThreadCheckCount());
+
+        crawlerContext.setMaxDepth(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, crawlerContext.getMaxDepth());
+
+        crawlerContext.setMaxAccessCount(Long.MAX_VALUE);
+        assertEquals(Long.MAX_VALUE, crawlerContext.getMaxAccessCount());
+
+        // Test with minimum values
+        crawlerContext.setActiveThreadCount(Integer.MIN_VALUE);
+        assertEquals(Integer.MIN_VALUE, crawlerContext.getActiveThreadCount().intValue());
+
+        crawlerContext.setNumOfThread(Integer.MIN_VALUE);
+        assertEquals(Integer.MIN_VALUE, crawlerContext.getNumOfThread());
+
+        crawlerContext.setMaxThreadCheckCount(Integer.MIN_VALUE);
+        assertEquals(Integer.MIN_VALUE, crawlerContext.getMaxThreadCheckCount());
+
+        crawlerContext.setMaxDepth(Integer.MIN_VALUE);
+        assertEquals(Integer.MIN_VALUE, crawlerContext.getMaxDepth());
+
+        crawlerContext.setMaxAccessCount(Long.MIN_VALUE);
+        assertEquals(Long.MIN_VALUE, crawlerContext.getMaxAccessCount());
+    }
+
+    /**
+     * Test access count atomic operations
+     */
+    public void test_accessCountAtomicOperations() {
+        // Verify atomic nature by checking return values
+        assertEquals(1L, crawlerContext.incrementAndGetAccessCount());
+        assertEquals(2L, crawlerContext.incrementAndGetAccessCount());
+        assertEquals(3L, crawlerContext.incrementAndGetAccessCount());
+
+        assertEquals(2L, crawlerContext.decrementAndGetAccessCount());
+        assertEquals(1L, crawlerContext.decrementAndGetAccessCount());
+
+        // Test large increments
+        for (int i = 0; i < 1000; i++) {
+            crawlerContext.incrementAndGetAccessCount();
+        }
+        assertEquals(1001L, crawlerContext.getAccessCount());
+
+        // Test large decrements
+        for (int i = 0; i < 500; i++) {
+            crawlerContext.decrementAndGetAccessCount();
+        }
+        assertEquals(501L, crawlerContext.getAccessCount());
+    }
+
+    /**
+     * Test volatile status field behavior
+     */
+    public void test_statusVolatile() throws Exception {
+        final CountDownLatch statusSetLatch = new CountDownLatch(1);
+        final CountDownLatch statusReadLatch = new CountDownLatch(1);
+        final AtomicInteger successCount = new AtomicInteger(0);
+
+        crawlerContext.setStatus(CrawlerStatus.INITIALIZING);
+
+        Thread writer = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    statusSetLatch.await();
+                    crawlerContext.setStatus(CrawlerStatus.DONE);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+
+        Thread reader = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    statusSetLatch.countDown();
+                    // Wait a bit for writer to update
+                    Thread.sleep(100);
+                    if (CrawlerStatus.DONE == crawlerContext.getStatus()) {
+                        successCount.incrementAndGet();
+                    }
+                    statusReadLatch.countDown();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+
+        writer.start();
+        reader.start();
+
+        statusReadLatch.await(5, TimeUnit.SECONDS);
+
+        assertEquals(1, successCount.get());
+        assertEquals(CrawlerStatus.DONE, crawlerContext.getStatus());
+    }
+}

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerStatusTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerStatusTest.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.dbflute.utflute.core.PlainTestCase;
+
+/**
+ * Test class for CrawlerStatus enum.
+ * Tests all enum functionality including values, valueOf, ordinal, and serialization.
+ */
+public class CrawlerStatusTest extends PlainTestCase {
+
+    /**
+     * Test that all expected enum values exist
+     */
+    public void test_enumValues() {
+        CrawlerStatus[] values = CrawlerStatus.values();
+
+        assertNotNull(values);
+        assertEquals(3, values.length);
+
+        // Verify all expected values exist
+        assertEquals(CrawlerStatus.INITIALIZING, values[0]);
+        assertEquals(CrawlerStatus.RUNNING, values[1]);
+        assertEquals(CrawlerStatus.DONE, values[2]);
+    }
+
+    /**
+     * Test valueOf method with valid values
+     */
+    public void test_valueOf_valid() {
+        assertEquals(CrawlerStatus.INITIALIZING, CrawlerStatus.valueOf("INITIALIZING"));
+        assertEquals(CrawlerStatus.RUNNING, CrawlerStatus.valueOf("RUNNING"));
+        assertEquals(CrawlerStatus.DONE, CrawlerStatus.valueOf("DONE"));
+    }
+
+    /**
+     * Test valueOf method with invalid values
+     */
+    public void test_valueOf_invalid() {
+        try {
+            CrawlerStatus.valueOf("INVALID");
+            fail("Should throw IllegalArgumentException for invalid value");
+        } catch (IllegalArgumentException e) {
+            // Expected
+            assertTrue(e.getMessage().contains("INVALID"));
+        }
+
+        try {
+            CrawlerStatus.valueOf("initializing"); // lowercase
+            fail("Should throw IllegalArgumentException for lowercase value");
+        } catch (IllegalArgumentException e) {
+            // Expected
+            assertTrue(e.getMessage().contains("initializing"));
+        }
+
+        try {
+            CrawlerStatus.valueOf("");
+            fail("Should throw IllegalArgumentException for empty string");
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        try {
+            CrawlerStatus.valueOf(" RUNNING "); // with spaces
+            fail("Should throw IllegalArgumentException for value with spaces");
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    /**
+     * Test valueOf method with null
+     */
+    public void test_valueOf_null() {
+        try {
+            CrawlerStatus.valueOf(null);
+            fail("Should throw NullPointerException for null value");
+        } catch (NullPointerException e) {
+            // Expected
+        }
+    }
+
+    /**
+     * Test name method
+     */
+    public void test_name() {
+        assertEquals("INITIALIZING", CrawlerStatus.INITIALIZING.name());
+        assertEquals("RUNNING", CrawlerStatus.RUNNING.name());
+        assertEquals("DONE", CrawlerStatus.DONE.name());
+    }
+
+    /**
+     * Test ordinal method
+     */
+    public void test_ordinal() {
+        assertEquals(0, CrawlerStatus.INITIALIZING.ordinal());
+        assertEquals(1, CrawlerStatus.RUNNING.ordinal());
+        assertEquals(2, CrawlerStatus.DONE.ordinal());
+    }
+
+    /**
+     * Test toString method
+     */
+    public void test_toString() {
+        assertEquals("INITIALIZING", CrawlerStatus.INITIALIZING.toString());
+        assertEquals("RUNNING", CrawlerStatus.RUNNING.toString());
+        assertEquals("DONE", CrawlerStatus.DONE.toString());
+    }
+
+    /**
+     * Test equals method
+     */
+    public void test_equals() {
+        // Same instance
+        assertTrue(CrawlerStatus.INITIALIZING.equals(CrawlerStatus.INITIALIZING));
+        assertTrue(CrawlerStatus.RUNNING.equals(CrawlerStatus.RUNNING));
+        assertTrue(CrawlerStatus.DONE.equals(CrawlerStatus.DONE));
+
+        // Different instances
+        assertFalse(CrawlerStatus.INITIALIZING.equals(CrawlerStatus.RUNNING));
+        assertFalse(CrawlerStatus.INITIALIZING.equals(CrawlerStatus.DONE));
+        assertFalse(CrawlerStatus.RUNNING.equals(CrawlerStatus.DONE));
+
+        // Null comparison
+        assertFalse(CrawlerStatus.INITIALIZING.equals(null));
+
+        // Different type comparison
+        assertFalse(CrawlerStatus.INITIALIZING.equals("INITIALIZING"));
+        assertFalse(CrawlerStatus.INITIALIZING.equals(0));
+    }
+
+    /**
+     * Test hashCode method
+     */
+    public void test_hashCode() {
+        // Same status should have same hashCode
+        CrawlerStatus status1 = CrawlerStatus.INITIALIZING;
+        CrawlerStatus status2 = CrawlerStatus.INITIALIZING;
+        assertEquals(status1.hashCode(), status2.hashCode());
+
+        // Different statuses likely have different hashCodes (not guaranteed but typical)
+        Set<Integer> hashCodes = new HashSet<>();
+        hashCodes.add(CrawlerStatus.INITIALIZING.hashCode());
+        hashCodes.add(CrawlerStatus.RUNNING.hashCode());
+        hashCodes.add(CrawlerStatus.DONE.hashCode());
+
+        // While not guaranteed, typically enum hashCodes are different
+        assertTrue(hashCodes.size() > 1);
+    }
+
+    /**
+     * Test compareTo method
+     */
+    public void test_compareTo() {
+        // Compare with self
+        assertEquals(0, CrawlerStatus.INITIALIZING.compareTo(CrawlerStatus.INITIALIZING));
+        assertEquals(0, CrawlerStatus.RUNNING.compareTo(CrawlerStatus.RUNNING));
+        assertEquals(0, CrawlerStatus.DONE.compareTo(CrawlerStatus.DONE));
+
+        // INITIALIZING < RUNNING < DONE (based on ordinal)
+        assertTrue(CrawlerStatus.INITIALIZING.compareTo(CrawlerStatus.RUNNING) < 0);
+        assertTrue(CrawlerStatus.INITIALIZING.compareTo(CrawlerStatus.DONE) < 0);
+        assertTrue(CrawlerStatus.RUNNING.compareTo(CrawlerStatus.DONE) < 0);
+
+        // Reverse comparisons
+        assertTrue(CrawlerStatus.RUNNING.compareTo(CrawlerStatus.INITIALIZING) > 0);
+        assertTrue(CrawlerStatus.DONE.compareTo(CrawlerStatus.INITIALIZING) > 0);
+        assertTrue(CrawlerStatus.DONE.compareTo(CrawlerStatus.RUNNING) > 0);
+    }
+
+    /**
+     * Test getDeclaringClass method
+     */
+    public void test_getDeclaringClass() {
+        assertEquals(CrawlerStatus.class, CrawlerStatus.INITIALIZING.getDeclaringClass());
+        assertEquals(CrawlerStatus.class, CrawlerStatus.RUNNING.getDeclaringClass());
+        assertEquals(CrawlerStatus.class, CrawlerStatus.DONE.getDeclaringClass());
+    }
+
+    /**
+     * Test serialization and deserialization
+     */
+    public void test_serialization() throws Exception {
+        // Test each enum value
+        CrawlerStatus[] statuses = CrawlerStatus.values();
+
+        for (CrawlerStatus original : statuses) {
+            // Serialize
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(original);
+            oos.close();
+
+            // Deserialize
+            ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+            ObjectInputStream ois = new ObjectInputStream(bais);
+            CrawlerStatus deserialized = (CrawlerStatus) ois.readObject();
+            ois.close();
+
+            // Verify - enum instances are singletons
+            assertSame(original, deserialized);
+            assertEquals(original.name(), deserialized.name());
+            assertEquals(original.ordinal(), deserialized.ordinal());
+        }
+    }
+
+    /**
+     * Test EnumSet functionality
+     */
+    public void test_enumSet() {
+        // Create EnumSet with all values
+        EnumSet<CrawlerStatus> allStatuses = EnumSet.allOf(CrawlerStatus.class);
+        assertEquals(3, allStatuses.size());
+        assertTrue(allStatuses.contains(CrawlerStatus.INITIALIZING));
+        assertTrue(allStatuses.contains(CrawlerStatus.RUNNING));
+        assertTrue(allStatuses.contains(CrawlerStatus.DONE));
+
+        // Create EnumSet with specific values
+        EnumSet<CrawlerStatus> activeStatuses = EnumSet.of(CrawlerStatus.INITIALIZING, CrawlerStatus.RUNNING);
+        assertEquals(2, activeStatuses.size());
+        assertTrue(activeStatuses.contains(CrawlerStatus.INITIALIZING));
+        assertTrue(activeStatuses.contains(CrawlerStatus.RUNNING));
+        assertFalse(activeStatuses.contains(CrawlerStatus.DONE));
+
+        // Create empty EnumSet
+        EnumSet<CrawlerStatus> emptySet = EnumSet.noneOf(CrawlerStatus.class);
+        assertEquals(0, emptySet.size());
+
+        // Create EnumSet with range
+        EnumSet<CrawlerStatus> rangeSet = EnumSet.range(CrawlerStatus.INITIALIZING, CrawlerStatus.RUNNING);
+        assertEquals(2, rangeSet.size());
+        assertTrue(rangeSet.contains(CrawlerStatus.INITIALIZING));
+        assertTrue(rangeSet.contains(CrawlerStatus.RUNNING));
+        assertFalse(rangeSet.contains(CrawlerStatus.DONE));
+    }
+
+    /**
+     * Test switch statement usage
+     */
+    public void test_switchStatement() {
+        for (CrawlerStatus status : CrawlerStatus.values()) {
+            String description = getStatusDescription(status);
+            assertNotNull(description);
+            assertFalse(description.isEmpty());
+        }
+    }
+
+    /**
+     * Helper method to test switch statement
+     */
+    private String getStatusDescription(CrawlerStatus status) {
+        switch (status) {
+        case INITIALIZING:
+            return "Crawler is initializing";
+        case RUNNING:
+            return "Crawler is running";
+        case DONE:
+            return "Crawler has completed";
+        default:
+            fail("Unexpected status: " + status);
+            return null;
+        }
+    }
+
+    /**
+     * Test state transitions (typical workflow)
+     */
+    public void test_stateTransitions() {
+        // Simulate typical crawler lifecycle
+        CrawlerStatus currentStatus = CrawlerStatus.INITIALIZING;
+        assertEquals(CrawlerStatus.INITIALIZING, currentStatus);
+
+        // Transition to RUNNING
+        currentStatus = CrawlerStatus.RUNNING;
+        assertEquals(CrawlerStatus.RUNNING, currentStatus);
+
+        // Transition to DONE
+        currentStatus = CrawlerStatus.DONE;
+        assertEquals(CrawlerStatus.DONE, currentStatus);
+
+        // Verify ordinal progression
+        assertTrue(CrawlerStatus.INITIALIZING.ordinal() < CrawlerStatus.RUNNING.ordinal());
+        assertTrue(CrawlerStatus.RUNNING.ordinal() < CrawlerStatus.DONE.ordinal());
+    }
+
+    /**
+     * Test usage in conditional statements
+     */
+    public void test_conditionalStatements() {
+        CrawlerStatus status = CrawlerStatus.RUNNING;
+
+        // Test with if-else
+        if (status == CrawlerStatus.INITIALIZING) {
+            fail("Should not be INITIALIZING");
+        } else if (status == CrawlerStatus.RUNNING) {
+            // Expected
+            assertTrue(true);
+        } else if (status == CrawlerStatus.DONE) {
+            fail("Should not be DONE");
+        }
+
+        // Test with ternary operator
+        String message = (status == CrawlerStatus.RUNNING) ? "Running" : "Not Running";
+        assertEquals("Running", message);
+
+        // Test with logical operators
+        assertTrue(status == CrawlerStatus.RUNNING || status == CrawlerStatus.DONE);
+        assertFalse(status == CrawlerStatus.INITIALIZING && status == CrawlerStatus.DONE);
+    }
+
+    /**
+     * Test null safety in comparisons
+     */
+    public void test_nullSafety() {
+        CrawlerStatus status = CrawlerStatus.INITIALIZING;
+        CrawlerStatus nullStatus = null;
+
+        // Enum == null should be false
+        assertFalse(status == nullStatus);
+        assertFalse(status.equals(nullStatus));
+
+        // null == Enum should be false
+        assertFalse(nullStatus == status);
+
+        // Verify no NullPointerException when comparing with ==
+        boolean result = (nullStatus == CrawlerStatus.INITIALIZING);
+        assertFalse(result);
+    }
+
+    /**
+     * Test thread safety of enum
+     */
+    public void test_threadSafety() throws Exception {
+        final int threadCount = 100;
+        final int iterationsPerThread = 1000;
+        final Set<Exception> exceptions = new HashSet<>();
+
+        Thread[] threads = new Thread[threadCount];
+        for (int i = 0; i < threadCount; i++) {
+            threads[i] = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        for (int j = 0; j < iterationsPerThread; j++) {
+                            // Access enum values
+                            CrawlerStatus[] values = CrawlerStatus.values();
+                            assertEquals(3, values.length);
+
+                            // Use valueOf
+                            CrawlerStatus status = CrawlerStatus.valueOf("RUNNING");
+                            assertEquals(CrawlerStatus.RUNNING, status);
+
+                            // Compare values
+                            assertTrue(CrawlerStatus.INITIALIZING.compareTo(CrawlerStatus.DONE) < 0);
+                        }
+                    } catch (Exception e) {
+                        synchronized (exceptions) {
+                            exceptions.add(e);
+                        }
+                    }
+                }
+            });
+        }
+
+        // Start all threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // Wait for all threads to complete
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // Verify no exceptions
+        assertTrue(exceptions.isEmpty());
+    }
+
+    /**
+     * Test memory reference equality
+     */
+    public void test_memoryReferenceEquality() {
+        // Enum instances are singletons
+        CrawlerStatus status1 = CrawlerStatus.INITIALIZING;
+        CrawlerStatus status2 = CrawlerStatus.INITIALIZING;
+
+        // Should be the same instance
+        assertSame(status1, status2);
+        assertTrue(status1 == status2);
+
+        // valueOf should return the same instance
+        CrawlerStatus status3 = CrawlerStatus.valueOf("INITIALIZING");
+        assertSame(status1, status3);
+        assertTrue(status1 == status3);
+
+        // values() array contains the same instances
+        CrawlerStatus status4 = CrawlerStatus.values()[0];
+        assertSame(status1, status4);
+        assertTrue(status1 == status4);
+    }
+
+    /**
+     * Test enum as map key
+     */
+    public void test_enumAsMapKey() {
+        java.util.Map<CrawlerStatus, String> statusMap = new java.util.HashMap<>();
+
+        // Add entries
+        statusMap.put(CrawlerStatus.INITIALIZING, "Starting up");
+        statusMap.put(CrawlerStatus.RUNNING, "In progress");
+        statusMap.put(CrawlerStatus.DONE, "Completed");
+
+        // Verify entries
+        assertEquals(3, statusMap.size());
+        assertEquals("Starting up", statusMap.get(CrawlerStatus.INITIALIZING));
+        assertEquals("In progress", statusMap.get(CrawlerStatus.RUNNING));
+        assertEquals("Completed", statusMap.get(CrawlerStatus.DONE));
+
+        // Test with EnumMap for better performance
+        java.util.EnumMap<CrawlerStatus, String> enumMap = new java.util.EnumMap<>(CrawlerStatus.class);
+        enumMap.put(CrawlerStatus.INITIALIZING, "Init");
+        enumMap.put(CrawlerStatus.RUNNING, "Run");
+        enumMap.put(CrawlerStatus.DONE, "Done");
+
+        assertEquals(3, enumMap.size());
+        assertTrue(enumMap.containsKey(CrawlerStatus.INITIALIZING));
+        assertTrue(enumMap.containsKey(CrawlerStatus.RUNNING));
+        assertTrue(enumMap.containsKey(CrawlerStatus.DONE));
+    }
+}

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/exception/CrawlerSystemExceptionTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/exception/CrawlerSystemExceptionTest.java
@@ -1,0 +1,534 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.exception;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Constructor;
+
+import org.dbflute.utflute.core.PlainTestCase;
+
+/**
+ * Test class for CrawlerSystemException.
+ * Tests all constructors and exception functionality including message, cause, suppression, and stack trace.
+ */
+public class CrawlerSystemExceptionTest extends PlainTestCase {
+
+    /**
+     * Test constructor with message only
+     */
+    public void test_constructor_withMessage() {
+        String message = "Test error message";
+        CrawlerSystemException exception = new CrawlerSystemException(message);
+
+        assertNotNull(exception);
+        assertEquals(message, exception.getMessage());
+        assertNull(exception.getCause());
+        assertTrue(exception instanceof RuntimeException);
+        assertTrue(exception instanceof Throwable);
+    }
+
+    /**
+     * Test constructor with null message
+     */
+    public void test_constructor_withNullMessage() {
+        CrawlerSystemException exception = new CrawlerSystemException((String) null);
+
+        assertNotNull(exception);
+        assertNull(exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    /**
+     * Test constructor with empty message
+     */
+    public void test_constructor_withEmptyMessage() {
+        CrawlerSystemException exception = new CrawlerSystemException("");
+
+        assertNotNull(exception);
+        assertEquals("", exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    /**
+     * Test constructor with very long message
+     */
+    public void test_constructor_withVeryLongMessage() {
+        StringBuilder longMessage = new StringBuilder();
+        for (int i = 0; i < 10000; i++) {
+            longMessage.append("Very long error message ");
+        }
+        String message = longMessage.toString();
+
+        CrawlerSystemException exception = new CrawlerSystemException(message);
+
+        assertNotNull(exception);
+        assertEquals(message, exception.getMessage());
+        assertEquals(240000, exception.getMessage().length());
+    }
+
+    /**
+     * Test constructor with special characters in message
+     */
+    public void test_constructor_withSpecialCharactersInMessage() {
+        String message = "Error: \n\t\r\0\b\f with special chars #@!$%^&*()[]{}";
+        CrawlerSystemException exception = new CrawlerSystemException(message);
+
+        assertNotNull(exception);
+        assertEquals(message, exception.getMessage());
+    }
+
+    /**
+     * Test constructor with cause only
+     */
+    public void test_constructor_withCause() {
+        Exception cause = new IllegalArgumentException("Root cause");
+        CrawlerSystemException exception = new CrawlerSystemException(cause);
+
+        assertNotNull(exception);
+        assertSame(cause, exception.getCause());
+        // When constructed with cause only, message should be cause's toString()
+        assertEquals("java.lang.IllegalArgumentException: Root cause", exception.getMessage());
+    }
+
+    /**
+     * Test constructor with null cause
+     */
+    public void test_constructor_withNullCause() {
+        CrawlerSystemException exception = new CrawlerSystemException((Throwable) null);
+
+        assertNotNull(exception);
+        assertNull(exception.getCause());
+        assertNull(exception.getMessage());
+    }
+
+    /**
+     * Test constructor with various cause types
+     */
+    public void test_constructor_withVariousCauseTypes() {
+        // With Exception cause
+        Exception exceptionCause = new Exception("Exception cause");
+        CrawlerSystemException exception1 = new CrawlerSystemException(exceptionCause);
+        assertSame(exceptionCause, exception1.getCause());
+
+        // With Error cause
+        Error errorCause = new Error("Error cause");
+        CrawlerSystemException exception2 = new CrawlerSystemException(errorCause);
+        assertSame(errorCause, exception2.getCause());
+
+        // With RuntimeException cause
+        RuntimeException runtimeCause = new RuntimeException("Runtime cause");
+        CrawlerSystemException exception3 = new CrawlerSystemException(runtimeCause);
+        assertSame(runtimeCause, exception3.getCause());
+
+        // With another CrawlerSystemException cause
+        CrawlerSystemException crawlerCause = new CrawlerSystemException("Crawler cause");
+        CrawlerSystemException exception4 = new CrawlerSystemException(crawlerCause);
+        assertSame(crawlerCause, exception4.getCause());
+    }
+
+    /**
+     * Test constructor with message and cause
+     */
+    public void test_constructor_withMessageAndCause() {
+        String message = "Custom error message";
+        Exception cause = new IOException("IO error occurred");
+        CrawlerSystemException exception = new CrawlerSystemException(message, cause);
+
+        assertNotNull(exception);
+        assertEquals(message, exception.getMessage());
+        assertSame(cause, exception.getCause());
+    }
+
+    /**
+     * Test constructor with null message and valid cause
+     */
+    public void test_constructor_withNullMessageAndValidCause() {
+        Exception cause = new IllegalStateException("State error");
+        CrawlerSystemException exception = new CrawlerSystemException(null, cause);
+
+        assertNotNull(exception);
+        assertNull(exception.getMessage());
+        assertSame(cause, exception.getCause());
+    }
+
+    /**
+     * Test constructor with valid message and null cause
+     */
+    public void test_constructor_withValidMessageAndNullCause() {
+        String message = "Error without cause";
+        CrawlerSystemException exception = new CrawlerSystemException(message, null);
+
+        assertNotNull(exception);
+        assertEquals(message, exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    /**
+     * Test constructor with both null message and null cause
+     */
+    public void test_constructor_withNullMessageAndNullCause() {
+        CrawlerSystemException exception = new CrawlerSystemException(null, null);
+
+        assertNotNull(exception);
+        assertNull(exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    /**
+     * Test protected constructor with suppression and stack trace control
+     */
+    public void test_protectedConstructor_withSuppressionAndStackTrace() throws Exception {
+        // Access protected constructor via reflection
+        Constructor<CrawlerSystemException> constructor =
+                CrawlerSystemException.class.getDeclaredConstructor(String.class, boolean.class, boolean.class);
+        constructor.setAccessible(true);
+
+        // Test with suppression enabled and writable stack trace
+        String message1 = "Test with suppression enabled";
+        CrawlerSystemException exception1 = constructor.newInstance(message1, true, true);
+        assertNotNull(exception1);
+        assertEquals(message1, exception1.getMessage());
+        assertNull(exception1.getCause());
+
+        // Test with suppression disabled and writable stack trace
+        String message2 = "Test with suppression disabled";
+        CrawlerSystemException exception2 = constructor.newInstance(message2, false, true);
+        assertNotNull(exception2);
+        assertEquals(message2, exception2.getMessage());
+
+        // Test with suppression enabled and non-writable stack trace
+        String message3 = "Test with non-writable stack trace";
+        CrawlerSystemException exception3 = constructor.newInstance(message3, true, false);
+        assertNotNull(exception3);
+        assertEquals(message3, exception3.getMessage());
+
+        // Test with both disabled
+        String message4 = "Test with both disabled";
+        CrawlerSystemException exception4 = constructor.newInstance(message4, false, false);
+        assertNotNull(exception4);
+        assertEquals(message4, exception4.getMessage());
+    }
+
+    /**
+     * Test protected constructor with null message
+     */
+    public void test_protectedConstructor_withNullMessage() throws Exception {
+        Constructor<CrawlerSystemException> constructor =
+                CrawlerSystemException.class.getDeclaredConstructor(String.class, boolean.class, boolean.class);
+        constructor.setAccessible(true);
+
+        CrawlerSystemException exception = constructor.newInstance(null, true, true);
+        assertNotNull(exception);
+        assertNull(exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    /**
+     * Test stack trace functionality
+     */
+    public void test_stackTrace() {
+        CrawlerSystemException exception = new CrawlerSystemException("Stack trace test");
+
+        StackTraceElement[] stackTrace = exception.getStackTrace();
+        assertNotNull(stackTrace);
+        assertTrue(stackTrace.length > 0);
+
+        // First element should be from this test class
+        StackTraceElement firstElement = stackTrace[0];
+        assertEquals(this.getClass().getName(), firstElement.getClassName());
+        assertEquals("test_stackTrace", firstElement.getMethodName());
+    }
+
+    /**
+     * Test stack trace with cause
+     */
+    public void test_stackTraceWithCause() {
+        Exception cause = new IllegalArgumentException("Cause exception");
+        CrawlerSystemException exception = new CrawlerSystemException("Main exception", cause);
+
+        StackTraceElement[] mainStackTrace = exception.getStackTrace();
+        StackTraceElement[] causeStackTrace = cause.getStackTrace();
+
+        assertNotNull(mainStackTrace);
+        assertNotNull(causeStackTrace);
+        assertTrue(mainStackTrace.length > 0);
+        assertTrue(causeStackTrace.length > 0);
+
+        // Stack traces should be different
+        assertNotSame(mainStackTrace, causeStackTrace);
+    }
+
+    /**
+     * Test printStackTrace functionality
+     */
+    public void test_printStackTrace() {
+        CrawlerSystemException exception = new CrawlerSystemException("Print stack trace test");
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        exception.printStackTrace(printWriter);
+
+        String stackTraceOutput = stringWriter.toString();
+        assertNotNull(stackTraceOutput);
+        assertTrue(stackTraceOutput.contains("CrawlerSystemException"));
+        assertTrue(stackTraceOutput.contains("Print stack trace test"));
+        assertTrue(stackTraceOutput.contains(this.getClass().getName()));
+    }
+
+    /**
+     * Test printStackTrace with cause
+     */
+    public void test_printStackTraceWithCause() {
+        Exception cause = new IOException("IO error");
+        CrawlerSystemException exception = new CrawlerSystemException("Wrapper exception", cause);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        exception.printStackTrace(printWriter);
+
+        String stackTraceOutput = stringWriter.toString();
+        assertNotNull(stackTraceOutput);
+        assertTrue(stackTraceOutput.contains("CrawlerSystemException"));
+        assertTrue(stackTraceOutput.contains("Wrapper exception"));
+        assertTrue(stackTraceOutput.contains("Caused by:"));
+        assertTrue(stackTraceOutput.contains("IOException"));
+        assertTrue(stackTraceOutput.contains("IO error"));
+    }
+
+    /**
+     * Test exception chaining
+     */
+    public void test_exceptionChaining() {
+        Exception level3 = new IllegalArgumentException("Level 3 - Root cause");
+        Exception level2 = new IllegalStateException("Level 2", level3);
+        Exception level1 = new IOException("Level 1", level2);
+        CrawlerSystemException topLevel = new CrawlerSystemException("Top level", level1);
+
+        // Verify chain
+        assertSame(level1, topLevel.getCause());
+        assertSame(level2, topLevel.getCause().getCause());
+        assertSame(level3, topLevel.getCause().getCause().getCause());
+        assertNull(topLevel.getCause().getCause().getCause().getCause());
+
+        // Verify messages
+        assertEquals("Top level", topLevel.getMessage());
+        assertEquals("Level 1", level1.getMessage());
+        assertEquals("Level 2", level2.getMessage());
+        assertEquals("Level 3 - Root cause", level3.getMessage());
+    }
+
+    /**
+     * Test serialization
+     */
+    public void test_serialization() throws Exception {
+        String message = "Serialization test";
+        Exception cause = new IOException("IO cause");
+        CrawlerSystemException original = new CrawlerSystemException(message, cause);
+
+        // Serialize
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(original);
+        oos.close();
+
+        // Deserialize
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        CrawlerSystemException deserialized = (CrawlerSystemException) ois.readObject();
+        ois.close();
+
+        // Verify
+        assertNotNull(deserialized);
+        assertEquals(original.getMessage(), deserialized.getMessage());
+        assertNotNull(deserialized.getCause());
+        assertEquals(original.getCause().getMessage(), deserialized.getCause().getMessage());
+        assertEquals(original.getCause().getClass(), deserialized.getCause().getClass());
+    }
+
+    /**
+     * Test throwing and catching the exception
+     */
+    public void test_throwAndCatch() {
+        try {
+            throw new CrawlerSystemException("Test throw");
+        } catch (CrawlerSystemException e) {
+            assertEquals("Test throw", e.getMessage());
+            assertNull(e.getCause());
+        }
+
+        try {
+            throw new CrawlerSystemException("Test with cause", new IllegalArgumentException("Cause"));
+        } catch (CrawlerSystemException e) {
+            assertEquals("Test with cause", e.getMessage());
+            assertNotNull(e.getCause());
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+        }
+    }
+
+    /**
+     * Test exception in method that declares throws
+     */
+    public void test_exceptionInMethod() {
+        try {
+            methodThatThrowsException();
+            fail("Should have thrown CrawlerSystemException");
+        } catch (CrawlerSystemException e) {
+            assertEquals("Method exception", e.getMessage());
+        }
+    }
+
+    private void methodThatThrowsException() {
+        throw new CrawlerSystemException("Method exception");
+    }
+
+    /**
+     * Test exception inheritance
+     */
+    public void test_inheritance() {
+        CrawlerSystemException exception = new CrawlerSystemException("Test");
+
+        // Should be instance of RuntimeException
+        assertTrue(exception instanceof RuntimeException);
+
+        // Should be instance of Exception
+        assertTrue(exception instanceof Exception);
+
+        // Should be instance of Throwable
+        assertTrue(exception instanceof Throwable);
+
+        // Should not require try-catch (unchecked exception)
+        throwUnchecked(); // This compiles without try-catch
+    }
+
+    private void throwUnchecked() {
+        if (Math.random() > 1) { // Never true, but compiler doesn't know
+            throw new CrawlerSystemException("Unchecked");
+        }
+    }
+
+    /**
+     * Test suppressed exceptions
+     */
+    public void test_suppressedExceptions() throws Exception {
+        // Create exception with suppression enabled
+        Constructor<CrawlerSystemException> constructor =
+                CrawlerSystemException.class.getDeclaredConstructor(String.class, boolean.class, boolean.class);
+        constructor.setAccessible(true);
+
+        CrawlerSystemException mainException = constructor.newInstance("Main exception", true, true);
+
+        // Add suppressed exceptions
+        Exception suppressed1 = new IllegalArgumentException("Suppressed 1");
+        Exception suppressed2 = new IOException("Suppressed 2");
+        mainException.addSuppressed(suppressed1);
+        mainException.addSuppressed(suppressed2);
+
+        Throwable[] suppressedExceptions = mainException.getSuppressed();
+        assertEquals(2, suppressedExceptions.length);
+        assertSame(suppressed1, suppressedExceptions[0]);
+        assertSame(suppressed2, suppressedExceptions[1]);
+    }
+
+    /**
+     * Test suppressed exceptions with suppression disabled
+     */
+    public void test_suppressedExceptions_disabled() throws Exception {
+        Constructor<CrawlerSystemException> constructor =
+                CrawlerSystemException.class.getDeclaredConstructor(String.class, boolean.class, boolean.class);
+        constructor.setAccessible(true);
+
+        // Create exception with suppression disabled
+        CrawlerSystemException exception = constructor.newInstance("No suppression", false, true);
+
+        // Try to add suppressed exception
+        Exception suppressed = new IllegalArgumentException("Should not be added");
+        exception.addSuppressed(suppressed);
+
+        // Suppressed exceptions should not be added when suppression is disabled
+        Throwable[] suppressedExceptions = exception.getSuppressed();
+        assertEquals(0, suppressedExceptions.length);
+    }
+
+    /**
+     * Test fillInStackTrace
+     */
+    public void test_fillInStackTrace() {
+        CrawlerSystemException exception = new CrawlerSystemException("Fill stack trace test");
+
+        StackTraceElement[] originalStackTrace = exception.getStackTrace();
+        assertNotNull(originalStackTrace);
+        assertTrue(originalStackTrace.length > 0);
+
+        // Fill in stack trace again
+        Throwable filled = exception.fillInStackTrace();
+        assertSame(exception, filled);
+
+        StackTraceElement[] newStackTrace = exception.getStackTrace();
+        assertNotNull(newStackTrace);
+        assertTrue(newStackTrace.length > 0);
+    }
+
+    /**
+     * Test with non-writable stack trace
+     */
+    public void test_nonWritableStackTrace() throws Exception {
+        Constructor<CrawlerSystemException> constructor =
+                CrawlerSystemException.class.getDeclaredConstructor(String.class, boolean.class, boolean.class);
+        constructor.setAccessible(true);
+
+        // Create exception with non-writable stack trace
+        CrawlerSystemException exception = constructor.newInstance("Non-writable stack", true, false);
+
+        StackTraceElement[] stackTrace = exception.getStackTrace();
+        assertEquals(0, stackTrace.length); // Stack trace should be empty when not writable
+    }
+
+    /**
+     * Test toString method
+     */
+    public void test_toString() {
+        CrawlerSystemException exception1 = new CrawlerSystemException("Test message");
+        String toString1 = exception1.toString();
+        assertNotNull(toString1);
+        assertTrue(toString1.contains("CrawlerSystemException"));
+        assertTrue(toString1.contains("Test message"));
+
+        CrawlerSystemException exception2 = new CrawlerSystemException((String) null);
+        String toString2 = exception2.toString();
+        assertNotNull(toString2);
+        assertTrue(toString2.contains("CrawlerSystemException"));
+    }
+
+    /**
+     * Test getLocalizedMessage
+     */
+    public void test_getLocalizedMessage() {
+        String message = "Localized message test";
+        CrawlerSystemException exception = new CrawlerSystemException(message);
+
+        assertEquals(message, exception.getLocalizedMessage());
+
+        // With null message
+        CrawlerSystemException nullMessageException = new CrawlerSystemException((String) null);
+        assertNull(nullMessageException.getLocalizedMessage());
+    }
+}

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/filter/UrlFilterTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/filter/UrlFilterTest.java
@@ -1,0 +1,580 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.filter;
+
+import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
+import org.codelibs.fess.crawler.filter.impl.UrlFilterImpl;
+import org.codelibs.fess.crawler.helper.MemoryDataHelper;
+import org.codelibs.fess.crawler.service.impl.DataServiceImpl;
+import org.codelibs.fess.crawler.service.impl.UrlFilterServiceImpl;
+import org.dbflute.utflute.core.PlainTestCase;
+
+/**
+ * Test class for UrlFilter interface.
+ * Tests the contract and behavior of UrlFilter implementations.
+ */
+public class UrlFilterTest extends PlainTestCase {
+
+    private UrlFilter urlFilter;
+    private StandardCrawlerContainer container;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Initialize container with necessary components
+        container = new StandardCrawlerContainer().singleton("dataHelper", MemoryDataHelper.class)
+                .singleton("urlFilterService", UrlFilterServiceImpl.class)
+                .singleton("urlFilter", UrlFilterImpl.class)
+                .singleton("dataService", DataServiceImpl.class);
+        urlFilter = container.getComponent("urlFilter");
+    }
+
+    /**
+     * Test basic initialization with session ID
+     */
+    public void test_init_withSessionId() {
+        String sessionId = "test-session-001";
+        urlFilter.init(sessionId);
+        // Initialization should complete without errors
+        assertNotNull(urlFilter);
+    }
+
+    /**
+     * Test initialization with null session ID
+     */
+    public void test_init_withNullSessionId() {
+        urlFilter.init(null);
+        // Should handle null session ID gracefully
+        assertNotNull(urlFilter);
+    }
+
+    /**
+     * Test initialization with empty session ID
+     */
+    public void test_init_withEmptySessionId() {
+        urlFilter.init("");
+        // Should handle empty session ID gracefully
+        assertNotNull(urlFilter);
+    }
+
+    /**
+     * Test adding a single include pattern
+     */
+    public void test_addInclude_singlePattern() {
+        String sessionId = "test-session-002";
+        urlFilter.init(sessionId);
+
+        urlFilter.addInclude("https://example.com/.*");
+
+        assertTrue(urlFilter.match("https://example.com/"));
+        assertTrue(urlFilter.match("https://example.com/page1"));
+        assertTrue(urlFilter.match("https://example.com/dir/page2"));
+        assertFalse(urlFilter.match("https://other.com/"));
+    }
+
+    /**
+     * Test adding multiple include patterns
+     */
+    public void test_addInclude_multiplePatterns() {
+        String sessionId = "test-session-003";
+        urlFilter.init(sessionId);
+
+        urlFilter.addInclude("https://example.com/.*");
+        urlFilter.addInclude("https://test.com/.*");
+        urlFilter.addInclude(".*\\.pdf$");
+
+        assertTrue(urlFilter.match("https://example.com/"));
+        assertTrue(urlFilter.match("https://test.com/page"));
+        assertTrue(urlFilter.match("https://any.com/document.pdf"));
+        assertFalse(urlFilter.match("https://other.com/page.html"));
+    }
+
+    /**
+     * Test adding invalid regex include pattern
+     */
+    public void test_addInclude_invalidRegex() {
+        String sessionId = "test-session-004";
+        urlFilter.init(sessionId);
+
+        // Invalid regex pattern should be handled gracefully
+        urlFilter.addInclude(".*[invalid");
+        urlFilter.addInclude("https://valid.com/.*");
+
+        // Valid pattern should still work
+        assertTrue(urlFilter.match("https://valid.com/page"));
+    }
+
+    /**
+     * Test adding a single exclude pattern
+     */
+    public void test_addExclude_singlePattern() {
+        String sessionId = "test-session-005";
+        urlFilter.init(sessionId);
+
+        urlFilter.addExclude(".*\\.(jpg|png|gif)$");
+
+        assertTrue(urlFilter.match("https://example.com/page.html"));
+        assertTrue(urlFilter.match("https://example.com/document.pdf"));
+        assertFalse(urlFilter.match("https://example.com/image.jpg"));
+        assertFalse(urlFilter.match("https://example.com/photo.png"));
+        assertFalse(urlFilter.match("https://example.com/animation.gif"));
+    }
+
+    /**
+     * Test adding multiple exclude patterns
+     */
+    public void test_addExclude_multiplePatterns() {
+        String sessionId = "test-session-006";
+        urlFilter.init(sessionId);
+
+        urlFilter.addExclude(".*\\.(css|js)$");
+        urlFilter.addExclude(".*\\/admin\\/.*");
+        urlFilter.addExclude(".*#.*");
+
+        assertTrue(urlFilter.match("https://example.com/page.html"));
+        assertFalse(urlFilter.match("https://example.com/style.css"));
+        assertFalse(urlFilter.match("https://example.com/script.js"));
+        assertFalse(urlFilter.match("https://example.com/admin/login"));
+        assertFalse(urlFilter.match("https://example.com/page#section"));
+    }
+
+    /**
+     * Test adding invalid regex exclude pattern
+     */
+    public void test_addExclude_invalidRegex() {
+        String sessionId = "test-session-007";
+        urlFilter.init(sessionId);
+
+        // Invalid regex pattern should be handled gracefully
+        urlFilter.addExclude(".*]invalid");
+        urlFilter.addExclude(".*\\.txt$");
+
+        // Valid pattern should still work
+        assertFalse(urlFilter.match("https://example.com/file.txt"));
+        assertTrue(urlFilter.match("https://example.com/file.html"));
+    }
+
+    /**
+     * Test combination of include and exclude patterns
+     */
+    public void test_match_includeAndExclude() {
+        String sessionId = "test-session-008";
+        urlFilter.init(sessionId);
+
+        // Include only example.com domain
+        urlFilter.addInclude("https://example.com/.*");
+        // But exclude images and admin section
+        urlFilter.addExclude(".*\\.(jpg|png|gif)$");
+        urlFilter.addExclude(".*/admin/.*");
+
+        assertTrue(urlFilter.match("https://example.com/page.html"));
+        assertTrue(urlFilter.match("https://example.com/document.pdf"));
+        assertFalse(urlFilter.match("https://example.com/image.jpg"));
+        assertFalse(urlFilter.match("https://example.com/admin/dashboard"));
+        assertFalse(urlFilter.match("https://other.com/page.html"));
+    }
+
+    /**
+     * Test match with no patterns configured
+     */
+    public void test_match_noPatterns() {
+        String sessionId = "test-session-009";
+        urlFilter.init(sessionId);
+
+        // Without any patterns, all URLs should match
+        assertTrue(urlFilter.match("https://example.com/"));
+        assertTrue(urlFilter.match("https://test.com/page"));
+        assertTrue(urlFilter.match("ftp://files.com/document.pdf"));
+        assertTrue(urlFilter.match("file:///home/user/file.txt"));
+    }
+
+    /**
+     * Test match with complex URL patterns
+     */
+    public void test_match_complexUrls() {
+        String sessionId = "test-session-010";
+        urlFilter.init(sessionId);
+
+        urlFilter.addInclude("https?://[^/]+\\.example\\.com/.*");
+
+        assertTrue(urlFilter.match("http://www.example.com/"));
+        assertTrue(urlFilter.match("https://api.example.com/v1/users"));
+        assertTrue(urlFilter.match("http://subdomain.example.com/page"));
+        assertFalse(urlFilter.match("https://example.org/"));
+        assertFalse(urlFilter.match("ftp://files.example.com/"));
+    }
+
+    /**
+     * Test match with query parameters and fragments
+     */
+    public void test_match_urlWithQueryAndFragment() {
+        String sessionId = "test-session-011";
+        urlFilter.init(sessionId);
+
+        urlFilter.addInclude("https://example.com/search.*");
+        urlFilter.addExclude(".*[?&]debug=true.*");
+
+        assertTrue(urlFilter.match("https://example.com/search"));
+        assertTrue(urlFilter.match("https://example.com/search?q=test"));
+        assertTrue(urlFilter.match("https://example.com/search?q=test&page=2"));
+        assertFalse(urlFilter.match("https://example.com/search?debug=true"));
+        assertFalse(urlFilter.match("https://example.com/search?q=test&debug=true"));
+    }
+
+    /**
+     * Test processUrl method with various URL patterns
+     */
+    public void test_processUrl_basic() {
+        String sessionId = "test-session-012";
+        urlFilter.init(sessionId);
+
+        // Process URL should handle different URL formats
+        urlFilter.processUrl("https://example.com/");
+        urlFilter.processUrl("http://test.com/path/to/page");
+        urlFilter.processUrl("ftp://files.server.com/documents/");
+        urlFilter.processUrl("file:///local/path/file.txt");
+
+        // Should complete without errors
+        assertNotNull(urlFilter);
+    }
+
+    /**
+     * Test processUrl with null URL
+     */
+    public void test_processUrl_nullUrl() {
+        String sessionId = "test-session-013";
+        urlFilter.init(sessionId);
+
+        try {
+            urlFilter.processUrl(null);
+            // Should handle null gracefully or throw appropriate exception
+        } catch (NullPointerException e) {
+            // Expected behavior for null input
+            assertTrue(true);
+        }
+    }
+
+    /**
+     * Test processUrl with empty URL
+     */
+    public void test_processUrl_emptyUrl() {
+        String sessionId = "test-session-014";
+        urlFilter.init(sessionId);
+
+        urlFilter.processUrl("");
+        // Should handle empty URL gracefully
+        assertNotNull(urlFilter);
+    }
+
+    /**
+     * Test clear method
+     */
+    public void test_clear() {
+        String sessionId = "test-session-015";
+        urlFilter.init(sessionId);
+
+        // Add some patterns
+        urlFilter.addInclude("https://example.com/.*");
+        urlFilter.addExclude(".*\\.jpg$");
+
+        // Verify patterns are working
+        assertTrue(urlFilter.match("https://example.com/page"));
+        assertFalse(urlFilter.match("https://other.com/page"));
+
+        // Clear the filter
+        urlFilter.clear();
+
+        // After clear, all URLs should match (no filters applied)
+        assertTrue(urlFilter.match("https://example.com/page"));
+        assertTrue(urlFilter.match("https://other.com/page"));
+        assertTrue(urlFilter.match("https://any.com/image.jpg"));
+    }
+
+    /**
+     * Test clear method without initialization
+     */
+    public void test_clear_withoutInit() {
+        // Create new filter without initialization
+        UrlFilter newFilter = container.getComponent("urlFilter");
+
+        // Clear should work even without initialization
+        newFilter.clear();
+        assertNotNull(newFilter);
+    }
+
+    /**
+     * Test adding patterns before initialization
+     */
+    public void test_addPatterns_beforeInit() {
+        // Create new filter
+        UrlFilter newFilter = container.getComponent("urlFilter");
+
+        // Add patterns before init
+        newFilter.addInclude("https://example.com/.*");
+        newFilter.addExclude(".*\\.css$");
+
+        // Initialize with session
+        String sessionId = "test-session-016";
+        newFilter.init(sessionId);
+
+        // Patterns should be applied after init
+        assertTrue(newFilter.match("https://example.com/page"));
+        assertFalse(newFilter.match("https://example.com/style.css"));
+        assertFalse(newFilter.match("https://other.com/page"));
+    }
+
+    /**
+     * Test multiple initializations with same session ID
+     */
+    public void test_multipleInit_sameSessionId() {
+        String sessionId = "test-session-017";
+
+        // First initialization
+        urlFilter.init(sessionId);
+        urlFilter.addInclude("https://first.com/.*");
+
+        // Second initialization with same session ID
+        urlFilter.init(sessionId);
+        urlFilter.addInclude("https://second.com/.*");
+
+        // Both patterns should work
+        assertTrue(urlFilter.match("https://first.com/page"));
+        assertTrue(urlFilter.match("https://second.com/page"));
+    }
+
+    /**
+     * Test multiple initializations with different session IDs
+     */
+    public void test_multipleInit_differentSessionIds() {
+        // First session
+        urlFilter.init("session-001");
+        urlFilter.addInclude("https://first.com/.*");
+
+        // Second session
+        urlFilter.init("session-002");
+        urlFilter.addInclude("https://second.com/.*");
+
+        // Behavior depends on implementation
+        // At minimum, should not throw exceptions
+        assertNotNull(urlFilter);
+    }
+
+    /**
+     * Test special characters in URL patterns
+     */
+    public void test_specialCharactersInPatterns() {
+        String sessionId = "test-session-018";
+        urlFilter.init(sessionId);
+
+        // Test patterns with special regex characters
+        urlFilter.addInclude("https://example\\.com/\\?.*");
+        urlFilter.addInclude(".*\\$price=\\d+.*");
+        urlFilter.addExclude(".*\\[\\].*");
+
+        assertTrue(urlFilter.match("https://example.com/?page=1"));
+        assertTrue(urlFilter.match("https://shop.com/item?$price=100"));
+        assertFalse(urlFilter.match("https://example.com/array[]"));
+    }
+
+    /**
+     * Test case sensitivity in patterns
+     */
+    public void test_caseSensitivity() {
+        String sessionId = "test-session-019";
+        urlFilter.init(sessionId);
+
+        urlFilter.addInclude(".*\\.PDF$");
+
+        // Test case sensitivity
+        assertFalse(urlFilter.match("https://example.com/document.pdf"));
+        assertTrue(urlFilter.match("https://example.com/document.PDF"));
+    }
+
+    /**
+     * Test very long URL handling
+     */
+    public void test_veryLongUrl() {
+        String sessionId = "test-session-020";
+        urlFilter.init(sessionId);
+
+        // Create a very long URL
+        StringBuilder longUrl = new StringBuilder("https://example.com/");
+        for (int i = 0; i < 1000; i++) {
+            longUrl.append("very/long/path/segment/");
+        }
+        longUrl.append("file.html");
+
+        urlFilter.addInclude("https://example.com/.*");
+
+        // Should handle long URLs without issues
+        assertTrue(urlFilter.match(longUrl.toString()));
+    }
+
+    /**
+     * Test internationalized domain names (IDN)
+     */
+    public void test_internationalizedDomainNames() {
+        String sessionId = "test-session-021";
+        urlFilter.init(sessionId);
+
+        urlFilter.addInclude(".*日本.*");
+
+        assertTrue(urlFilter.match("https://日本.example.com/"));
+        assertTrue(urlFilter.match("https://example.com/日本/page"));
+        assertFalse(urlFilter.match("https://example.com/china/page"));
+    }
+
+    /**
+     * Test URL with special protocols
+     */
+    public void test_specialProtocols() {
+        String sessionId = "test-session-022";
+        urlFilter.init(sessionId);
+
+        urlFilter.addInclude("(http|https|ftp|file)://.*");
+        urlFilter.addExclude("javascript:.*");
+        urlFilter.addExclude("mailto:.*");
+
+        assertTrue(urlFilter.match("http://example.com/"));
+        assertTrue(urlFilter.match("https://example.com/"));
+        assertTrue(urlFilter.match("ftp://files.com/"));
+        assertTrue(urlFilter.match("file:///home/user/file"));
+        assertFalse(urlFilter.match("javascript:alert('test')"));
+        assertFalse(urlFilter.match("mailto:user@example.com"));
+    }
+
+    /**
+     * Test concurrent pattern additions
+     */
+    public void test_concurrentPatternAdditions() throws InterruptedException {
+        String sessionId = "test-session-023";
+        urlFilter.init(sessionId);
+
+        // Create multiple threads adding patterns
+        Thread thread1 = new Thread(() -> {
+            for (int i = 0; i < 100; i++) {
+                urlFilter.addInclude("https://site" + i + ".com/.*");
+            }
+        });
+
+        Thread thread2 = new Thread(() -> {
+            for (int i = 0; i < 100; i++) {
+                urlFilter.addExclude(".*\\.type" + i + "$");
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+
+        thread1.join();
+        thread2.join();
+
+        // Should complete without errors
+        assertNotNull(urlFilter);
+    }
+
+    /**
+     * Test boundary conditions
+     */
+    public void test_boundaryConditions() {
+        String sessionId = "test-session-024";
+        urlFilter.init(sessionId);
+
+        // Test empty pattern
+        urlFilter.addInclude("");
+        urlFilter.addExclude("");
+
+        // Test single character pattern
+        urlFilter.addInclude(".");
+        urlFilter.addExclude("*");
+
+        // Test patterns with only special characters
+        urlFilter.addInclude("^$");
+        urlFilter.addExclude(".*");
+
+        // Should handle boundary conditions gracefully
+        assertNotNull(urlFilter);
+    }
+
+    /**
+     * Test pattern priority (include vs exclude)
+     */
+    public void test_patternPriority() {
+        String sessionId = "test-session-025";
+        urlFilter.init(sessionId);
+
+        // Add conflicting patterns
+        urlFilter.addInclude("https://example.com/.*");
+        urlFilter.addExclude("https://example.com/.*");
+
+        // Exclude should take precedence
+        assertFalse(urlFilter.match("https://example.com/page"));
+    }
+
+    /**
+     * Test URL normalization scenarios
+     */
+    public void test_urlNormalization() {
+        String sessionId = "test-session-026";
+        urlFilter.init(sessionId);
+
+        urlFilter.addInclude("https://example.com/path/.*");
+
+        // Test various URL formats that should be equivalent
+        assertTrue(urlFilter.match("https://example.com/path/"));
+        assertTrue(urlFilter.match("https://example.com/path/page"));
+        assertTrue(urlFilter.match("https://example.com/path//page"));
+        assertTrue(urlFilter.match("https://example.com/path/./page"));
+    }
+
+    /**
+     * Test wildcard patterns
+     */
+    public void test_wildcardPatterns() {
+        String sessionId = "test-session-027";
+        urlFilter.init(sessionId);
+
+        // Test various wildcard patterns
+        urlFilter.addInclude(".*"); // Match all
+        assertTrue(urlFilter.match("https://any.com/any/path"));
+
+        urlFilter.clear();
+        urlFilter.init(sessionId);
+
+        urlFilter.addInclude(".+"); // Match at least one character
+        assertTrue(urlFilter.match("https://example.com/"));
+        assertFalse(urlFilter.match(""));
+    }
+
+    /**
+     * Test memory efficiency with large number of patterns
+     */
+    public void test_largeNumberOfPatterns() {
+        String sessionId = "test-session-028";
+        urlFilter.init(sessionId);
+
+        // Add many patterns
+        for (int i = 0; i < 1000; i++) {
+            urlFilter.addInclude("https://site" + i + ".com/.*");
+            urlFilter.addExclude(".*\\.exclude" + i + "$");
+        }
+
+        // Test matching performance
+        assertTrue(urlFilter.match("https://site500.com/page"));
+        assertFalse(urlFilter.match("https://site500.com/file.exclude500"));
+        assertFalse(urlFilter.match("https://unknown.com/page"));
+    }
+}

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/pool/CrawlerPooledObjectFactoryTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/pool/CrawlerPooledObjectFactoryTest.java
@@ -1,0 +1,592 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.pool;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
+import org.codelibs.fess.crawler.pool.CrawlerPooledObjectFactory.OnDestroyListener;
+import org.dbflute.utflute.core.PlainTestCase;
+
+/**
+ * Test class for CrawlerPooledObjectFactory.
+ * Tests the pooled object factory functionality including object creation,
+ * wrapping, destruction, and listener mechanisms.
+ */
+public class CrawlerPooledObjectFactoryTest extends PlainTestCase {
+
+    private CrawlerPooledObjectFactory<TestComponent> factory;
+    private StandardCrawlerContainer container;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        // Reset counters before each test
+        TestComponent.resetCounter();
+        SingletonTestComponent.resetInstanceCount();
+
+        // Initialize container with test components
+        container = new StandardCrawlerContainer().prototype("testComponent", TestComponent.class)
+                .singleton("singletonComponent", SingletonTestComponent.class)
+                .singleton("factory", CrawlerPooledObjectFactory.class);
+
+        factory = new CrawlerPooledObjectFactory<>();
+        factory.crawlerContainer = container;
+    }
+
+    /**
+     * Test component class for testing factory operations
+     */
+    public static class TestComponent {
+        private static AtomicInteger instanceCounter = new AtomicInteger(0);
+        private final int id;
+        private boolean destroyed = false;
+
+        public TestComponent() {
+            this.id = instanceCounter.incrementAndGet();
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public boolean isDestroyed() {
+            return destroyed;
+        }
+
+        public void destroy() {
+            this.destroyed = true;
+        }
+
+        public static void resetCounter() {
+            instanceCounter.set(0);
+        }
+    }
+
+    /**
+     * Singleton test component for testing singleton behavior
+     */
+    public static class SingletonTestComponent {
+        private static int instanceCount = 0;
+
+        public SingletonTestComponent() {
+            instanceCount++;
+        }
+
+        public static int getInstanceCount() {
+            return instanceCount;
+        }
+
+        public static void resetInstanceCount() {
+            instanceCount = 0;
+        }
+    }
+
+    /**
+     * Test basic object creation
+     */
+    public void test_create_basic() throws Exception {
+        factory.setComponentName("testComponent");
+
+        TestComponent component = factory.create();
+        assertNotNull(component);
+        assertEquals(1, component.getId());
+
+        TestComponent component2 = factory.create();
+        assertNotNull(component2);
+        assertEquals(2, component2.getId());
+
+        // Different instances for prototype
+        assertNotSame(component, component2);
+    }
+
+    /**
+     * Test creation with null component name
+     */
+    public void test_create_nullComponentName() {
+        factory.setComponentName(null);
+
+        try {
+            factory.create();
+            fail("Should throw exception for null component name");
+        } catch (Exception e) {
+            // Expected behavior
+            assertTrue(true);
+        }
+    }
+
+    /**
+     * Test creation with invalid component name
+     */
+    public void test_create_invalidComponentName() {
+        factory.setComponentName("nonExistentComponent");
+
+        try {
+            Object result = factory.create();
+            // The container may return null for non-existent components
+            assertNull("Should return null for invalid component name", result);
+        } catch (Exception e) {
+            // Exception is also acceptable behavior
+            assertTrue(true);
+        }
+    }
+
+    /**
+     * Test creation with singleton component
+     */
+    public void test_create_singletonComponent() throws Exception {
+        factory.setComponentName("singletonComponent");
+
+        Object component1 = factory.create();
+        Object component2 = factory.create();
+
+        assertNotNull(component1);
+        assertNotNull(component2);
+
+        // Should be same instance for singleton
+        assertSame(component1, component2);
+        // The first creation should increment the counter
+        assertTrue("Instance count should be at least 1", SingletonTestComponent.getInstanceCount() >= 1);
+    }
+
+    /**
+     * Test wrap method
+     */
+    public void test_wrap_basic() {
+        TestComponent component = new TestComponent();
+
+        PooledObject<TestComponent> pooledObject = factory.wrap(component);
+
+        assertNotNull(pooledObject);
+        assertTrue(pooledObject instanceof DefaultPooledObject);
+        assertSame(component, pooledObject.getObject());
+    }
+
+    /**
+     * Test wrap with null object
+     */
+    public void test_wrap_nullObject() {
+        PooledObject<TestComponent> pooledObject = factory.wrap(null);
+
+        assertNotNull(pooledObject);
+        assertNull(pooledObject.getObject());
+    }
+
+    /**
+     * Test destroyObject without listener
+     */
+    public void test_destroyObject_noListener() throws Exception {
+        TestComponent component = new TestComponent();
+        PooledObject<TestComponent> pooledObject = new DefaultPooledObject<>(component);
+
+        // Should not throw exception even without listener
+        factory.destroyObject(pooledObject);
+
+        // Component should remain unchanged without listener
+        assertFalse(component.isDestroyed());
+    }
+
+    /**
+     * Test destroyObject with listener
+     */
+    public void test_destroyObject_withListener() throws Exception {
+        TestComponent component = new TestComponent();
+        PooledObject<TestComponent> pooledObject = new DefaultPooledObject<>(component);
+
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        final PooledObject<TestComponent>[] capturedObject = new PooledObject[1];
+
+        factory.setOnDestroyListener(new OnDestroyListener<TestComponent>() {
+            @Override
+            public void onDestroy(PooledObject<TestComponent> p) {
+                listenerCalled.set(true);
+                capturedObject[0] = p;
+                p.getObject().destroy();
+            }
+        });
+
+        factory.destroyObject(pooledObject);
+
+        assertTrue(listenerCalled.get());
+        assertSame(pooledObject, capturedObject[0]);
+        assertTrue(component.isDestroyed());
+    }
+
+    /**
+     * Test destroyObject with null pooled object
+     */
+    public void test_destroyObject_nullPooledObject() throws Exception {
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
+
+        factory.setOnDestroyListener(new OnDestroyListener<TestComponent>() {
+            @Override
+            public void onDestroy(PooledObject<TestComponent> p) {
+                listenerCalled.set(true);
+            }
+        });
+
+        factory.destroyObject(null);
+
+        // Listener should be called even with null
+        assertTrue(listenerCalled.get());
+    }
+
+    /**
+     * Test destroyObject with exception in listener
+     */
+    public void test_destroyObject_listenerException() {
+        TestComponent component = new TestComponent();
+        PooledObject<TestComponent> pooledObject = new DefaultPooledObject<>(component);
+
+        factory.setOnDestroyListener(new OnDestroyListener<TestComponent>() {
+            @Override
+            public void onDestroy(PooledObject<TestComponent> p) {
+                throw new RuntimeException("Test exception in listener");
+            }
+        });
+
+        try {
+            factory.destroyObject(pooledObject);
+            fail("Should propagate exception from listener");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Test exception"));
+        }
+    }
+
+    /**
+     * Test getter and setter for componentName
+     */
+    public void test_componentName_getterSetter() {
+        assertNull(factory.getComponentName());
+
+        factory.setComponentName("testName");
+        assertEquals("testName", factory.getComponentName());
+
+        factory.setComponentName(null);
+        assertNull(factory.getComponentName());
+
+        factory.setComponentName("");
+        assertEquals("", factory.getComponentName());
+    }
+
+    /**
+     * Test getter and setter for onDestroyListener
+     */
+    public void test_onDestroyListener_getterSetter() {
+        assertNull(factory.getOnDestroyListener());
+
+        OnDestroyListener<TestComponent> listener = new OnDestroyListener<TestComponent>() {
+            @Override
+            public void onDestroy(PooledObject<TestComponent> p) {
+                // Empty implementation
+            }
+        };
+
+        factory.setOnDestroyListener(listener);
+        assertSame(listener, factory.getOnDestroyListener());
+
+        factory.setOnDestroyListener(null);
+        assertNull(factory.getOnDestroyListener());
+    }
+
+    /**
+     * Test multiple listener changes
+     */
+    public void test_multipleListenerChanges() throws Exception {
+        TestComponent component = new TestComponent();
+        PooledObject<TestComponent> pooledObject = new DefaultPooledObject<>(component);
+
+        List<String> callOrder = new ArrayList<>();
+
+        // First listener
+        factory.setOnDestroyListener(new OnDestroyListener<TestComponent>() {
+            @Override
+            public void onDestroy(PooledObject<TestComponent> p) {
+                callOrder.add("listener1");
+            }
+        });
+
+        factory.destroyObject(pooledObject);
+        assertEquals(1, callOrder.size());
+        assertEquals("listener1", callOrder.get(0));
+
+        // Change listener
+        factory.setOnDestroyListener(new OnDestroyListener<TestComponent>() {
+            @Override
+            public void onDestroy(PooledObject<TestComponent> p) {
+                callOrder.add("listener2");
+            }
+        });
+
+        factory.destroyObject(pooledObject);
+        assertEquals(2, callOrder.size());
+        assertEquals("listener2", callOrder.get(1));
+
+        // Remove listener
+        factory.setOnDestroyListener(null);
+        factory.destroyObject(pooledObject);
+        assertEquals(2, callOrder.size()); // Should not add more
+    }
+
+    /**
+     * Test lifecycle: create, wrap, destroy
+     */
+    public void test_fullLifecycle() throws Exception {
+        TestComponent.resetCounter();
+        factory.setComponentName("testComponent");
+
+        final List<TestComponent> destroyedComponents = new ArrayList<>();
+        factory.setOnDestroyListener(new OnDestroyListener<TestComponent>() {
+            @Override
+            public void onDestroy(PooledObject<TestComponent> p) {
+                TestComponent component = p.getObject();
+                component.destroy();
+                destroyedComponents.add(component);
+            }
+        });
+
+        // Create
+        TestComponent component = factory.create();
+        assertNotNull(component);
+        assertEquals(1, component.getId());
+        assertFalse(component.isDestroyed());
+
+        // Wrap
+        PooledObject<TestComponent> pooledObject = factory.wrap(component);
+        assertNotNull(pooledObject);
+        assertSame(component, pooledObject.getObject());
+
+        // Destroy
+        factory.destroyObject(pooledObject);
+        assertTrue(component.isDestroyed());
+        assertEquals(1, destroyedComponents.size());
+        assertSame(component, destroyedComponents.get(0));
+    }
+
+    /**
+     * Test concurrent object creation
+     */
+    public void test_concurrentCreation() throws Exception {
+        TestComponent.resetCounter();
+        factory.setComponentName("testComponent");
+
+        final int threadCount = 10;
+        final int objectsPerThread = 10;
+        final List<TestComponent> createdComponents = new ArrayList<>();
+        final List<Exception> exceptions = new ArrayList<>();
+
+        Thread[] threads = new Thread[threadCount];
+        for (int i = 0; i < threadCount; i++) {
+            threads[i] = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        for (int j = 0; j < objectsPerThread; j++) {
+                            TestComponent component = factory.create();
+                            synchronized (createdComponents) {
+                                createdComponents.add(component);
+                            }
+                        }
+                    } catch (Exception e) {
+                        synchronized (exceptions) {
+                            exceptions.add(e);
+                        }
+                    }
+                }
+            });
+        }
+
+        // Start all threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // Wait for all threads to complete
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // Verify results
+        assertTrue(exceptions.isEmpty());
+        assertEquals(threadCount * objectsPerThread, createdComponents.size());
+
+        // Check all components are unique (for prototype)
+        for (int i = 0; i < createdComponents.size(); i++) {
+            for (int j = i + 1; j < createdComponents.size(); j++) {
+                assertNotSame(createdComponents.get(i), createdComponents.get(j));
+            }
+        }
+    }
+
+    /**
+     * Test concurrent destroy operations
+     */
+    public void test_concurrentDestroy() throws Exception {
+        final AtomicInteger destroyCount = new AtomicInteger(0);
+
+        factory.setOnDestroyListener(new OnDestroyListener<TestComponent>() {
+            @Override
+            public void onDestroy(PooledObject<TestComponent> p) {
+                destroyCount.incrementAndGet();
+                if (p != null && p.getObject() != null) {
+                    p.getObject().destroy();
+                }
+            }
+        });
+
+        final int threadCount = 10;
+        final int destroysPerThread = 10;
+        final List<Exception> exceptions = new ArrayList<>();
+
+        Thread[] threads = new Thread[threadCount];
+        for (int i = 0; i < threadCount; i++) {
+            threads[i] = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        for (int j = 0; j < destroysPerThread; j++) {
+                            TestComponent component = new TestComponent();
+                            PooledObject<TestComponent> pooledObject = new DefaultPooledObject<>(component);
+                            factory.destroyObject(pooledObject);
+                        }
+                    } catch (Exception e) {
+                        synchronized (exceptions) {
+                            exceptions.add(e);
+                        }
+                    }
+                }
+            });
+        }
+
+        // Start all threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // Wait for all threads to complete
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // Verify results
+        assertTrue(exceptions.isEmpty());
+        assertEquals(threadCount * destroysPerThread, destroyCount.get());
+    }
+
+    /**
+     * Test with different component types
+     */
+    public void test_differentComponentTypes() throws Exception {
+        // Test with String component
+        container.singleton("stringComponent", "TestString");
+        CrawlerPooledObjectFactory<String> stringFactory = new CrawlerPooledObjectFactory<>();
+        stringFactory.crawlerContainer = container;
+        stringFactory.setComponentName("stringComponent");
+
+        String stringComponent = stringFactory.create();
+        assertEquals("TestString", stringComponent);
+
+        PooledObject<String> pooledString = stringFactory.wrap(stringComponent);
+        assertNotNull(pooledString);
+        assertEquals("TestString", pooledString.getObject());
+    }
+
+    /**
+     * Test edge cases for wrap method
+     */
+    public void test_wrap_edgeCases() {
+        // Test with various object types
+        TestComponent component = new TestComponent();
+        PooledObject<TestComponent> pooled1 = factory.wrap(component);
+        assertNotNull(pooled1);
+
+        // Test wrapping same object multiple times
+        PooledObject<TestComponent> pooled2 = factory.wrap(component);
+        assertNotNull(pooled2);
+        assertNotSame(pooled1, pooled2); // Different PooledObject instances
+        assertSame(pooled1.getObject(), pooled2.getObject()); // Same wrapped object
+    }
+
+    /**
+     * Test factory reusability
+     */
+    public void test_factoryReusability() throws Exception {
+        TestComponent.resetCounter();
+
+        // Use factory with first component type
+        factory.setComponentName("testComponent");
+        TestComponent comp1 = factory.create();
+        assertEquals(1, comp1.getId());
+
+        // Change component name and reuse factory
+        factory.setComponentName("testComponent");
+        TestComponent comp2 = factory.create();
+        assertEquals(2, comp2.getId());
+
+        // Components should be different instances
+        assertNotSame(comp1, comp2);
+    }
+
+    /**
+     * Test listener state consistency
+     */
+    public void test_listenerStateConsistency() throws Exception {
+        final List<String> events = new ArrayList<>();
+
+        OnDestroyListener<TestComponent> listener1 = new OnDestroyListener<TestComponent>() {
+            @Override
+            public void onDestroy(PooledObject<TestComponent> p) {
+                events.add("listener1");
+            }
+        };
+
+        OnDestroyListener<TestComponent> listener2 = new OnDestroyListener<TestComponent>() {
+            @Override
+            public void onDestroy(PooledObject<TestComponent> p) {
+                events.add("listener2");
+            }
+        };
+
+        TestComponent component = new TestComponent();
+        PooledObject<TestComponent> pooledObject = new DefaultPooledObject<>(component);
+
+        // Test with listener1
+        factory.setOnDestroyListener(listener1);
+        assertEquals(listener1, factory.getOnDestroyListener());
+        factory.destroyObject(pooledObject);
+        assertEquals(1, events.size());
+        assertEquals("listener1", events.get(0));
+
+        // Switch to listener2
+        factory.setOnDestroyListener(listener2);
+        assertEquals(listener2, factory.getOnDestroyListener());
+        factory.destroyObject(pooledObject);
+        assertEquals(2, events.size());
+        assertEquals("listener2", events.get(1));
+
+        // Clear listener
+        factory.setOnDestroyListener(null);
+        assertNull(factory.getOnDestroyListener());
+        factory.destroyObject(pooledObject);
+        assertEquals(2, events.size()); // No new events
+    }
+}

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/rule/RuleManagerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/rule/RuleManagerTest.java
@@ -1,0 +1,798 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.rule;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.codelibs.fess.crawler.entity.ResponseData;
+import org.codelibs.fess.crawler.processor.ResponseProcessor;
+import org.dbflute.utflute.core.PlainTestCase;
+
+/**
+ * Test class for RuleManager interface.
+ * Tests the contract and behavior of RuleManager implementations.
+ */
+public class RuleManagerTest extends PlainTestCase {
+
+    /**
+     * Test implementation of RuleManager for testing purposes
+     */
+    public static class TestRuleManager implements RuleManager {
+        private final List<Rule> rules = new ArrayList<>();
+        private int getRuleCallCount = 0;
+
+        @Override
+        public Rule getRule(ResponseData responseData) {
+            getRuleCallCount++;
+            if (responseData == null) {
+                return null;
+            }
+
+            for (Rule rule : rules) {
+                if (rule != null && rule.match(responseData)) {
+                    return rule;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public void addRule(Rule rule) {
+            if (rule != null) {
+                rules.add(rule);
+            }
+        }
+
+        @Override
+        public void addRule(int index, Rule rule) {
+            if (rule != null) {
+                if (index < 0 || index > rules.size()) {
+                    throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + rules.size());
+                }
+                rules.add(index, rule);
+            }
+        }
+
+        @Override
+        public boolean removeRule(Rule rule) {
+            return rules.remove(rule);
+        }
+
+        @Override
+        public boolean hasRule(Rule rule) {
+            return rules.contains(rule);
+        }
+
+        public int getRuleCount() {
+            return rules.size();
+        }
+
+        public int getGetRuleCallCount() {
+            return getRuleCallCount;
+        }
+
+        public void clearRules() {
+            rules.clear();
+        }
+
+        public List<Rule> getRules() {
+            return new ArrayList<>(rules);
+        }
+    }
+
+    /**
+     * Thread-safe implementation of RuleManager
+     */
+    public static class ThreadSafeRuleManager implements RuleManager {
+        private final List<Rule> rules = new CopyOnWriteArrayList<>();
+
+        @Override
+        public Rule getRule(ResponseData responseData) {
+            if (responseData == null) {
+                return null;
+            }
+
+            for (Rule rule : rules) {
+                if (rule != null && rule.match(responseData)) {
+                    return rule;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public void addRule(Rule rule) {
+            if (rule != null) {
+                rules.add(rule);
+            }
+        }
+
+        @Override
+        public void addRule(int index, Rule rule) {
+            if (rule != null) {
+                rules.add(index, rule);
+            }
+        }
+
+        @Override
+        public boolean removeRule(Rule rule) {
+            return rules.remove(rule);
+        }
+
+        @Override
+        public boolean hasRule(Rule rule) {
+            return rules.contains(rule);
+        }
+    }
+
+    /**
+     * Simple test rule implementation
+     */
+    public static class TestRule implements Rule {
+        private static final long serialVersionUID = 1L;
+        private final String ruleId;
+        private final boolean matchResult;
+        private final ResponseProcessor responseProcessor;
+
+        public TestRule(String ruleId, boolean matchResult) {
+            this(ruleId, matchResult, null);
+        }
+
+        public TestRule(String ruleId, boolean matchResult, ResponseProcessor responseProcessor) {
+            this.ruleId = ruleId;
+            this.matchResult = matchResult;
+            this.responseProcessor = responseProcessor;
+        }
+
+        @Override
+        public boolean match(ResponseData responseData) {
+            return matchResult;
+        }
+
+        @Override
+        public String getRuleId() {
+            return ruleId;
+        }
+
+        @Override
+        public ResponseProcessor getResponseProcessor() {
+            return responseProcessor;
+        }
+    }
+
+    /**
+     * Conditional test rule that matches based on URL pattern
+     */
+    public static class UrlPatternRule implements Rule {
+        private static final long serialVersionUID = 1L;
+        private final String ruleId;
+        private final String urlPattern;
+        private final ResponseProcessor responseProcessor;
+
+        public UrlPatternRule(String ruleId, String urlPattern) {
+            this(ruleId, urlPattern, null);
+        }
+
+        public UrlPatternRule(String ruleId, String urlPattern, ResponseProcessor responseProcessor) {
+            this.ruleId = ruleId;
+            this.urlPattern = urlPattern;
+            this.responseProcessor = responseProcessor;
+        }
+
+        @Override
+        public boolean match(ResponseData responseData) {
+            if (responseData == null || responseData.getUrl() == null) {
+                return false;
+            }
+            return responseData.getUrl().matches(urlPattern);
+        }
+
+        @Override
+        public String getRuleId() {
+            return ruleId;
+        }
+
+        @Override
+        public ResponseProcessor getResponseProcessor() {
+            return responseProcessor;
+        }
+    }
+
+    private TestRuleManager ruleManager;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        ruleManager = new TestRuleManager();
+    }
+
+    /**
+     * Test adding a single rule
+     */
+    public void test_addRule_single() {
+        TestRule rule = new TestRule("rule1", true);
+
+        ruleManager.addRule(rule);
+
+        assertTrue(ruleManager.hasRule(rule));
+        assertEquals(1, ruleManager.getRuleCount());
+    }
+
+    /**
+     * Test adding multiple rules
+     */
+    public void test_addRule_multiple() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", false);
+        TestRule rule3 = new TestRule("rule3", true);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+        ruleManager.addRule(rule3);
+
+        assertTrue(ruleManager.hasRule(rule1));
+        assertTrue(ruleManager.hasRule(rule2));
+        assertTrue(ruleManager.hasRule(rule3));
+        assertEquals(3, ruleManager.getRuleCount());
+    }
+
+    /**
+     * Test adding null rule
+     */
+    public void test_addRule_null() {
+        ruleManager.addRule(null);
+
+        assertEquals(0, ruleManager.getRuleCount());
+    }
+
+    /**
+     * Test adding rule at specific index
+     */
+    public void test_addRule_atIndex() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", false);
+        TestRule rule3 = new TestRule("rule3", true);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule3);
+        ruleManager.addRule(1, rule2); // Insert in middle
+
+        List<Rule> rules = ruleManager.getRules();
+        assertEquals(3, rules.size());
+        assertEquals("rule1", rules.get(0).getRuleId());
+        assertEquals("rule2", rules.get(1).getRuleId());
+        assertEquals("rule3", rules.get(2).getRuleId());
+    }
+
+    /**
+     * Test adding rule at index 0
+     */
+    public void test_addRule_atIndexZero() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", false);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(0, rule2); // Insert at beginning
+
+        List<Rule> rules = ruleManager.getRules();
+        assertEquals(2, rules.size());
+        assertEquals("rule2", rules.get(0).getRuleId());
+        assertEquals("rule1", rules.get(1).getRuleId());
+    }
+
+    /**
+     * Test adding rule at last index
+     */
+    public void test_addRule_atLastIndex() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", false);
+        TestRule rule3 = new TestRule("rule3", true);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+        ruleManager.addRule(2, rule3); // Insert at end
+
+        List<Rule> rules = ruleManager.getRules();
+        assertEquals(3, rules.size());
+        assertEquals("rule3", rules.get(2).getRuleId());
+    }
+
+    /**
+     * Test adding rule at invalid index
+     */
+    public void test_addRule_atInvalidIndex() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", false);
+
+        ruleManager.addRule(rule1);
+
+        try {
+            ruleManager.addRule(-1, rule2);
+            fail("Should throw IndexOutOfBoundsException for negative index");
+        } catch (IndexOutOfBoundsException e) {
+            // Expected
+        }
+
+        try {
+            ruleManager.addRule(5, rule2);
+            fail("Should throw IndexOutOfBoundsException for index > size");
+        } catch (IndexOutOfBoundsException e) {
+            // Expected
+        }
+    }
+
+    /**
+     * Test adding null rule at index
+     */
+    public void test_addRule_nullAtIndex() {
+        TestRule rule1 = new TestRule("rule1", true);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(0, null);
+
+        assertEquals(1, ruleManager.getRuleCount());
+        assertEquals("rule1", ruleManager.getRules().get(0).getRuleId());
+    }
+
+    /**
+     * Test removing existing rule
+     */
+    public void test_removeRule_existing() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", false);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+
+        assertTrue(ruleManager.removeRule(rule1));
+
+        assertFalse(ruleManager.hasRule(rule1));
+        assertTrue(ruleManager.hasRule(rule2));
+        assertEquals(1, ruleManager.getRuleCount());
+    }
+
+    /**
+     * Test removing non-existing rule
+     */
+    public void test_removeRule_nonExisting() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", false);
+
+        ruleManager.addRule(rule1);
+
+        assertFalse(ruleManager.removeRule(rule2));
+
+        assertTrue(ruleManager.hasRule(rule1));
+        assertEquals(1, ruleManager.getRuleCount());
+    }
+
+    /**
+     * Test removing null rule
+     */
+    public void test_removeRule_null() {
+        TestRule rule = new TestRule("rule1", true);
+
+        ruleManager.addRule(rule);
+
+        assertFalse(ruleManager.removeRule(null));
+
+        assertTrue(ruleManager.hasRule(rule));
+        assertEquals(1, ruleManager.getRuleCount());
+    }
+
+    /**
+     * Test removing all rules
+     */
+    public void test_removeRule_all() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", false);
+        TestRule rule3 = new TestRule("rule3", true);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+        ruleManager.addRule(rule3);
+
+        assertTrue(ruleManager.removeRule(rule2));
+        assertTrue(ruleManager.removeRule(rule1));
+        assertTrue(ruleManager.removeRule(rule3));
+
+        assertEquals(0, ruleManager.getRuleCount());
+    }
+
+    /**
+     * Test hasRule with existing rule
+     */
+    public void test_hasRule_existing() {
+        TestRule rule = new TestRule("rule1", true);
+
+        ruleManager.addRule(rule);
+
+        assertTrue(ruleManager.hasRule(rule));
+    }
+
+    /**
+     * Test hasRule with non-existing rule
+     */
+    public void test_hasRule_nonExisting() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", false);
+
+        ruleManager.addRule(rule1);
+
+        assertFalse(ruleManager.hasRule(rule2));
+    }
+
+    /**
+     * Test hasRule with null
+     */
+    public void test_hasRule_null() {
+        TestRule rule = new TestRule("rule1", true);
+
+        ruleManager.addRule(rule);
+
+        assertFalse(ruleManager.hasRule(null));
+    }
+
+    /**
+     * Test getRule with matching rule
+     */
+    public void test_getRule_matching() {
+        TestRule rule1 = new TestRule("rule1", false);
+        TestRule rule2 = new TestRule("rule2", true);
+        TestRule rule3 = new TestRule("rule3", false);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+        ruleManager.addRule(rule3);
+
+        ResponseData responseData = new ResponseData();
+        Rule matchedRule = ruleManager.getRule(responseData);
+
+        assertNotNull(matchedRule);
+        assertEquals("rule2", matchedRule.getRuleId());
+    }
+
+    /**
+     * Test getRule with no matching rule
+     */
+    public void test_getRule_noMatch() {
+        TestRule rule1 = new TestRule("rule1", false);
+        TestRule rule2 = new TestRule("rule2", false);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+
+        ResponseData responseData = new ResponseData();
+        Rule matchedRule = ruleManager.getRule(responseData);
+
+        assertNull(matchedRule);
+    }
+
+    /**
+     * Test getRule with null ResponseData
+     */
+    public void test_getRule_nullResponseData() {
+        TestRule rule = new TestRule("rule1", true);
+
+        ruleManager.addRule(rule);
+
+        Rule matchedRule = ruleManager.getRule(null);
+
+        assertNull(matchedRule);
+    }
+
+    /**
+     * Test getRule with first matching rule (priority)
+     */
+    public void test_getRule_firstMatchPriority() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", true);
+        TestRule rule3 = new TestRule("rule3", true);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+        ruleManager.addRule(rule3);
+
+        ResponseData responseData = new ResponseData();
+        Rule matchedRule = ruleManager.getRule(responseData);
+
+        assertNotNull(matchedRule);
+        assertEquals("rule1", matchedRule.getRuleId()); // First matching rule
+    }
+
+    /**
+     * Test getRule with URL pattern rules
+     */
+    public void test_getRule_urlPattern() {
+        UrlPatternRule rule1 = new UrlPatternRule("httpRule", "https?://.*");
+        UrlPatternRule rule2 = new UrlPatternRule("exampleRule", ".*example\\.com.*");
+        UrlPatternRule rule3 = new UrlPatternRule("pdfRule", ".*\\.pdf$");
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+        ruleManager.addRule(rule3);
+
+        ResponseData responseData1 = new ResponseData();
+        responseData1.setUrl("https://example.com/page");
+        Rule matchedRule1 = ruleManager.getRule(responseData1);
+        assertEquals("httpRule", matchedRule1.getRuleId()); // First match
+
+        ResponseData responseData2 = new ResponseData();
+        responseData2.setUrl("ftp://files.com/document.pdf");
+        Rule matchedRule2 = ruleManager.getRule(responseData2);
+        assertEquals("pdfRule", matchedRule2.getRuleId());
+
+        ResponseData responseData3 = new ResponseData();
+        responseData3.setUrl("file:///local/file.txt");
+        Rule matchedRule3 = ruleManager.getRule(responseData3);
+        assertNull(matchedRule3); // No match
+    }
+
+    /**
+     * Test rule order preservation
+     */
+    public void test_ruleOrderPreservation() {
+        TestRule rule1 = new TestRule("rule1", false);
+        TestRule rule2 = new TestRule("rule2", true);
+        TestRule rule3 = new TestRule("rule3", false);
+        TestRule rule4 = new TestRule("rule4", true);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+        ruleManager.addRule(rule3);
+        ruleManager.addRule(rule4);
+
+        List<Rule> rules = ruleManager.getRules();
+        assertEquals(4, rules.size());
+        assertEquals("rule1", rules.get(0).getRuleId());
+        assertEquals("rule2", rules.get(1).getRuleId());
+        assertEquals("rule3", rules.get(2).getRuleId());
+        assertEquals("rule4", rules.get(3).getRuleId());
+    }
+
+    /**
+     * Test adding duplicate rules
+     */
+    public void test_addRule_duplicates() {
+        TestRule rule = new TestRule("rule1", true);
+
+        ruleManager.addRule(rule);
+        ruleManager.addRule(rule); // Add same rule again
+
+        assertEquals(2, ruleManager.getRuleCount());
+        assertTrue(ruleManager.hasRule(rule));
+
+        // Remove one instance
+        assertTrue(ruleManager.removeRule(rule));
+        assertEquals(1, ruleManager.getRuleCount());
+        assertTrue(ruleManager.hasRule(rule));
+
+        // Remove second instance
+        assertTrue(ruleManager.removeRule(rule));
+        assertEquals(0, ruleManager.getRuleCount());
+        assertFalse(ruleManager.hasRule(rule));
+    }
+
+    /**
+     * Test empty RuleManager
+     */
+    public void test_emptyRuleManager() {
+        assertEquals(0, ruleManager.getRuleCount());
+
+        ResponseData responseData = new ResponseData();
+        assertNull(ruleManager.getRule(responseData));
+
+        TestRule rule = new TestRule("rule1", true);
+        assertFalse(ruleManager.hasRule(rule));
+        assertFalse(ruleManager.removeRule(rule));
+    }
+
+    /**
+     * Test clearing all rules
+     */
+    public void test_clearRules() {
+        TestRule rule1 = new TestRule("rule1", true);
+        TestRule rule2 = new TestRule("rule2", false);
+        TestRule rule3 = new TestRule("rule3", true);
+
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+        ruleManager.addRule(rule3);
+
+        assertEquals(3, ruleManager.getRuleCount());
+
+        ruleManager.clearRules();
+
+        assertEquals(0, ruleManager.getRuleCount());
+        assertFalse(ruleManager.hasRule(rule1));
+        assertFalse(ruleManager.hasRule(rule2));
+        assertFalse(ruleManager.hasRule(rule3));
+    }
+
+    /**
+     * Test getRule call count
+     */
+    public void test_getRuleCallCount() {
+        TestRule rule = new TestRule("rule1", true);
+        ruleManager.addRule(rule);
+
+        ResponseData responseData = new ResponseData();
+
+        assertEquals(0, ruleManager.getGetRuleCallCount());
+
+        ruleManager.getRule(responseData);
+        assertEquals(1, ruleManager.getGetRuleCallCount());
+
+        ruleManager.getRule(responseData);
+        assertEquals(2, ruleManager.getGetRuleCallCount());
+
+        ruleManager.getRule(null);
+        assertEquals(3, ruleManager.getGetRuleCallCount());
+    }
+
+    /**
+     * Test concurrent rule additions
+     */
+    public void test_concurrentAddRule() throws Exception {
+        final ThreadSafeRuleManager threadSafeManager = new ThreadSafeRuleManager();
+        final int threadCount = 10;
+        final int rulesPerThread = 100;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        startLatch.await();
+                        for (int j = 0; j < rulesPerThread; j++) {
+                            TestRule rule = new TestRule("rule_" + threadId + "_" + j, true);
+                            threadSafeManager.addRule(rule);
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }
+            }).start();
+        }
+
+        startLatch.countDown();
+        endLatch.await();
+
+        // Verify all rules were added (can't check exact count due to thread-safe implementation)
+        ResponseData responseData = new ResponseData();
+        assertNotNull(threadSafeManager.getRule(responseData)); // At least one rule should match
+    }
+
+    /**
+     * Test concurrent rule removals
+     */
+    public void test_concurrentRemoveRule() throws Exception {
+        final ThreadSafeRuleManager threadSafeManager = new ThreadSafeRuleManager();
+        final List<TestRule> rules = new ArrayList<>();
+
+        // Add rules
+        for (int i = 0; i < 100; i++) {
+            TestRule rule = new TestRule("rule_" + i, true);
+            rules.add(rule);
+            threadSafeManager.addRule(rule);
+        }
+
+        final int threadCount = 10;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+        final AtomicInteger removeCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        startLatch.await();
+                        for (int j = threadId; j < rules.size(); j += threadCount) {
+                            if (threadSafeManager.removeRule(rules.get(j))) {
+                                removeCount.incrementAndGet();
+                            }
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }
+            }).start();
+        }
+
+        startLatch.countDown();
+        endLatch.await();
+
+        // All rules should be removed
+        assertEquals(100, removeCount.get());
+    }
+
+    /**
+     * Test mixed operations
+     */
+    public void test_mixedOperations() {
+        TestRule rule1 = new TestRule("rule1", false);
+        TestRule rule2 = new TestRule("rule2", true);
+        TestRule rule3 = new TestRule("rule3", false);
+        TestRule rule4 = new TestRule("rule4", true);
+
+        // Add rules
+        ruleManager.addRule(rule1);
+        ruleManager.addRule(rule2);
+        assertEquals(2, ruleManager.getRuleCount());
+
+        // Check existence
+        assertTrue(ruleManager.hasRule(rule1));
+        assertTrue(ruleManager.hasRule(rule2));
+        assertFalse(ruleManager.hasRule(rule3));
+
+        // Get matching rule
+        ResponseData responseData = new ResponseData();
+        Rule matched = ruleManager.getRule(responseData);
+        assertEquals("rule2", matched.getRuleId());
+
+        // Add at index
+        ruleManager.addRule(1, rule3);
+        assertEquals(3, ruleManager.getRuleCount());
+
+        // Remove rule
+        assertTrue(ruleManager.removeRule(rule2));
+        assertEquals(2, ruleManager.getRuleCount());
+
+        // Get rule after removal
+        matched = ruleManager.getRule(responseData);
+        assertNull(matched); // No matching rule now
+
+        // Add rule4 which matches
+        ruleManager.addRule(rule4);
+        matched = ruleManager.getRule(responseData);
+        assertEquals("rule4", matched.getRuleId());
+    }
+
+    /**
+     * Test rule replacement scenario
+     */
+    public void test_ruleReplacement() {
+        TestRule oldRule = new TestRule("rule1", false);
+        TestRule newRule = new TestRule("rule1", true); // Same ID, different behavior
+
+        ruleManager.addRule(oldRule);
+
+        ResponseData responseData = new ResponseData();
+        assertNull(ruleManager.getRule(responseData)); // Old rule doesn't match
+
+        // Replace old rule with new rule
+        ruleManager.removeRule(oldRule);
+        ruleManager.addRule(newRule);
+
+        Rule matched = ruleManager.getRule(responseData);
+        assertNotNull(matched);
+        assertEquals("rule1", matched.getRuleId()); // New rule matches
+    }
+}

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/rule/RuleTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/rule/RuleTest.java
@@ -1,0 +1,677 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.rule;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.codelibs.fess.crawler.entity.ResponseData;
+import org.codelibs.fess.crawler.processor.ResponseProcessor;
+import org.dbflute.utflute.core.PlainTestCase;
+
+/**
+ * Test class for Rule interface.
+ * Tests the contract and behavior of Rule implementations.
+ */
+public class RuleTest extends PlainTestCase {
+
+    /**
+     * Test implementation of Rule interface for testing purposes
+     */
+    public static class TestRule implements Rule {
+        private static final long serialVersionUID = 1L;
+
+        private final String ruleId;
+        private final ResponseProcessor responseProcessor;
+        private final boolean matchResult;
+        private int matchCallCount = 0;
+
+        public TestRule(String ruleId, ResponseProcessor responseProcessor, boolean matchResult) {
+            this.ruleId = ruleId;
+            this.responseProcessor = responseProcessor;
+            this.matchResult = matchResult;
+        }
+
+        @Override
+        public boolean match(ResponseData responseData) {
+            matchCallCount++;
+            return matchResult;
+        }
+
+        @Override
+        public String getRuleId() {
+            return ruleId;
+        }
+
+        @Override
+        public ResponseProcessor getResponseProcessor() {
+            return responseProcessor;
+        }
+
+        public int getMatchCallCount() {
+            return matchCallCount;
+        }
+    }
+
+    /**
+     * Configurable test rule implementation
+     */
+    public static class ConfigurableRule implements Rule {
+        private static final long serialVersionUID = 1L;
+
+        private String ruleId;
+        private ResponseProcessor responseProcessor;
+        private Map<String, String> conditions = new HashMap<>();
+
+        @Override
+        public boolean match(ResponseData responseData) {
+            if (responseData == null) {
+                return false;
+            }
+
+            // Check URL condition
+            String urlCondition = conditions.get("url");
+            if (urlCondition != null && responseData.getUrl() != null) {
+                if (!responseData.getUrl().matches(urlCondition)) {
+                    return false;
+                }
+            }
+
+            // Check MIME type condition
+            String mimeTypeCondition = conditions.get("mimeType");
+            if (mimeTypeCondition != null && responseData.getMimeType() != null) {
+                if (!responseData.getMimeType().matches(mimeTypeCondition)) {
+                    return false;
+                }
+            }
+
+            // Check status code condition
+            String statusCodeCondition = conditions.get("statusCode");
+            if (statusCodeCondition != null) {
+                int expectedCode = Integer.parseInt(statusCodeCondition);
+                if (responseData.getHttpStatusCode() != expectedCode) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        @Override
+        public String getRuleId() {
+            return ruleId;
+        }
+
+        @Override
+        public ResponseProcessor getResponseProcessor() {
+            return responseProcessor;
+        }
+
+        public void setRuleId(String ruleId) {
+            this.ruleId = ruleId;
+        }
+
+        public void setResponseProcessor(ResponseProcessor responseProcessor) {
+            this.responseProcessor = responseProcessor;
+        }
+
+        public void addCondition(String key, String value) {
+            conditions.put(key, value);
+        }
+
+        public void clearConditions() {
+            conditions.clear();
+        }
+    }
+
+    /**
+     * Test response processor implementation
+     */
+    public static class TestResponseProcessor implements ResponseProcessor, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+        private int processCount = 0;
+
+        public TestResponseProcessor(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void process(ResponseData responseData) {
+            processCount++;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getProcessCount() {
+            return processCount;
+        }
+    }
+
+    /**
+     * Test basic Rule implementation
+     */
+    public void test_basicRuleImplementation() {
+        TestResponseProcessor processor = new TestResponseProcessor("testProcessor");
+        TestRule rule = new TestRule("rule1", processor, true);
+
+        // Test getRuleId
+        assertEquals("rule1", rule.getRuleId());
+
+        // Test getResponseProcessor
+        assertSame(processor, rule.getResponseProcessor());
+
+        // Test match
+        ResponseData responseData = new ResponseData();
+        assertTrue(rule.match(responseData));
+        assertEquals(1, rule.getMatchCallCount());
+    }
+
+    /**
+     * Test Rule with always true match
+     */
+    public void test_ruleAlwaysMatch() {
+        TestResponseProcessor processor = new TestResponseProcessor("alwaysMatch");
+        TestRule rule = new TestRule("alwaysRule", processor, true);
+
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+
+        assertTrue(rule.match(responseData));
+        assertTrue(rule.match(responseData));
+        assertTrue(rule.match(responseData));
+        assertEquals(3, rule.getMatchCallCount());
+    }
+
+    /**
+     * Test Rule with always false match
+     */
+    public void test_ruleNeverMatch() {
+        TestResponseProcessor processor = new TestResponseProcessor("neverMatch");
+        TestRule rule = new TestRule("neverRule", processor, false);
+
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+
+        assertFalse(rule.match(responseData));
+        assertFalse(rule.match(responseData));
+        assertFalse(rule.match(responseData));
+        assertEquals(3, rule.getMatchCallCount());
+    }
+
+    /**
+     * Test Rule with null ResponseData
+     */
+    public void test_matchWithNullResponseData() {
+        ConfigurableRule rule = new ConfigurableRule();
+        rule.setRuleId("nullTest");
+        rule.setResponseProcessor(new TestResponseProcessor("nullProcessor"));
+
+        // Should handle null gracefully
+        assertFalse(rule.match(null));
+    }
+
+    /**
+     * Test Rule with null rule ID
+     */
+    public void test_nullRuleId() {
+        TestRule rule = new TestRule(null, new TestResponseProcessor("test"), true);
+
+        assertNull(rule.getRuleId());
+
+        ResponseData responseData = new ResponseData();
+        assertTrue(rule.match(responseData));
+    }
+
+    /**
+     * Test Rule with null ResponseProcessor
+     */
+    public void test_nullResponseProcessor() {
+        TestRule rule = new TestRule("rule1", null, true);
+
+        assertEquals("rule1", rule.getRuleId());
+        assertNull(rule.getResponseProcessor());
+
+        ResponseData responseData = new ResponseData();
+        assertTrue(rule.match(responseData));
+    }
+
+    /**
+     * Test ConfigurableRule with URL condition
+     */
+    public void test_configurableRule_urlCondition() {
+        ConfigurableRule rule = new ConfigurableRule();
+        rule.setRuleId("urlRule");
+        rule.setResponseProcessor(new TestResponseProcessor("urlProcessor"));
+        rule.addCondition("url", "https?://.*\\.example\\.com/.*");
+
+        ResponseData responseData1 = new ResponseData();
+        responseData1.setUrl("http://www.example.com/page");
+        assertTrue(rule.match(responseData1));
+
+        ResponseData responseData2 = new ResponseData();
+        responseData2.setUrl("https://api.example.com/v1/users");
+        assertTrue(rule.match(responseData2));
+
+        ResponseData responseData3 = new ResponseData();
+        responseData3.setUrl("http://other.com/page");
+        assertFalse(rule.match(responseData3));
+    }
+
+    /**
+     * Test ConfigurableRule with MIME type condition
+     */
+    public void test_configurableRule_mimeTypeCondition() {
+        ConfigurableRule rule = new ConfigurableRule();
+        rule.setRuleId("mimeRule");
+        rule.setResponseProcessor(new TestResponseProcessor("mimeProcessor"));
+        rule.addCondition("mimeType", "text/.*");
+
+        ResponseData responseData1 = new ResponseData();
+        responseData1.setMimeType("text/html");
+        assertTrue(rule.match(responseData1));
+
+        ResponseData responseData2 = new ResponseData();
+        responseData2.setMimeType("text/plain");
+        assertTrue(rule.match(responseData2));
+
+        ResponseData responseData3 = new ResponseData();
+        responseData3.setMimeType("image/png");
+        assertFalse(rule.match(responseData3));
+    }
+
+    /**
+     * Test ConfigurableRule with status code condition
+     */
+    public void test_configurableRule_statusCodeCondition() {
+        ConfigurableRule rule = new ConfigurableRule();
+        rule.setRuleId("statusRule");
+        rule.setResponseProcessor(new TestResponseProcessor("statusProcessor"));
+        rule.addCondition("statusCode", "200");
+
+        ResponseData responseData1 = new ResponseData();
+        responseData1.setHttpStatusCode(200);
+        assertTrue(rule.match(responseData1));
+
+        ResponseData responseData2 = new ResponseData();
+        responseData2.setHttpStatusCode(404);
+        assertFalse(rule.match(responseData2));
+
+        ResponseData responseData3 = new ResponseData();
+        responseData3.setHttpStatusCode(500);
+        assertFalse(rule.match(responseData3));
+    }
+
+    /**
+     * Test ConfigurableRule with multiple conditions (AND logic)
+     */
+    public void test_configurableRule_multipleConditions() {
+        ConfigurableRule rule = new ConfigurableRule();
+        rule.setRuleId("multiRule");
+        rule.setResponseProcessor(new TestResponseProcessor("multiProcessor"));
+        rule.addCondition("url", "https://.*\\.example\\.com/.*");
+        rule.addCondition("mimeType", "text/html");
+        rule.addCondition("statusCode", "200");
+
+        // All conditions match
+        ResponseData responseData1 = new ResponseData();
+        responseData1.setUrl("https://www.example.com/page");
+        responseData1.setMimeType("text/html");
+        responseData1.setHttpStatusCode(200);
+        assertTrue(rule.match(responseData1));
+
+        // URL doesn't match
+        ResponseData responseData2 = new ResponseData();
+        responseData2.setUrl("https://other.com/page");
+        responseData2.setMimeType("text/html");
+        responseData2.setHttpStatusCode(200);
+        assertFalse(rule.match(responseData2));
+
+        // MIME type doesn't match
+        ResponseData responseData3 = new ResponseData();
+        responseData3.setUrl("https://www.example.com/page");
+        responseData3.setMimeType("application/json");
+        responseData3.setHttpStatusCode(200);
+        assertFalse(rule.match(responseData3));
+
+        // Status code doesn't match
+        ResponseData responseData4 = new ResponseData();
+        responseData4.setUrl("https://www.example.com/page");
+        responseData4.setMimeType("text/html");
+        responseData4.setHttpStatusCode(404);
+        assertFalse(rule.match(responseData4));
+    }
+
+    /**
+     * Test Rule serialization
+     */
+    public void test_serialization() throws Exception {
+        TestResponseProcessor processor = new TestResponseProcessor("serializeProcessor");
+        TestRule originalRule = new TestRule("serializeRule", processor, true);
+
+        // Serialize
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(originalRule);
+        oos.close();
+
+        // Deserialize
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        TestRule deserializedRule = (TestRule) ois.readObject();
+        ois.close();
+
+        // Verify
+        assertEquals(originalRule.getRuleId(), deserializedRule.getRuleId());
+        assertNotNull(deserializedRule.getResponseProcessor());
+
+        ResponseData responseData = new ResponseData();
+        assertTrue(deserializedRule.match(responseData));
+    }
+
+    /**
+     * Test multiple rules with same ResponseProcessor
+     */
+    public void test_multipleRulesWithSameProcessor() {
+        TestResponseProcessor sharedProcessor = new TestResponseProcessor("shared");
+
+        TestRule rule1 = new TestRule("rule1", sharedProcessor, true);
+        TestRule rule2 = new TestRule("rule2", sharedProcessor, false);
+        TestRule rule3 = new TestRule("rule3", sharedProcessor, true);
+
+        // Same processor instance
+        assertSame(sharedProcessor, rule1.getResponseProcessor());
+        assertSame(sharedProcessor, rule2.getResponseProcessor());
+        assertSame(sharedProcessor, rule3.getResponseProcessor());
+
+        // Different rule IDs
+        assertEquals("rule1", rule1.getRuleId());
+        assertEquals("rule2", rule2.getRuleId());
+        assertEquals("rule3", rule3.getRuleId());
+
+        // Different match results
+        ResponseData responseData = new ResponseData();
+        assertTrue(rule1.match(responseData));
+        assertFalse(rule2.match(responseData));
+        assertTrue(rule3.match(responseData));
+    }
+
+    /**
+     * Test rule with empty string ID
+     */
+    public void test_emptyStringRuleId() {
+        TestRule rule = new TestRule("", new TestResponseProcessor("empty"), true);
+
+        assertEquals("", rule.getRuleId());
+        assertNotNull(rule.getResponseProcessor());
+
+        ResponseData responseData = new ResponseData();
+        assertTrue(rule.match(responseData));
+    }
+
+    /**
+     * Test ConfigurableRule condition clearing
+     */
+    public void test_configurableRule_clearConditions() {
+        ConfigurableRule rule = new ConfigurableRule();
+        rule.setRuleId("clearRule");
+        rule.setResponseProcessor(new TestResponseProcessor("clearProcessor"));
+
+        // Add conditions
+        rule.addCondition("url", "https://.*");
+        rule.addCondition("mimeType", "text/.*");
+
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+        responseData.setMimeType("image/png");
+
+        // Should not match with conditions
+        assertFalse(rule.match(responseData));
+
+        // Clear conditions
+        rule.clearConditions();
+
+        // Should match after clearing conditions
+        assertTrue(rule.match(responseData));
+    }
+
+    /**
+     * Test rule matching with various ResponseData states
+     */
+    public void test_matchWithVariousResponseDataStates() {
+        ConfigurableRule rule = new ConfigurableRule();
+        rule.setRuleId("stateRule");
+        rule.setResponseProcessor(new TestResponseProcessor("stateProcessor"));
+
+        // Empty ResponseData
+        ResponseData emptyData = new ResponseData();
+        assertTrue(rule.match(emptyData));
+
+        // ResponseData with only URL
+        ResponseData urlOnlyData = new ResponseData();
+        urlOnlyData.setUrl("http://example.com");
+        assertTrue(rule.match(urlOnlyData));
+
+        // ResponseData with only MIME type
+        ResponseData mimeOnlyData = new ResponseData();
+        mimeOnlyData.setMimeType("text/html");
+        assertTrue(rule.match(mimeOnlyData));
+
+        // ResponseData with only status code
+        ResponseData statusOnlyData = new ResponseData();
+        statusOnlyData.setHttpStatusCode(200);
+        assertTrue(rule.match(statusOnlyData));
+
+        // Full ResponseData
+        ResponseData fullData = new ResponseData();
+        fullData.setUrl("http://example.com/page");
+        fullData.setMimeType("text/html");
+        fullData.setHttpStatusCode(200);
+        fullData.setCharSet("UTF-8");
+        fullData.setContentLength(1024L);
+        assertTrue(rule.match(fullData));
+    }
+
+    /**
+     * Test concurrent rule matching
+     */
+    public void test_concurrentRuleMatching() throws Exception {
+        final ConfigurableRule rule = new ConfigurableRule();
+        rule.setRuleId("concurrentRule");
+        rule.setResponseProcessor(new TestResponseProcessor("concurrentProcessor"));
+        rule.addCondition("url", "https://.*\\.example\\.com/.*");
+
+        final int threadCount = 10;
+        final int matchesPerThread = 100;
+        final AtomicInteger matchCount = new AtomicInteger(0);
+        final AtomicInteger noMatchCount = new AtomicInteger(0);
+        final List<Exception> exceptions = new ArrayList<>();
+
+        Thread[] threads = new Thread[threadCount];
+        for (int i = 0; i < threadCount; i++) {
+            final int threadIndex = i;
+            threads[i] = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        for (int j = 0; j < matchesPerThread; j++) {
+                            ResponseData responseData = new ResponseData();
+                            if (threadIndex % 2 == 0) {
+                                responseData.setUrl("https://www.example.com/page" + j);
+                                if (rule.match(responseData)) {
+                                    matchCount.incrementAndGet();
+                                }
+                            } else {
+                                responseData.setUrl("https://other.com/page" + j);
+                                if (!rule.match(responseData)) {
+                                    noMatchCount.incrementAndGet();
+                                }
+                            }
+                        }
+                    } catch (Exception e) {
+                        synchronized (exceptions) {
+                            exceptions.add(e);
+                        }
+                    }
+                }
+            });
+        }
+
+        // Start all threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // Wait for all threads
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // Verify results
+        assertTrue(exceptions.isEmpty());
+        assertEquals(threadCount / 2 * matchesPerThread, matchCount.get());
+        assertEquals(threadCount / 2 * matchesPerThread, noMatchCount.get());
+    }
+
+    /**
+     * Test rule with special characters in conditions
+     */
+    public void test_specialCharactersInConditions() {
+        ConfigurableRule rule = new ConfigurableRule();
+        rule.setRuleId("specialRule");
+        rule.setResponseProcessor(new TestResponseProcessor("specialProcessor"));
+
+        // Test with regex special characters
+        rule.addCondition("url", "https://example\\.com/\\?param=.*");
+
+        ResponseData responseData1 = new ResponseData();
+        responseData1.setUrl("https://example.com/?param=value");
+        assertTrue(rule.match(responseData1));
+
+        ResponseData responseData2 = new ResponseData();
+        responseData2.setUrl("https://exampleXcom/?param=value");
+        assertFalse(rule.match(responseData2));
+    }
+
+    /**
+     * Test rule ID uniqueness
+     */
+    public void test_ruleIdUniqueness() {
+        List<Rule> rules = new ArrayList<>();
+
+        // Create rules with unique IDs
+        for (int i = 0; i < 100; i++) {
+            TestRule rule = new TestRule("rule_" + i, new TestResponseProcessor("processor_" + i), true);
+            rules.add(rule);
+        }
+
+        // Verify all IDs are unique
+        for (int i = 0; i < rules.size(); i++) {
+            for (int j = i + 1; j < rules.size(); j++) {
+                assertNotSame(rules.get(i).getRuleId(), rules.get(j).getRuleId());
+            }
+        }
+    }
+
+    /**
+     * Test rule processor chain behavior
+     */
+    public void test_ruleProcessorChain() {
+        final List<String> executionOrder = new ArrayList<>();
+
+        // Create custom processor that tracks execution
+        ResponseProcessor processor = new ResponseProcessor() {
+            @Override
+            public void process(ResponseData responseData) {
+                executionOrder.add("processor_executed");
+            }
+        };
+
+        TestRule rule = new TestRule("chainRule", processor, true);
+
+        ResponseData responseData = new ResponseData();
+        if (rule.match(responseData)) {
+            executionOrder.add("match_true");
+            rule.getResponseProcessor().process(responseData);
+        }
+
+        assertEquals(2, executionOrder.size());
+        assertEquals("match_true", executionOrder.get(0));
+        assertEquals("processor_executed", executionOrder.get(1));
+    }
+
+    /**
+     * Test rule with very long rule ID
+     */
+    public void test_veryLongRuleId() {
+        StringBuilder longId = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            longId.append("verylongruleid_");
+        }
+
+        TestRule rule = new TestRule(longId.toString(), new TestResponseProcessor("longProcessor"), true);
+
+        assertEquals(longId.toString(), rule.getRuleId());
+
+        ResponseData responseData = new ResponseData();
+        assertTrue(rule.match(responseData));
+    }
+
+    /**
+     * Test rule behavior consistency
+     */
+    public void test_ruleBehaviorConsistency() {
+        TestRule rule = new TestRule("consistentRule", new TestResponseProcessor("consistentProcessor"), true);
+
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+
+        // Multiple calls should return same result
+        boolean firstResult = rule.match(responseData);
+        boolean secondResult = rule.match(responseData);
+        boolean thirdResult = rule.match(responseData);
+
+        assertEquals(firstResult, secondResult);
+        assertEquals(secondResult, thirdResult);
+
+        // Rule ID should remain constant
+        String id1 = rule.getRuleId();
+        String id2 = rule.getRuleId();
+        String id3 = rule.getRuleId();
+
+        assertEquals(id1, id2);
+        assertEquals(id2, id3);
+
+        // Processor should remain the same instance
+        ResponseProcessor proc1 = rule.getResponseProcessor();
+        ResponseProcessor proc2 = rule.getResponseProcessor();
+        ResponseProcessor proc3 = rule.getResponseProcessor();
+
+        assertSame(proc1, proc2);
+        assertSame(proc2, proc3);
+    }
+}

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/rule/impl/AbstractRuleTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/rule/impl/AbstractRuleTest.java
@@ -1,0 +1,681 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.rule.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
+import org.codelibs.fess.crawler.entity.ResponseData;
+import org.codelibs.fess.crawler.processor.ResponseProcessor;
+import org.codelibs.fess.crawler.rule.Rule;
+import org.codelibs.fess.crawler.rule.RuleManager;
+import org.dbflute.utflute.core.PlainTestCase;
+
+/**
+ * Test class for AbstractRule.
+ * Tests the abstract rule implementation and its common functionality.
+ */
+public class AbstractRuleTest extends PlainTestCase {
+
+    /**
+     * Concrete implementation of AbstractRule for testing
+     */
+    public static class TestAbstractRule extends AbstractRule {
+        private static final long serialVersionUID = 1L;
+
+        private boolean matchResult = true;
+        private int matchCallCount = 0;
+        private ResponseData lastResponseData = null;
+
+        @Override
+        public boolean match(ResponseData responseData) {
+            matchCallCount++;
+            lastResponseData = responseData;
+            return matchResult;
+        }
+
+        public void setMatchResult(boolean matchResult) {
+            this.matchResult = matchResult;
+        }
+
+        public int getMatchCallCount() {
+            return matchCallCount;
+        }
+
+        public ResponseData getLastResponseData() {
+            return lastResponseData;
+        }
+
+        public void resetCounters() {
+            matchCallCount = 0;
+            lastResponseData = null;
+        }
+    }
+
+    /**
+     * Another concrete implementation for testing different scenarios
+     */
+    public static class ConditionalAbstractRule extends AbstractRule {
+        private static final long serialVersionUID = 1L;
+
+        private String urlPattern;
+        private String mimeTypePattern;
+
+        @Override
+        public boolean match(ResponseData responseData) {
+            if (responseData == null) {
+                return false;
+            }
+
+            boolean urlMatch = true;
+            if (urlPattern != null && responseData.getUrl() != null) {
+                urlMatch = responseData.getUrl().matches(urlPattern);
+            }
+
+            boolean mimeMatch = true;
+            if (mimeTypePattern != null && responseData.getMimeType() != null) {
+                mimeMatch = responseData.getMimeType().matches(mimeTypePattern);
+            }
+
+            return urlMatch && mimeMatch;
+        }
+
+        public void setUrlPattern(String urlPattern) {
+            this.urlPattern = urlPattern;
+        }
+
+        public void setMimeTypePattern(String mimeTypePattern) {
+            this.mimeTypePattern = mimeTypePattern;
+        }
+    }
+
+    /**
+     * Test RuleManager implementation
+     */
+    public static class TestRuleManager implements RuleManager {
+        private final List<Rule> rules = new ArrayList<>();
+
+        @Override
+        public Rule getRule(ResponseData responseData) {
+            for (Rule rule : rules) {
+                if (rule != null && rule.match(responseData)) {
+                    return rule;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public void addRule(Rule rule) {
+            if (rule != null) {
+                rules.add(rule);
+            }
+        }
+
+        @Override
+        public void addRule(int index, Rule rule) {
+            if (rule != null) {
+                rules.add(index, rule);
+            }
+        }
+
+        @Override
+        public boolean removeRule(Rule rule) {
+            return rules.remove(rule);
+        }
+
+        @Override
+        public boolean hasRule(Rule rule) {
+            return rules.contains(rule);
+        }
+
+        public List<Rule> getRules() {
+            return new ArrayList<>(rules);
+        }
+
+        public void clearRules() {
+            rules.clear();
+        }
+    }
+
+    /**
+     * Test ResponseProcessor implementation
+     */
+    public static class TestResponseProcessor implements ResponseProcessor, Serializable {
+        private static final long serialVersionUID = 1L;
+        private int processCount = 0;
+        private ResponseData lastProcessedData = null;
+
+        @Override
+        public void process(ResponseData responseData) {
+            processCount++;
+            lastProcessedData = responseData;
+        }
+
+        public int getProcessCount() {
+            return processCount;
+        }
+
+        public ResponseData getLastProcessedData() {
+            return lastProcessedData;
+        }
+
+        public void reset() {
+            processCount = 0;
+            lastProcessedData = null;
+        }
+    }
+
+    private StandardCrawlerContainer container;
+    private TestRuleManager ruleManager;
+    private TestAbstractRule testRule;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        ruleManager = new TestRuleManager();
+        container = new StandardCrawlerContainer().singleton("ruleManager", ruleManager);
+
+        testRule = new TestAbstractRule();
+        testRule.crawlerContainer = container;
+    }
+
+    /**
+     * Test getRuleId and setRuleId
+     */
+    public void test_ruleId_getterSetter() {
+        // Initial state
+        assertNull(testRule.getRuleId());
+
+        // Set rule ID
+        testRule.setRuleId("testRule1");
+        assertEquals("testRule1", testRule.getRuleId());
+
+        // Change rule ID
+        testRule.setRuleId("changedRule");
+        assertEquals("changedRule", testRule.getRuleId());
+
+        // Set null rule ID
+        testRule.setRuleId(null);
+        assertNull(testRule.getRuleId());
+
+        // Set empty rule ID
+        testRule.setRuleId("");
+        assertEquals("", testRule.getRuleId());
+    }
+
+    /**
+     * Test getResponseProcessor and setResponseProcessor
+     */
+    public void test_responseProcessor_getterSetter() {
+        // Initial state
+        assertNull(testRule.getResponseProcessor());
+
+        // Set response processor
+        TestResponseProcessor processor = new TestResponseProcessor();
+        testRule.setResponseProcessor(processor);
+        assertSame(processor, testRule.getResponseProcessor());
+
+        // Change response processor
+        TestResponseProcessor newProcessor = new TestResponseProcessor();
+        testRule.setResponseProcessor(newProcessor);
+        assertSame(newProcessor, testRule.getResponseProcessor());
+        assertNotSame(processor, testRule.getResponseProcessor());
+
+        // Set null processor
+        testRule.setResponseProcessor(null);
+        assertNull(testRule.getResponseProcessor());
+    }
+
+    /**
+     * Test register method with index 0
+     */
+    public void test_register_indexZero() {
+        testRule.setRuleId("rule1");
+
+        // Pre-add some rules
+        TestAbstractRule existingRule = new TestAbstractRule();
+        existingRule.setRuleId("existing");
+        ruleManager.addRule(existingRule);
+
+        // Register at index 0
+        testRule.register(0);
+
+        List<Rule> rules = ruleManager.getRules();
+        assertEquals(2, rules.size());
+        assertEquals("rule1", rules.get(0).getRuleId());
+        assertEquals("existing", rules.get(1).getRuleId());
+    }
+
+    /**
+     * Test register method with middle index
+     */
+    public void test_register_middleIndex() {
+        // Pre-add some rules
+        TestAbstractRule rule1 = new TestAbstractRule();
+        rule1.setRuleId("rule1");
+        ruleManager.addRule(rule1);
+
+        TestAbstractRule rule2 = new TestAbstractRule();
+        rule2.setRuleId("rule2");
+        ruleManager.addRule(rule2);
+
+        // Register at index 1
+        testRule.setRuleId("middle");
+        testRule.register(1);
+
+        List<Rule> rules = ruleManager.getRules();
+        assertEquals(3, rules.size());
+        assertEquals("rule1", rules.get(0).getRuleId());
+        assertEquals("middle", rules.get(1).getRuleId());
+        assertEquals("rule2", rules.get(2).getRuleId());
+    }
+
+    /**
+     * Test register method with last index
+     */
+    public void test_register_lastIndex() {
+        testRule.setRuleId("lastRule");
+
+        // Pre-add some rules
+        TestAbstractRule rule1 = new TestAbstractRule();
+        rule1.setRuleId("rule1");
+        ruleManager.addRule(rule1);
+
+        TestAbstractRule rule2 = new TestAbstractRule();
+        rule2.setRuleId("rule2");
+        ruleManager.addRule(rule2);
+
+        // Register at last index
+        testRule.register(2);
+
+        List<Rule> rules = ruleManager.getRules();
+        assertEquals(3, rules.size());
+        assertEquals("lastRule", rules.get(2).getRuleId());
+    }
+
+    /**
+     * Test register method on empty RuleManager
+     */
+    public void test_register_emptyRuleManager() {
+        testRule.setRuleId("firstRule");
+
+        // Register on empty manager
+        testRule.register(0);
+
+        List<Rule> rules = ruleManager.getRules();
+        assertEquals(1, rules.size());
+        assertEquals("firstRule", rules.get(0).getRuleId());
+        assertTrue(ruleManager.hasRule(testRule));
+    }
+
+    /**
+     * Test multiple properties configuration
+     */
+    public void test_multiplePropertiesConfiguration() {
+        TestResponseProcessor processor = new TestResponseProcessor();
+
+        testRule.setRuleId("multiRule");
+        testRule.setResponseProcessor(processor);
+
+        assertEquals("multiRule", testRule.getRuleId());
+        assertSame(processor, testRule.getResponseProcessor());
+
+        // Register and verify
+        testRule.register(0);
+        assertTrue(ruleManager.hasRule(testRule));
+
+        // Verify registered rule maintains properties
+        Rule registeredRule = ruleManager.getRules().get(0);
+        assertEquals("multiRule", registeredRule.getRuleId());
+        assertSame(processor, registeredRule.getResponseProcessor());
+    }
+
+    /**
+     * Test match method implementation
+     */
+    public void test_match_implementation() {
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+
+        // Test default match (true)
+        assertTrue(testRule.match(responseData));
+        assertEquals(1, testRule.getMatchCallCount());
+        assertSame(responseData, testRule.getLastResponseData());
+
+        // Change match result
+        testRule.setMatchResult(false);
+        assertFalse(testRule.match(responseData));
+        assertEquals(2, testRule.getMatchCallCount());
+
+        // Test with null ResponseData
+        testRule.setMatchResult(true);
+        assertTrue(testRule.match(null));
+        assertEquals(3, testRule.getMatchCallCount());
+        assertNull(testRule.getLastResponseData());
+    }
+
+    /**
+     * Test ConditionalAbstractRule implementation
+     */
+    public void test_conditionalRule_implementation() {
+        ConditionalAbstractRule conditionalRule = new ConditionalAbstractRule();
+        conditionalRule.crawlerContainer = container;
+        conditionalRule.setRuleId("conditionalRule");
+
+        // Set patterns
+        conditionalRule.setUrlPattern("https?://.*\\.example\\.com/.*");
+        conditionalRule.setMimeTypePattern("text/.*");
+
+        // Test matching
+        ResponseData responseData1 = new ResponseData();
+        responseData1.setUrl("http://www.example.com/page");
+        responseData1.setMimeType("text/html");
+        assertTrue(conditionalRule.match(responseData1));
+
+        // Test non-matching URL
+        ResponseData responseData2 = new ResponseData();
+        responseData2.setUrl("http://other.com/page");
+        responseData2.setMimeType("text/html");
+        assertFalse(conditionalRule.match(responseData2));
+
+        // Test non-matching MIME type
+        ResponseData responseData3 = new ResponseData();
+        responseData3.setUrl("http://www.example.com/page");
+        responseData3.setMimeType("image/png");
+        assertFalse(conditionalRule.match(responseData3));
+
+        // Test null ResponseData
+        assertFalse(conditionalRule.match(null));
+    }
+
+    /**
+     * Test serialization of AbstractRule
+     */
+    public void test_serialization() throws Exception {
+        TestResponseProcessor processor = new TestResponseProcessor();
+        testRule.setRuleId("serializeRule");
+        testRule.setResponseProcessor(processor);
+        testRule.setMatchResult(false);
+
+        // Serialize
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(testRule);
+        oos.close();
+
+        // Deserialize
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        TestAbstractRule deserializedRule = (TestAbstractRule) ois.readObject();
+        ois.close();
+
+        // Verify
+        assertEquals("serializeRule", deserializedRule.getRuleId());
+        assertNotNull(deserializedRule.getResponseProcessor());
+
+        // Note: crawlerContainer is transient (marked with @Resource)
+        // so it won't be serialized
+        assertNull(deserializedRule.crawlerContainer);
+    }
+
+    /**
+     * Test with null CrawlerContainer
+     */
+    public void test_nullCrawlerContainer() {
+        TestAbstractRule ruleWithoutContainer = new TestAbstractRule();
+        ruleWithoutContainer.setRuleId("noContainer");
+
+        // Properties should work without container
+        assertEquals("noContainer", ruleWithoutContainer.getRuleId());
+
+        TestResponseProcessor processor = new TestResponseProcessor();
+        ruleWithoutContainer.setResponseProcessor(processor);
+        assertSame(processor, ruleWithoutContainer.getResponseProcessor());
+
+        // Match should work
+        ResponseData responseData = new ResponseData();
+        assertTrue(ruleWithoutContainer.match(responseData));
+
+        // Register should fail with null container
+        try {
+            ruleWithoutContainer.register(0);
+            fail("Should throw exception with null container");
+        } catch (NullPointerException e) {
+            // Expected
+        }
+    }
+
+    /**
+     * Test concurrent property access
+     */
+    public void test_concurrentPropertyAccess() throws Exception {
+        final int threadCount = 10;
+        final int iterationsPerThread = 100;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+        final AtomicInteger errorCount = new AtomicInteger(0);
+
+        // Set initial values
+        testRule.setRuleId("concurrentRule");
+        TestResponseProcessor processor = new TestResponseProcessor();
+        testRule.setResponseProcessor(processor);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        startLatch.await();
+                        for (int j = 0; j < iterationsPerThread; j++) {
+                            // Read properties
+                            String ruleId = testRule.getRuleId();
+                            ResponseProcessor proc = testRule.getResponseProcessor();
+
+                            // Verify consistency
+                            if (!"concurrentRule".equals(ruleId)) {
+                                errorCount.incrementAndGet();
+                            }
+                            if (proc != processor) {
+                                errorCount.incrementAndGet();
+                            }
+
+                            // Occasionally update (half the threads)
+                            if (threadId % 2 == 0 && j % 10 == 0) {
+                                testRule.setRuleId("concurrentRule");
+                                testRule.setResponseProcessor(processor);
+                            }
+                        }
+                    } catch (Exception e) {
+                        errorCount.incrementAndGet();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }
+            }).start();
+        }
+
+        startLatch.countDown();
+        endLatch.await();
+
+        assertEquals(0, errorCount.get());
+        assertEquals("concurrentRule", testRule.getRuleId());
+        assertSame(processor, testRule.getResponseProcessor());
+    }
+
+    /**
+     * Test rule chain with AbstractRule
+     */
+    public void test_ruleChain() {
+        // Create chain of rules
+        TestAbstractRule rule1 = new TestAbstractRule();
+        rule1.crawlerContainer = container;
+        rule1.setRuleId("rule1");
+        rule1.setMatchResult(false);
+
+        TestAbstractRule rule2 = new TestAbstractRule();
+        rule2.crawlerContainer = container;
+        rule2.setRuleId("rule2");
+        rule2.setMatchResult(true);
+
+        TestAbstractRule rule3 = new TestAbstractRule();
+        rule3.crawlerContainer = container;
+        rule3.setRuleId("rule3");
+        rule3.setMatchResult(false);
+
+        // Register in order
+        rule1.register(0);
+        rule2.register(1);
+        rule3.register(2);
+
+        // Get matching rule
+        ResponseData responseData = new ResponseData();
+        Rule matchedRule = ruleManager.getRule(responseData);
+
+        assertNotNull(matchedRule);
+        assertEquals("rule2", matchedRule.getRuleId());
+    }
+
+    /**
+     * Test edge cases for rule ID
+     */
+    public void test_ruleId_edgeCases() {
+        // Very long rule ID
+        StringBuilder longId = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            longId.append("verylongruleid");
+        }
+        testRule.setRuleId(longId.toString());
+        assertEquals(longId.toString(), testRule.getRuleId());
+
+        // Special characters in rule ID
+        testRule.setRuleId("rule-id_with.special@chars#123");
+        assertEquals("rule-id_with.special@chars#123", testRule.getRuleId());
+
+        // Unicode characters
+        testRule.setRuleId("ルール日本語");
+        assertEquals("ルール日本語", testRule.getRuleId());
+
+        // Whitespace
+        testRule.setRuleId("  rule with spaces  ");
+        assertEquals("  rule with spaces  ", testRule.getRuleId());
+    }
+
+    /**
+     * Test multiple registrations of same rule
+     */
+    public void test_multipleRegistrations() {
+        testRule.setRuleId("multiRegRule");
+
+        // Register multiple times
+        testRule.register(0);
+        testRule.register(0);
+        testRule.register(1);
+
+        List<Rule> rules = ruleManager.getRules();
+        assertEquals(3, rules.size());
+
+        // All should be the same instance
+        assertSame(testRule, rules.get(0));
+        assertSame(testRule, rules.get(1));
+        assertSame(testRule, rules.get(2));
+    }
+
+    /**
+     * Test property changes after registration
+     */
+    public void test_propertyChangesAfterRegistration() {
+        TestResponseProcessor processor1 = new TestResponseProcessor();
+        testRule.setRuleId("originalId");
+        testRule.setResponseProcessor(processor1);
+
+        // Register
+        testRule.register(0);
+
+        // Verify initial state
+        Rule registeredRule = ruleManager.getRules().get(0);
+        assertEquals("originalId", registeredRule.getRuleId());
+        assertSame(processor1, registeredRule.getResponseProcessor());
+
+        // Change properties after registration
+        TestResponseProcessor processor2 = new TestResponseProcessor();
+        testRule.setRuleId("changedId");
+        testRule.setResponseProcessor(processor2);
+
+        // Verify changes are reflected (same object reference)
+        assertEquals("changedId", registeredRule.getRuleId());
+        assertSame(processor2, registeredRule.getResponseProcessor());
+    }
+
+    /**
+     * Test inheritance behavior
+     */
+    public void test_inheritanceBehavior() {
+        // Test that subclass can override match method
+        ConditionalAbstractRule conditionalRule = new ConditionalAbstractRule();
+        TestAbstractRule testRule = new TestAbstractRule();
+
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+
+        // Different implementations should behave differently
+        conditionalRule.setUrlPattern("https://.*");
+        assertFalse(conditionalRule.match(responseData)); // Doesn't match pattern
+
+        testRule.setMatchResult(true);
+        assertTrue(testRule.match(responseData)); // Always matches when set to true
+
+        // Both should inherit same property behavior
+        conditionalRule.setRuleId("conditional");
+        testRule.setRuleId("test");
+
+        assertEquals("conditional", conditionalRule.getRuleId());
+        assertEquals("test", testRule.getRuleId());
+    }
+
+    /**
+     * Test protected field access
+     */
+    public void test_protectedFieldAccess() {
+        // Test direct field access (protected fields)
+        TestAbstractRule rule = new TestAbstractRule();
+
+        // Direct field assignment
+        rule.ruleId = "directFieldAccess";
+        TestResponseProcessor processor = new TestResponseProcessor();
+        rule.responseProcessor = processor;
+        rule.crawlerContainer = container;
+
+        // Verify through getters
+        assertEquals("directFieldAccess", rule.getRuleId());
+        assertSame(processor, rule.getResponseProcessor());
+        assertSame(container, rule.crawlerContainer);
+
+        // Register should work with direct field access
+        rule.register(0);
+        assertTrue(ruleManager.hasRule(rule));
+    }
+}

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/TransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/TransformerTest.java
@@ -1,0 +1,822 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.transformer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.codelibs.fess.crawler.entity.AccessResultData;
+import org.codelibs.fess.crawler.entity.ResponseData;
+import org.codelibs.fess.crawler.entity.ResultData;
+import org.codelibs.fess.crawler.exception.CrawlerSystemException;
+import org.dbflute.utflute.core.PlainTestCase;
+
+/**
+ * Test class for Transformer interface.
+ * Tests the contract and behavior of Transformer implementations.
+ */
+public class TransformerTest extends PlainTestCase {
+
+    /**
+     * Basic test implementation of Transformer
+     */
+    public static class TestTransformer implements Transformer {
+        private String name;
+        private final AtomicInteger transformCallCount = new AtomicInteger(0);
+        private final AtomicInteger getDataCallCount = new AtomicInteger(0);
+        private ResponseData lastResponseData = null;
+        private AccessResultData<?> lastAccessResultData = null;
+
+        public TestTransformer() {
+            this.name = null;
+        }
+
+        public TestTransformer(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public ResultData transform(ResponseData responseData) {
+            transformCallCount.incrementAndGet();
+            lastResponseData = responseData;
+
+            if (responseData == null) {
+                return null;
+            }
+
+            ResultData resultData = new ResultData();
+            resultData.setTransformerName(name);
+            // Store some dummy data
+            resultData.setData("test data".getBytes());
+
+            return resultData;
+        }
+
+        @Override
+        public Object getData(AccessResultData<?> accessResultData) {
+            getDataCallCount.incrementAndGet();
+            lastAccessResultData = accessResultData;
+
+            if (accessResultData == null) {
+                return null;
+            }
+
+            byte[] data = accessResultData.getData();
+            return data != null ? new String(data) : null;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getTransformCallCount() {
+            return transformCallCount.get();
+        }
+
+        public int getGetDataCallCount() {
+            return getDataCallCount.get();
+        }
+
+        public ResponseData getLastResponseData() {
+            return lastResponseData;
+        }
+
+        public AccessResultData<?> getLastAccessResultData() {
+            return lastAccessResultData;
+        }
+
+        public void reset() {
+            transformCallCount.set(0);
+            getDataCallCount.set(0);
+            lastResponseData = null;
+            lastAccessResultData = null;
+        }
+    }
+
+    /**
+     * Transformer implementation that performs content transformation
+     */
+    public static class ContentTransformer implements Transformer {
+        private final String name;
+        private final Map<String, String> transformationRules = new HashMap<>();
+
+        public ContentTransformer(String name) {
+            this.name = name;
+        }
+
+        public void addTransformationRule(String pattern, String replacement) {
+            transformationRules.put(pattern, replacement);
+        }
+
+        @Override
+        public ResultData transform(ResponseData responseData) {
+            if (responseData == null) {
+                return null;
+            }
+
+            ResultData resultData = new ResultData();
+            resultData.setTransformerName(name);
+            // Apply transformation rules
+            try (InputStream is = responseData.getResponseBody()) {
+                byte[] bytes = is.readAllBytes();
+                String content = new String(bytes);
+                for (Map.Entry<String, String> rule : transformationRules.entrySet()) {
+                    content = content.replaceAll(rule.getKey(), rule.getValue());
+                }
+                resultData.setData(content.getBytes());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            return resultData;
+        }
+
+        @Override
+        public Object getData(AccessResultData<?> accessResultData) {
+            if (accessResultData == null) {
+                return null;
+            }
+
+            byte[] data = accessResultData.getData();
+            if (data != null) {
+                String content = new String(data);
+                // Apply transformation rules to retrieved data
+                for (Map.Entry<String, String> rule : transformationRules.entrySet()) {
+                    content = content.replaceAll(rule.getKey(), rule.getValue());
+                }
+                return content;
+            }
+
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+
+    /**
+     * Transformer that throws exceptions for testing error handling
+     */
+    public static class ExceptionThrowingTransformer implements Transformer {
+        private final String name;
+        private boolean throwInTransform = false;
+        private boolean throwInGetData = false;
+
+        public ExceptionThrowingTransformer(String name) {
+            this.name = name;
+        }
+
+        public void setThrowInTransform(boolean throwInTransform) {
+            this.throwInTransform = throwInTransform;
+        }
+
+        public void setThrowInGetData(boolean throwInGetData) {
+            this.throwInGetData = throwInGetData;
+        }
+
+        @Override
+        public ResultData transform(ResponseData responseData) {
+            if (throwInTransform) {
+                throw new CrawlerSystemException("Transform exception");
+            }
+
+            ResultData resultData = new ResultData();
+            resultData.setTransformerName(name);
+            return resultData;
+        }
+
+        @Override
+        public Object getData(AccessResultData<?> accessResultData) {
+            if (throwInGetData) {
+                throw new CrawlerSystemException("GetData exception");
+            }
+
+            if (accessResultData == null) {
+                return null;
+            }
+            byte[] data = accessResultData.getData();
+            return data != null ? new String(data) : null;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+
+    /**
+     * Stateful transformer for testing state management
+     */
+    public static class StatefulTransformer implements Transformer {
+        private final String name;
+        private final List<String> processedUrls = new ArrayList<>();
+        private int state = 0;
+
+        public StatefulTransformer(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public ResultData transform(ResponseData responseData) {
+            if (responseData != null) {
+                processedUrls.add(responseData.getUrl());
+                state++;
+            }
+
+            ResultData resultData = new ResultData();
+            resultData.setTransformerName(name);
+            resultData.setData(("State: " + state).getBytes());
+            return resultData;
+        }
+
+        @Override
+        public Object getData(AccessResultData<?> accessResultData) {
+            if (accessResultData == null) {
+                return null;
+            }
+            byte[] data = accessResultData.getData();
+            return data != null ? new String(data) : null;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        public List<String> getProcessedUrls() {
+            return new ArrayList<>(processedUrls);
+        }
+
+        public int getState() {
+            return state;
+        }
+
+        public void reset() {
+            processedUrls.clear();
+            state = 0;
+        }
+    }
+
+    /**
+     * Test AccessResultData implementation
+     */
+    public static class TestAccessResultData<T> implements AccessResultData<T>, Serializable {
+        private static final long serialVersionUID = 1L;
+        private T id;
+        private byte[] data;
+        private String encoding;
+        private String transformerName;
+        private String url;
+
+        public TestAccessResultData() {
+        }
+
+        public TestAccessResultData(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public T getId() {
+            return id;
+        }
+
+        @Override
+        public void setId(T id) {
+            this.id = id;
+        }
+
+        @Override
+        public String getTransformerName() {
+            return transformerName;
+        }
+
+        @Override
+        public void setTransformerName(String transformerName) {
+            this.transformerName = transformerName;
+        }
+
+        @Override
+        public byte[] getData() {
+            return data;
+        }
+
+        @Override
+        public String getDataAsString() {
+            return data != null ? new String(data) : null;
+        }
+
+        @Override
+        public void setData(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public String getEncoding() {
+            return encoding;
+        }
+
+        @Override
+        public void setEncoding(String encoding) {
+            this.encoding = encoding;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+    }
+
+    private TestTransformer testTransformer;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        testTransformer = new TestTransformer("testTransformer");
+    }
+
+    /**
+     * Test basic transform implementation
+     */
+    public void test_transform_basic() {
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+        responseData.setParentUrl("http://parent.com");
+
+        ResultData resultData = testTransformer.transform(responseData);
+
+        assertNotNull(resultData);
+        assertEquals("testTransformer", resultData.getTransformerName());
+        assertNotNull(resultData.getData());
+        assertEquals("test data", new String(resultData.getData()));
+        assertEquals(1, testTransformer.getTransformCallCount());
+        assertSame(responseData, testTransformer.getLastResponseData());
+    }
+
+    /**
+     * Test transform with null ResponseData
+     */
+    public void test_transform_nullResponseData() {
+        ResultData resultData = testTransformer.transform(null);
+
+        assertNull(resultData);
+        assertEquals(1, testTransformer.getTransformCallCount());
+        assertNull(testTransformer.getLastResponseData());
+    }
+
+    /**
+     * Test transform with various ResponseData states
+     */
+    public void test_transform_variousResponseDataStates() {
+        // Empty ResponseData - should return a valid ResultData with empty/null data
+        ResponseData emptyData = new ResponseData();
+        ResultData result1 = testTransformer.transform(emptyData);
+        assertNotNull(result1);
+        assertNotNull(result1.getData()); // Transform should return ResultData with some data
+
+        // ResponseData with only URL
+        ResponseData urlOnlyData = new ResponseData();
+        urlOnlyData.setUrl("http://example.com");
+        ResultData result2 = testTransformer.transform(urlOnlyData);
+        assertNotNull(result2);
+        assertNotNull(result2.getData());
+
+        // ResponseData with response body
+        ResponseData withBodyData = new ResponseData();
+        withBodyData.setUrl("http://example.com");
+        withBodyData.setResponseBody("Test content".getBytes());
+        ResultData result3 = testTransformer.transform(withBodyData);
+        assertNotNull(result3);
+        assertNotNull(result3.getData());
+    }
+
+    /**
+     * Test getData basic implementation
+     */
+    public void test_getData_basic() {
+        TestAccessResultData<String> accessResultData = new TestAccessResultData<>();
+        accessResultData.setData("test data".getBytes());
+        accessResultData.setUrl("http://example.com");
+
+        Object data = testTransformer.getData(accessResultData);
+
+        assertEquals("test data", data);
+        assertEquals(1, testTransformer.getGetDataCallCount());
+        assertSame(accessResultData, testTransformer.getLastAccessResultData());
+    }
+
+    /**
+     * Test getData with null AccessResultData
+     */
+    public void test_getData_nullAccessResultData() {
+        Object data = testTransformer.getData(null);
+
+        assertNull(data);
+        assertEquals(1, testTransformer.getGetDataCallCount());
+        assertNull(testTransformer.getLastAccessResultData());
+    }
+
+    /**
+     * Test getData with different data types
+     */
+    public void test_getData_differentDataTypes() {
+        // String data
+        TestAccessResultData<String> stringData = new TestAccessResultData<>("string value".getBytes());
+        assertEquals("string value", testTransformer.getData(stringData));
+
+        // Integer data
+        TestAccessResultData<Integer> intData = new TestAccessResultData<>("123".getBytes());
+        assertEquals("123", testTransformer.getData(intData));
+
+        // List data
+        List<String> list = new ArrayList<>();
+        list.add("item1");
+        list.add("item2");
+        TestAccessResultData<String> listData = new TestAccessResultData<>(list.toString().getBytes());
+        Object retrievedList = testTransformer.getData(listData);
+        assertEquals(list.toString(), retrievedList);
+
+        // Null data
+        TestAccessResultData<Object> nullData = new TestAccessResultData<>();
+        assertNull(testTransformer.getData(nullData));
+    }
+
+    /**
+     * Test getName implementation
+     */
+    public void test_getName() {
+        assertEquals("testTransformer", testTransformer.getName());
+
+        // Test with null name
+        TestTransformer nullNameTransformer = new TestTransformer();
+        assertNull(nullNameTransformer.getName());
+
+        // Test with empty name
+        TestTransformer emptyNameTransformer = new TestTransformer("");
+        assertEquals("", emptyNameTransformer.getName());
+
+        // Test with special characters
+        TestTransformer specialNameTransformer = new TestTransformer("trans-former_123#");
+        assertEquals("trans-former_123#", specialNameTransformer.getName());
+    }
+
+    /**
+     * Test ContentTransformer implementation
+     */
+    public void test_contentTransformer() {
+        ContentTransformer transformer = new ContentTransformer("contentTransformer");
+        transformer.addTransformationRule("old", "new");
+        transformer.addTransformationRule("\\d+", "NUMBER");
+
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+        responseData.setResponseBody("This is old text with 123 numbers".getBytes());
+
+        ResultData resultData = transformer.transform(responseData);
+
+        assertNotNull(resultData);
+        assertEquals("contentTransformer", resultData.getTransformerName());
+        assertEquals("This is new text with NUMBER numbers", new String(resultData.getData()));
+
+        // Test getData with transformation
+        TestAccessResultData<String> accessData = new TestAccessResultData<>("old value 456".getBytes());
+        Object transformedData = transformer.getData(accessData);
+        assertEquals("new value NUMBER", transformedData);
+    }
+
+    /**
+     * Test exception handling in transform
+     */
+    public void test_exceptionHandling_transform() {
+        ExceptionThrowingTransformer transformer = new ExceptionThrowingTransformer("exceptionTransformer");
+        transformer.setThrowInTransform(true);
+
+        ResponseData responseData = new ResponseData();
+
+        try {
+            transformer.transform(responseData);
+            fail("Should throw CrawlerSystemException");
+        } catch (CrawlerSystemException e) {
+            assertEquals("Transform exception", e.getMessage());
+        }
+    }
+
+    /**
+     * Test exception handling in getData
+     */
+    public void test_exceptionHandling_getData() {
+        ExceptionThrowingTransformer transformer = new ExceptionThrowingTransformer("exceptionTransformer");
+        transformer.setThrowInGetData(true);
+
+        TestAccessResultData<String> accessData = new TestAccessResultData<>("data".getBytes());
+
+        try {
+            transformer.getData(accessData);
+            fail("Should throw CrawlerSystemException");
+        } catch (CrawlerSystemException e) {
+            assertEquals("GetData exception", e.getMessage());
+        }
+    }
+
+    /**
+     * Test stateful transformer
+     */
+    public void test_statefulTransformer() {
+        StatefulTransformer transformer = new StatefulTransformer("statefulTransformer");
+
+        // Process multiple URLs
+        String[] urls = { "http://example1.com", "http://example2.com", "http://example3.com" };
+
+        for (String url : urls) {
+            ResponseData responseData = new ResponseData();
+            responseData.setUrl(url);
+
+            ResultData resultData = transformer.transform(responseData);
+            assertNotNull(resultData);
+        }
+
+        // Verify state
+        assertEquals(3, transformer.getState());
+        List<String> processedUrls = transformer.getProcessedUrls();
+        assertEquals(3, processedUrls.size());
+        assertEquals("http://example1.com", processedUrls.get(0));
+        assertEquals("http://example2.com", processedUrls.get(1));
+        assertEquals("http://example3.com", processedUrls.get(2));
+
+        // Reset and verify
+        transformer.reset();
+        assertEquals(0, transformer.getState());
+        assertEquals(0, transformer.getProcessedUrls().size());
+    }
+
+    /**
+     * Test multiple transformer instances
+     */
+    public void test_multipleTransformerInstances() {
+        TestTransformer transformer1 = new TestTransformer("transformer1");
+        TestTransformer transformer2 = new TestTransformer("transformer2");
+        TestTransformer transformer3 = new TestTransformer("transformer3");
+
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+
+        ResultData result1 = transformer1.transform(responseData);
+        ResultData result2 = transformer2.transform(responseData);
+        ResultData result3 = transformer3.transform(responseData);
+
+        assertEquals("transformer1", result1.getTransformerName());
+        assertEquals("transformer2", result2.getTransformerName());
+        assertEquals("transformer3", result3.getTransformerName());
+
+        assertEquals(1, transformer1.getTransformCallCount());
+        assertEquals(1, transformer2.getTransformCallCount());
+        assertEquals(1, transformer3.getTransformCallCount());
+    }
+
+    /**
+     * Test concurrent transformer operations
+     */
+    public void test_concurrentOperations() throws Exception {
+        final TestTransformer transformer = new TestTransformer("concurrentTransformer");
+        final int threadCount = 5;
+        final int operationsPerThread = 10;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+        final AtomicInteger successCount = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        startLatch.await();
+                        for (int j = 0; j < operationsPerThread; j++) {
+                            // Transform operation
+                            ResponseData responseData = new ResponseData();
+                            responseData.setUrl("http://thread" + threadId + ".com/page" + j);
+                            ResultData resultData = transformer.transform(responseData);
+
+                            if (resultData != null && "concurrentTransformer".equals(resultData.getTransformerName())) {
+                                successCount.incrementAndGet();
+                            }
+
+                            // GetData operation
+                            TestAccessResultData<String> accessData = new TestAccessResultData<>(("data" + j).getBytes());
+                            Object data = transformer.getData(accessData);
+                            if (data != null) {
+                                successCount.incrementAndGet();
+                            }
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }
+            });
+        }
+
+        startLatch.countDown();
+        boolean completed = endLatch.await(30, TimeUnit.SECONDS);
+        assertTrue("Test should complete within timeout", completed);
+        executor.shutdown();
+
+        assertEquals(threadCount * operationsPerThread * 2, successCount.get());
+        assertEquals(threadCount * operationsPerThread, transformer.getTransformCallCount());
+        assertEquals(threadCount * operationsPerThread, transformer.getGetDataCallCount());
+    }
+
+    /**
+     * Test transformer chain
+     */
+    public void test_transformerChain() {
+        // Create chain of transformers
+        List<Transformer> transformerChain = new ArrayList<>();
+        transformerChain.add(new TestTransformer("first"));
+        transformerChain.add(new TestTransformer("second"));
+        transformerChain.add(new TestTransformer("third"));
+
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+
+        ResultData currentResult = null;
+        for (Transformer transformer : transformerChain) {
+            currentResult = transformer.transform(responseData);
+            assertNotNull(currentResult);
+            assertEquals(transformer.getName(), currentResult.getTransformerName());
+        }
+
+        // Final result should be from last transformer
+        assertEquals("third", currentResult.getTransformerName());
+    }
+
+    /**
+     * Test null name handling
+     */
+    public void test_nullNameHandling() {
+        TestTransformer transformer = new TestTransformer(null);
+        assertNull(transformer.getName());
+
+        ResponseData responseData = new ResponseData();
+        ResultData resultData = transformer.transform(responseData);
+
+        assertNotNull(resultData);
+        assertNull(resultData.getTransformerName());
+    }
+
+    /**
+     * Test serialization of AccessResultData
+     */
+    public void test_accessResultDataSerialization() throws Exception {
+        TestAccessResultData<String> original = new TestAccessResultData<>("test data".getBytes());
+        original.setUrl("http://example.com");
+
+        // Serialize
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(original);
+        oos.close();
+
+        // Deserialize
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        @SuppressWarnings("unchecked")
+        TestAccessResultData<String> deserialized = (TestAccessResultData<String>) ois.readObject();
+        ois.close();
+
+        // Verify
+        assertEquals("test data", new String(deserialized.getData()));
+        assertNotNull(deserialized.getData());
+    }
+
+    /**
+     * Test transformer with large data
+     */
+    public void test_transformerWithLargeData() {
+        TestTransformer transformer = new TestTransformer("largeDataTransformer");
+
+        // Create large response data
+        byte[] largeBody = new byte[10 * 1024 * 1024]; // 10MB
+        for (int i = 0; i < largeBody.length; i++) {
+            largeBody[i] = (byte) (i % 256);
+        }
+
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com/large");
+        responseData.setResponseBody(largeBody);
+
+        ResultData resultData = transformer.transform(responseData);
+
+        assertNotNull(resultData);
+        assertEquals("largeDataTransformer", resultData.getTransformerName());
+        assertNotNull(resultData.getData());
+
+        // Test with large AccessResultData
+        StringBuilder largeString = new StringBuilder();
+        for (int i = 0; i < 1000000; i++) {
+            largeString.append("Large data content ");
+        }
+        TestAccessResultData<String> largeAccessData = new TestAccessResultData<>(largeString.toString().getBytes());
+
+        Object retrievedData = transformer.getData(largeAccessData);
+        assertNotNull(retrievedData);
+        assertEquals(largeString.toString(), retrievedData);
+    }
+
+    /**
+     * Test transformer reusability
+     */
+    public void test_transformerReusability() {
+        TestTransformer transformer = new TestTransformer("reusableTransformer");
+
+        // Use transformer multiple times
+        for (int i = 0; i < 10; i++) {
+            ResponseData responseData = new ResponseData();
+            responseData.setUrl("http://example.com/page" + i);
+
+            ResultData resultData = transformer.transform(responseData);
+            assertNotNull(resultData);
+            assertEquals("reusableTransformer", resultData.getTransformerName());
+            assertNotNull(resultData.getData());
+
+            TestAccessResultData<String> accessData = new TestAccessResultData<>(("data" + i).getBytes());
+            Object data = transformer.getData(accessData);
+            assertEquals("data" + i, data);
+        }
+
+        assertEquals(10, transformer.getTransformCallCount());
+        assertEquals(10, transformer.getGetDataCallCount());
+    }
+
+    /**
+     * Test complete workflow
+     */
+    public void test_completeWorkflow() {
+        // Create transformer
+        ContentTransformer transformer = new ContentTransformer("workflowTransformer");
+        transformer.addTransformationRule("<[^>]+>", ""); // Remove HTML tags
+        transformer.addTransformationRule("\\s+", " "); // Normalize whitespace
+
+        // Simulate crawling response
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com/page.html");
+        responseData.setParentUrl("http://example.com/");
+        responseData.setResponseBody("<html><body>  Test   Content  </body></html>".getBytes());
+        responseData.setHttpStatusCode(200);
+        responseData.setMimeType("text/html");
+
+        // Transform response
+        ResultData resultData = transformer.transform(responseData);
+
+        assertNotNull(resultData);
+        assertEquals("workflowTransformer", resultData.getTransformerName());
+        assertNotNull(resultData.getData());
+        assertEquals(" Test Content ", new String(resultData.getData()));
+
+        // Store and retrieve data
+        TestAccessResultData<Object> accessData = new TestAccessResultData<>();
+        accessData.setData(resultData.getData());
+        // URL handling removed as ResultData doesn't have getUrl()
+
+        Object retrievedData = transformer.getData(accessData);
+        assertEquals(" Test Content ", retrievedData);
+    }
+}

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/AbstractTransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/AbstractTransformerTest.java
@@ -1,0 +1,640 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.transformer.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.codelibs.fess.crawler.entity.AccessResult;
+import org.codelibs.fess.crawler.entity.AccessResultData;
+import org.codelibs.fess.crawler.entity.ResponseData;
+import org.codelibs.fess.crawler.entity.ResultData;
+import org.codelibs.fess.crawler.exception.CrawlerSystemException;
+import org.dbflute.utflute.core.PlainTestCase;
+
+/**
+ * Test class for AbstractTransformer.
+ * Tests the abstract transformer implementation and its name management functionality.
+ */
+public class AbstractTransformerTest extends PlainTestCase {
+
+    /**
+     * Concrete implementation of AbstractTransformer for testing
+     */
+    public static class TestTransformer extends AbstractTransformer {
+        private int transformCallCount = 0;
+        private ResponseData lastResponseData = null;
+        private ResultData returnedResultData = null;
+        private boolean throwException = false;
+
+        @Override
+        public ResultData transform(ResponseData responseData) {
+            transformCallCount++;
+            lastResponseData = responseData;
+
+            if (throwException) {
+                throw new CrawlerSystemException("Test exception");
+            }
+
+            if (returnedResultData != null) {
+                return returnedResultData;
+            }
+
+            // Create default ResultData
+            ResultData resultData = new ResultData();
+            resultData.setTransformerName(getName());
+            return resultData;
+        }
+
+        @Override
+        public Object getData(AccessResultData<?> accessResultData) {
+            return accessResultData != null ? accessResultData.getData() : null;
+        }
+
+        public int getTransformCallCount() {
+            return transformCallCount;
+        }
+
+        public ResponseData getLastResponseData() {
+            return lastResponseData;
+        }
+
+        public void setReturnedResultData(ResultData resultData) {
+            this.returnedResultData = resultData;
+        }
+
+        public void setThrowException(boolean throwException) {
+            this.throwException = throwException;
+        }
+
+        public void reset() {
+            transformCallCount = 0;
+            lastResponseData = null;
+            returnedResultData = null;
+            throwException = false;
+        }
+    }
+
+    /**
+     * Another concrete implementation for testing different scenarios
+     */
+    public static class NameTrackingTransformer extends AbstractTransformer {
+        private final List<String> nameHistory = new ArrayList<>();
+
+        @Override
+        public ResultData transform(ResponseData responseData) {
+            nameHistory.add(getName());
+            ResultData resultData = new ResultData();
+            resultData.setTransformerName(getName());
+            return resultData;
+        }
+
+        @Override
+        public Object getData(AccessResultData<?> accessResultData) {
+            return accessResultData;
+        }
+
+        public List<String> getNameHistory() {
+            return new ArrayList<>(nameHistory);
+        }
+
+        public void clearHistory() {
+            nameHistory.clear();
+        }
+    }
+
+    private TestTransformer testTransformer;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        testTransformer = new TestTransformer();
+    }
+
+    /**
+     * Test default constructor
+     */
+    public void test_constructor() {
+        TestTransformer transformer = new TestTransformer();
+        assertNotNull(transformer);
+        assertNull(transformer.getName());
+    }
+
+    /**
+     * Test getName and setName with normal values
+     */
+    public void test_name_getterSetter() {
+        // Initial state
+        assertNull(testTransformer.getName());
+
+        // Set name
+        testTransformer.setName("testTransformer");
+        assertEquals("testTransformer", testTransformer.getName());
+
+        // Change name
+        testTransformer.setName("changedName");
+        assertEquals("changedName", testTransformer.getName());
+
+        // Set null name
+        testTransformer.setName(null);
+        assertNull(testTransformer.getName());
+
+        // Set empty name
+        testTransformer.setName("");
+        assertEquals("", testTransformer.getName());
+    }
+
+    /**
+     * Test name with special characters
+     */
+    public void test_name_specialCharacters() {
+        // Test with spaces
+        testTransformer.setName("name with spaces");
+        assertEquals("name with spaces", testTransformer.getName());
+
+        // Test with special characters
+        testTransformer.setName("name-with_special.chars#123");
+        assertEquals("name-with_special.chars#123", testTransformer.getName());
+
+        // Test with Unicode characters
+        testTransformer.setName("変換器の名前");
+        assertEquals("変換器の名前", testTransformer.getName());
+
+        // Test with mixed characters
+        testTransformer.setName("Transformer-変換器-123");
+        assertEquals("Transformer-変換器-123", testTransformer.getName());
+    }
+
+    /**
+     * Test name with very long string
+     */
+    public void test_name_veryLongString() {
+        StringBuilder longName = new StringBuilder();
+        for (int i = 0; i < 10000; i++) {
+            longName.append("verylongname");
+        }
+        String longNameStr = longName.toString();
+
+        testTransformer.setName(longNameStr);
+        assertEquals(longNameStr, testTransformer.getName());
+        assertEquals(120000, testTransformer.getName().length());
+    }
+
+    /**
+     * Test name with whitespace variations
+     */
+    public void test_name_whitespace() {
+        // Leading whitespace
+        testTransformer.setName("  leadingSpaces");
+        assertEquals("  leadingSpaces", testTransformer.getName());
+
+        // Trailing whitespace
+        testTransformer.setName("trailingSpaces  ");
+        assertEquals("trailingSpaces  ", testTransformer.getName());
+
+        // Both leading and trailing
+        testTransformer.setName("  bothSpaces  ");
+        assertEquals("  bothSpaces  ", testTransformer.getName());
+
+        // Only whitespace
+        testTransformer.setName("   ");
+        assertEquals("   ", testTransformer.getName());
+
+        // Tab characters
+        testTransformer.setName("\tname\twith\ttabs\t");
+        assertEquals("\tname\twith\ttabs\t", testTransformer.getName());
+
+        // Newline characters
+        testTransformer.setName("name\nwith\nnewlines");
+        assertEquals("name\nwith\nnewlines", testTransformer.getName());
+    }
+
+    /**
+     * Test multiple name changes
+     */
+    public void test_multipleNameChanges() {
+        String[] names = { "first", "second", "third", "fourth", "fifth" };
+
+        for (String name : names) {
+            testTransformer.setName(name);
+            assertEquals(name, testTransformer.getName());
+        }
+
+        // Verify final state
+        assertEquals("fifth", testTransformer.getName());
+    }
+
+    /**
+     * Test transform method implementation
+     */
+    public void test_transform_implementation() {
+        testTransformer.setName("myTransformer");
+
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com");
+
+        ResultData resultData = testTransformer.transform(responseData);
+
+        assertNotNull(resultData);
+        assertEquals("myTransformer", resultData.getTransformerName());
+        assertEquals(1, testTransformer.getTransformCallCount());
+        assertSame(responseData, testTransformer.getLastResponseData());
+    }
+
+    /**
+     * Test transform with null name
+     */
+    public void test_transform_withNullName() {
+        // Don't set name (remains null)
+        ResponseData responseData = new ResponseData();
+
+        ResultData resultData = testTransformer.transform(responseData);
+
+        assertNotNull(resultData);
+        assertNull(resultData.getTransformerName());
+    }
+
+    /**
+     * Test transform with exception
+     */
+    public void test_transform_withException() {
+        testTransformer.setName("exceptionTransformer");
+        testTransformer.setThrowException(true);
+
+        ResponseData responseData = new ResponseData();
+
+        try {
+            testTransformer.transform(responseData);
+            fail("Should throw CrawlerSystemException");
+        } catch (CrawlerSystemException e) {
+            assertEquals("Test exception", e.getMessage());
+        }
+
+        assertEquals(1, testTransformer.getTransformCallCount());
+    }
+
+    /**
+     * Test getData implementation
+     */
+    public void test_getData_implementation() {
+        AccessResultData<String> accessResultData = new AccessResultData<String>() {
+            private byte[] data = "test data".getBytes();
+            private String encoding = "UTF-8";
+            private String transformerName = "test";
+            private String id;
+
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public void setId(String id) {
+                this.id = id;
+            }
+
+            @Override
+            public String getTransformerName() {
+                return transformerName;
+            }
+
+            @Override
+            public void setTransformerName(String transformerName) {
+                this.transformerName = transformerName;
+            }
+
+            @Override
+            public byte[] getData() {
+                return data;
+            }
+
+            @Override
+            public String getDataAsString() {
+                return new String(data);
+            }
+
+            @Override
+            public void setData(byte[] data) {
+                this.data = data;
+            }
+
+            @Override
+            public String getEncoding() {
+                return encoding;
+            }
+
+            @Override
+            public void setEncoding(String encoding) {
+                this.encoding = encoding;
+            }
+        };
+
+        Object data = testTransformer.getData(accessResultData);
+        byte[] expected = "test data".getBytes();
+        byte[] actual = (byte[]) data;
+        assertEquals(expected.length, actual.length);
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], actual[i]);
+        }
+
+        // Test with null
+        assertNull(testTransformer.getData(null));
+    }
+
+    /**
+     * Test name tracking transformer
+     */
+    public void test_nameTrackingTransformer() {
+        NameTrackingTransformer tracker = new NameTrackingTransformer();
+        ResponseData responseData = new ResponseData();
+
+        // Transform with different names
+        tracker.setName("name1");
+        tracker.transform(responseData);
+
+        tracker.setName("name2");
+        tracker.transform(responseData);
+
+        tracker.setName("name3");
+        tracker.transform(responseData);
+
+        List<String> history = tracker.getNameHistory();
+        assertEquals(3, history.size());
+        assertEquals("name1", history.get(0));
+        assertEquals("name2", history.get(1));
+        assertEquals("name3", history.get(2));
+    }
+
+    /**
+     * Test concurrent name access
+     */
+    public void test_concurrentNameAccess() throws Exception {
+        final int threadCount = 100;
+        final int operationsPerThread = 100;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+        final AtomicInteger errorCount = new AtomicInteger(0);
+
+        testTransformer.setName("concurrentName");
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        startLatch.await();
+                        for (int j = 0; j < operationsPerThread; j++) {
+                            // Read name
+                            String name = testTransformer.getName();
+                            if (!"concurrentName".equals(name)) {
+                                errorCount.incrementAndGet();
+                            }
+
+                            // Occasionally change name (10% of threads)
+                            if (threadId % 10 == 0 && j % 10 == 0) {
+                                testTransformer.setName("concurrentName");
+                            }
+                        }
+                    } catch (Exception e) {
+                        errorCount.incrementAndGet();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }
+            });
+        }
+
+        startLatch.countDown();
+        endLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals(0, errorCount.get());
+        assertEquals("concurrentName", testTransformer.getName());
+    }
+
+    /**
+     * Test concurrent name changes
+     */
+    public void test_concurrentNameChanges() throws Exception {
+        final int threadCount = 10;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+        final List<Exception> exceptions = new ArrayList<>();
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        startLatch.await();
+                        for (int j = 0; j < 100; j++) {
+                            testTransformer.setName("thread" + threadId + "_iteration" + j);
+                            String name = testTransformer.getName();
+                            assertNotNull(name);
+                            assertTrue(name.startsWith("thread"));
+                        }
+                    } catch (Exception e) {
+                        synchronized (exceptions) {
+                            exceptions.add(e);
+                        }
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }
+            });
+        }
+
+        startLatch.countDown();
+        endLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertTrue(exceptions.isEmpty());
+        // Final name should be from one of the threads
+        assertNotNull(testTransformer.getName());
+        assertTrue(testTransformer.getName().startsWith("thread"));
+    }
+
+    /**
+     * Test inheritance behavior
+     */
+    public void test_inheritanceBehavior() {
+        // Test that subclasses inherit name management
+        TestTransformer transformer1 = new TestTransformer();
+        NameTrackingTransformer transformer2 = new NameTrackingTransformer();
+
+        transformer1.setName("transformer1");
+        transformer2.setName("transformer2");
+
+        assertEquals("transformer1", transformer1.getName());
+        assertEquals("transformer2", transformer2.getName());
+
+        // Both should have independent name storage
+        transformer1.setName("changed1");
+        assertEquals("changed1", transformer1.getName());
+        assertEquals("transformer2", transformer2.getName());
+    }
+
+    /**
+     * Test protected field access
+     */
+    public void test_protectedFieldAccess() {
+        TestTransformer transformer = new TestTransformer();
+
+        // Direct field access (simulating subclass behavior)
+        transformer.name = "directFieldAccess";
+        assertEquals("directFieldAccess", transformer.getName());
+
+        // Setter should update the field
+        transformer.setName("setterAccess");
+        assertEquals("setterAccess", transformer.name);
+
+        // Field modification should be reflected in getter
+        transformer.name = "modifiedField";
+        assertEquals("modifiedField", transformer.getName());
+    }
+
+    /**
+     * Test name persistence across operations
+     */
+    public void test_namePersistence() {
+        testTransformer.setName("persistentName");
+
+        // Perform multiple transforms
+        for (int i = 0; i < 10; i++) {
+            ResponseData responseData = new ResponseData();
+            ResultData resultData = testTransformer.transform(responseData);
+            assertEquals("persistentName", resultData.getTransformerName());
+        }
+
+        // Name should remain unchanged
+        assertEquals("persistentName", testTransformer.getName());
+        assertEquals(10, testTransformer.getTransformCallCount());
+    }
+
+    /**
+     * Test name with control characters
+     */
+    public void test_name_controlCharacters() {
+        // Test with various control characters
+        testTransformer.setName("name\0with\0null");
+        assertEquals("name\0with\0null", testTransformer.getName());
+
+        testTransformer.setName("name\rwith\rcarriage\rreturn");
+        assertEquals("name\rwith\rcarriage\rreturn", testTransformer.getName());
+
+        testTransformer.setName("name\bwith\bbackspace");
+        assertEquals("name\bwith\bbackspace", testTransformer.getName());
+
+        testTransformer.setName("name\fwith\fform\ffeed");
+        assertEquals("name\fwith\fform\ffeed", testTransformer.getName());
+    }
+
+    /**
+     * Test multiple transformer instances
+     */
+    public void test_multipleInstances() {
+        TestTransformer transformer1 = new TestTransformer();
+        TestTransformer transformer2 = new TestTransformer();
+        TestTransformer transformer3 = new TestTransformer();
+
+        transformer1.setName("instance1");
+        transformer2.setName("instance2");
+        transformer3.setName("instance3");
+
+        assertEquals("instance1", transformer1.getName());
+        assertEquals("instance2", transformer2.getName());
+        assertEquals("instance3", transformer3.getName());
+
+        // Change one instance's name
+        transformer2.setName("changed2");
+
+        // Others should remain unchanged
+        assertEquals("instance1", transformer1.getName());
+        assertEquals("changed2", transformer2.getName());
+        assertEquals("instance3", transformer3.getName());
+    }
+
+    /**
+     * Test name boundary cases
+     */
+    public void test_name_boundaryCases() {
+        // Single character
+        testTransformer.setName("a");
+        assertEquals("a", testTransformer.getName());
+
+        // Single space
+        testTransformer.setName(" ");
+        assertEquals(" ", testTransformer.getName());
+
+        // Single Unicode character
+        testTransformer.setName("あ");
+        assertEquals("あ", testTransformer.getName());
+
+        // Maximum practical length (avoid OutOfMemoryError)
+        StringBuilder maxName = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            maxName.append("0123456789");
+        }
+        testTransformer.setName(maxName.toString());
+        assertEquals(10000, testTransformer.getName().length());
+        assertEquals(maxName.toString(), testTransformer.getName());
+    }
+
+    /**
+     * Test complete workflow
+     */
+    public void test_completeWorkflow() {
+        // Create transformer with name
+        TestTransformer transformer = new TestTransformer();
+        transformer.setName("workflowTransformer");
+
+        // Create custom result data
+        ResultData customResult = new ResultData();
+        customResult.setTransformerName("customName");
+        transformer.setReturnedResultData(customResult);
+
+        // Perform transform
+        ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://example.com/test");
+
+        ResultData result = transformer.transform(responseData);
+
+        // Verify
+        assertNotNull(result);
+        assertEquals("customName", result.getTransformerName());
+        assertEquals(1, transformer.getTransformCallCount());
+        assertEquals("http://example.com/test", transformer.getLastResponseData().getUrl());
+
+        // Reset and verify
+        transformer.reset();
+        assertEquals(0, transformer.getTransformCallCount());
+        assertNull(transformer.getLastResponseData());
+
+        // Name should persist after reset
+        assertEquals("workflowTransformer", transformer.getName());
+    }
+}


### PR DESCRIPTION
This pull request makes a small change to the `AbstractRule` class to improve serialization safety. The `crawlerContainer` field is now marked as `transient`, which prevents it from being serialized.

* Marked the `crawlerContainer` field as `transient` in the `AbstractRule` class to avoid serialization issues with non-serializable resources.