### PR TITLE
Update parent POM version from snapshot to release 15.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0-SNAPSHOT</version>
+		<version>15.2.0</version>
 	</parent>
 	<modules>
 		<module>fess-crawler</module>


### PR DESCRIPTION
This pull request updates the parent version in the `pom.xml` file to the latest release version. This change ensures that the project uses stable dependencies from `fess-parent` rather than a snapshot version.