### PR TITLE
Update crawler modules to version 15.3.0-SNAPSHOT and improve test stability with polling waits

### DIFF
--- a/fess-crawler-lasta/pom.xml
+++ b/fess-crawler-lasta/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-crawler-parent</artifactId>
-		<version>15.2.1-SNAPSHOT</version>
+		<version>15.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<build>

--- a/fess-crawler-lasta/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java
+++ b/fess-crawler-lasta/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java
@@ -229,7 +229,17 @@ public class CrawlerTest extends LastaDiTestCase {
             crawler.getCrawlerContext().setMaxAccessCount(maxCount);
             crawler.getCrawlerContext().setNumOfThread(numOfThread);
             final String sessionId = crawler.execute();
-            Thread.sleep(3000);
+
+            // Wait for crawler to start running with polling
+            long startTime = System.currentTimeMillis();
+            while (crawler.crawlerContext.getStatus() != CrawlerStatus.RUNNING && System.currentTimeMillis() - startTime < 5000) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
             assertEquals(CrawlerStatus.RUNNING, crawler.crawlerContext.getStatus());
             crawler.awaitTermination();
             assertEquals(maxCount, dataService.getCount(sessionId));
@@ -279,7 +289,17 @@ public class CrawlerTest extends LastaDiTestCase {
             assertNotSame(sessionId1, sessionId2);
             assertNotSame(crawler1.crawlerContext, crawler2.crawlerContext);
 
-            Thread.sleep(1000);
+            // Wait for both crawlers to start with polling
+            long startTime = System.currentTimeMillis();
+            while ((crawler1.crawlerContext.getStatus() != CrawlerStatus.RUNNING
+                    || crawler2.crawlerContext.getStatus() != CrawlerStatus.RUNNING) && System.currentTimeMillis() - startTime < 5000) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
 
             assertEquals(CrawlerStatus.RUNNING, crawler1.crawlerContext.getStatus());
             assertEquals(CrawlerStatus.RUNNING, crawler2.crawlerContext.getStatus());

--- a/fess-crawler-opensearch/pom.xml
+++ b/fess-crawler-opensearch/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-crawler-parent</artifactId>
-		<version>15.2.1-SNAPSHOT</version>
+		<version>15.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<build>

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java
@@ -158,8 +158,6 @@ public class CrawlerTest extends LastaDiTestCase {
             crawler1.getCrawlerContext().setMaxAccessCount(maxCount);
             crawler1.getCrawlerContext().setNumOfThread(numOfThread);
 
-            Thread.sleep(100);
-
             final Crawler crawler2 = getComponent(Crawler.class);
             crawler2.setBackground(true);
             ((UrlFilterImpl) crawler2.urlFilter).setIncludeFilteringPattern("$1$2$3.*");
@@ -173,18 +171,18 @@ public class CrawlerTest extends LastaDiTestCase {
             assertNotSame(sessionId1, sessionId2);
             assertNotSame(crawler1.crawlerContext, crawler2.crawlerContext);
 
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 100; i++) {
                 if (crawler1.crawlerContext.getStatus() == CrawlerStatus.RUNNING) {
                     break;
                 }
-                Thread.sleep(500);
+                Thread.sleep(50);
             }
             assertEquals(CrawlerStatus.RUNNING, crawler1.crawlerContext.getStatus());
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 100; i++) {
                 if (crawler2.crawlerContext.getStatus() == CrawlerStatus.RUNNING) {
                     break;
                 }
-                Thread.sleep(500);
+                Thread.sleep(50);
             }
             assertEquals(CrawlerStatus.RUNNING, crawler2.crawlerContext.getStatus());
 

--- a/fess-crawler/pom.xml
+++ b/fess-crawler/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-crawler-parent</artifactId>
-		<version>15.2.1-SNAPSHOT</version>
+		<version>15.3.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<build>

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/AbstractCrawlerClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/AbstractCrawlerClient.java
@@ -25,7 +25,6 @@ import org.codelibs.fess.crawler.container.CrawlerContainer;
 import org.codelibs.fess.crawler.entity.RequestData;
 import org.codelibs.fess.crawler.entity.ResponseData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
-import org.codelibs.fess.crawler.exception.ExtractException;
 import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
 
 import jakarta.annotation.Resource;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/ExtractData.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/entity/ExtractData.java
@@ -28,7 +28,6 @@ import org.apache.tika.metadata.Message;
 import org.apache.tika.metadata.TIFF;
 import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.metadata.TikaMimeKeys;
-import org.apache.tika.parser.pdf.PDFParser;
 
 /**
  * Represents extracted data from a crawled resource, including content and metadata.

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java
@@ -329,7 +329,17 @@ public class CrawlerTest extends PlainTestCase {
             crawler.getCrawlerContext().setMaxAccessCount(maxCount);
             crawler.getCrawlerContext().setNumOfThread(numOfThread);
             final String sessionId = crawler.execute();
-            Thread.sleep(3000);
+
+            // Wait for crawler to start running with polling
+            long startTime = System.currentTimeMillis();
+            while (crawler.crawlerContext.getStatus() != CrawlerStatus.RUNNING && System.currentTimeMillis() - startTime < 5000) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
             assertEquals(CrawlerStatus.RUNNING, crawler.crawlerContext.getStatus());
             crawler.awaitTermination();
             assertEquals(maxCount, dataService.getCount(sessionId));
@@ -379,7 +389,17 @@ public class CrawlerTest extends PlainTestCase {
             assertNotSame(sessionId1, sessionId2);
             assertNotSame(crawler1.crawlerContext, crawler2.crawlerContext);
 
-            Thread.sleep(1000);
+            // Wait for both crawlers to start with polling
+            long startTime = System.currentTimeMillis();
+            while ((crawler1.crawlerContext.getStatus() != CrawlerStatus.RUNNING
+                    || crawler2.crawlerContext.getStatus() != CrawlerStatus.RUNNING) && System.currentTimeMillis() - startTime < 5000) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
 
             assertEquals(CrawlerStatus.RUNNING, crawler1.crawlerContext.getStatus());
             assertEquals(CrawlerStatus.RUNNING, crawler2.crawlerContext.getStatus());

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/fs/FileSystemClientTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/fs/FileSystemClientTest.java
@@ -167,7 +167,7 @@ public class FileSystemClientTest extends PlainTestCase {
             @Override
             protected ResponseData getResponseData(final String uri, final boolean includeContent) {
                 try {
-                    Thread.sleep(10000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     throw new CrawlingAccessException(e);
                 }
@@ -188,11 +188,11 @@ public class FileSystemClientTest extends PlainTestCase {
             @Override
             protected ResponseData getResponseData(final String uri, final boolean includeContent) {
                 try {
-                    Thread.sleep(10000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     throw new CrawlingAccessException(e);
                 }
-                return null;
+                return new ResponseData();
             }
         };
         client.setAccessTimeout(1);

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/ftp/FtpClientTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/ftp/FtpClientTest.java
@@ -388,7 +388,7 @@ public class FtpClientTest extends PlainTestCase {
             @Override
             protected ResponseData getResponseData(final String uri, final boolean includeContent) {
                 try {
-                    Thread.sleep(10000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     throw new CrawlingAccessException(e);
                 }
@@ -409,11 +409,11 @@ public class FtpClientTest extends PlainTestCase {
             @Override
             protected ResponseData getResponseData(final String uri, final boolean includeContent) {
                 try {
-                    Thread.sleep(10000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     throw new CrawlingAccessException(e);
                 }
-                return null;
+                return new ResponseData();
             }
         };
         client.setAccessTimeout(1);

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/HcHttpClientTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/HcHttpClientTest.java
@@ -120,7 +120,6 @@ public class HcHttpClientTest extends PlainTestCase {
         final String url = "http://localhost:7070/";
         try {
             final ResponseData responseData = httpClient.doHead(url);
-            Thread.sleep(100);
             assertNotNull(responseData.getLastModified());
             assertTrue(responseData.getLastModified().getTime() < new Date().getTime());
         } finally {
@@ -133,7 +132,7 @@ public class HcHttpClientTest extends PlainTestCase {
             @Override
             protected ResponseData processHttpMethod(final String url, final HttpUriRequest httpRequest) {
                 try {
-                    Thread.sleep(10000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     throw new CrawlingAccessException(e);
                 }
@@ -154,7 +153,7 @@ public class HcHttpClientTest extends PlainTestCase {
             @Override
             protected ResponseData processHttpMethod(final String url, final HttpUriRequest httpRequest) {
                 try {
-                    Thread.sleep(10000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     throw new CrawlingAccessException(e);
                 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/smb/SmbClientTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/smb/SmbClientTest.java
@@ -31,7 +31,6 @@ import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.CrawlingAccessException;
 import org.codelibs.fess.crawler.helper.impl.MimeTypeHelperImpl;
 import org.dbflute.utflute.core.PlainTestCase;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.MountableFile;
 
@@ -277,7 +276,7 @@ public class SmbClientTest extends PlainTestCase {
             @Override
             protected ResponseData getResponseData(final String uri, final boolean includeContent) {
                 try {
-                    Thread.sleep(10000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     throw new CrawlingAccessException(e);
                 }
@@ -298,11 +297,11 @@ public class SmbClientTest extends PlainTestCase {
             @Override
             protected ResponseData getResponseData(final String uri, final boolean includeContent) {
                 try {
-                    Thread.sleep(10000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     throw new CrawlingAccessException(e);
                 }
-                return null;
+                return new ResponseData();
             }
         };
         client.setAccessTimeout(1);

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/smb1/SmbClientTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/smb1/SmbClientTest.java
@@ -30,7 +30,7 @@ public class SmbClientTest extends PlainTestCase {
             @Override
             protected ResponseData getResponseData(final String uri, final boolean includeContent) {
                 try {
-                    Thread.sleep(10000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     throw new CrawlingAccessException(e);
                 }
@@ -51,11 +51,11 @@ public class SmbClientTest extends PlainTestCase {
             @Override
             protected ResponseData getResponseData(final String uri, final boolean includeContent) {
                 try {
-                    Thread.sleep(10000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException e) {
                     throw new CrawlingAccessException(e);
                 }
-                return null;
+                return new ResponseData();
             }
         };
         client.setAccessTimeout(1);

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/rule/RuleManagerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/rule/RuleManagerTest.java
@@ -16,7 +16,6 @@
 package org.codelibs.fess.crawler.rule;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/TransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/TransformerTest.java
@@ -17,8 +17,8 @@ package org.codelibs.fess.crawler.transformer;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/AbstractTransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/AbstractTransformerTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.codelibs.fess.crawler.entity.AccessResult;
 import org.codelibs.fess.crawler.entity.AccessResultData;
 import org.codelibs.fess.crawler.entity.ResponseData;
 import org.codelibs.fess.crawler.entity.ResultData;

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.fess</groupId>
 	<artifactId>fess-crawler-parent</artifactId>
-	<version>15.2.1-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Fess Crawler Project</name>
 	<description>Fess Crawler is Crawler Framework.</description>
@@ -42,7 +42,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0</version>
+		<version>15.3.0-SNAPSHOT</version>
 	</parent>
 	<modules>
 		<module>fess-crawler</module>


### PR DESCRIPTION
This pull request focuses on improving test reliability and efficiency in the crawler modules by replacing fixed sleep statements with polling mechanisms and reducing unnecessary wait times. Additionally, it updates parent version references and performs minor cleanup of unused imports.

### Test reliability and efficiency improvements

* Replaced fixed `Thread.sleep` calls with polling loops in crawler tests (`CrawlerTest.java`, `CrawlerContextTest.java`) to more reliably wait for crawler status changes, reducing flakiness and speeding up tests. [[1]](diffhunk://#diff-f48e17272fd21d0cdb1e842f3fae8e04009c9386adab51cad62dca32371f8907L232-R242) [[2]](diffhunk://#diff-f48e17272fd21d0cdb1e842f3fae8e04009c9386adab51cad62dca32371f8907L282-R302) [[3]](diffhunk://#diff-04f21eaf2b73ded4d2fc45db660d1ef4cc39ffa72b0b5a6278b52bca5d332578L332-R342) [[4]](diffhunk://#diff-04f21eaf2b73ded4d2fc45db660d1ef4cc39ffa72b0b5a6278b52bca5d332578L382-R402) [[5]](diffhunk://#diff-495fb40d66731d4a463ea894f3b7ea429f65d15fd6af38eafe1b0b3695faa152L718-R733)
* Reduced sleep durations from 10 seconds to 2 seconds in various client timeout tests, and ensured `doHead` methods return a valid `ResponseData` object instead of `null`, improving test speed and consistency. [[1]](diffhunk://#diff-a479637da528aed8c2ab9efbfdcdf1b743e210a55577d1da4106220e7c66eb2bL170-R170) [[2]](diffhunk://#diff-a479637da528aed8c2ab9efbfdcdf1b743e210a55577d1da4106220e7c66eb2bL191-R195) [[3]](diffhunk://#diff-9ad625727ff15f75628b5c4014ead43464c5545f071215b5e0f05ee15619703eL391-R391) [[4]](diffhunk://#diff-9ad625727ff15f75628b5c4014ead43464c5545f071215b5e0f05ee15619703eL412-R416) [[5]](diffhunk://#diff-37d7317eba019d0228d92dc5cd368db27361dd3279746d68715cca60247a9bd4L280-R279) [[6]](diffhunk://#diff-37d7317eba019d0228d92dc5cd368db27361dd3279746d68715cca60247a9bd4L301-R304) [[7]](diffhunk://#diff-b48beae98114983cd9a28e3df21f9a3035883183c17c6404e9a8163d76b6ce4dL33-R33) [[8]](diffhunk://#diff-b48beae98114983cd9a28e3df21f9a3035883183c17c6404e9a8163d76b6ce4dL54-R58) [[9]](diffhunk://#diff-1e060cfe90245f9c7429ea6eac3c0a7744a709fd26815a5925536f135af7534bL136-R135) [[10]](diffhunk://#diff-1e060cfe90245f9c7429ea6eac3c0a7744a709fd26815a5925536f135af7534bL157-R156)

### Dependency and version updates

* Updated the parent project version from `15.2.1-SNAPSHOT` to `15.3.0-SNAPSHOT` in multiple `pom.xml` files for crawler modules. [[1]](diffhunk://#diff-a5fdbf779df5590b2555108d4bd9f5dcbb8f061d076af7bd6929362283584690L11-R11) [[2]](diffhunk://#diff-556fbe2b3ab4ee10bfa42ea4384ec98614157d3eb666d49f8de2ce22d4469f2dL10-R10) [[3]](diffhunk://#diff-2f4efd86ddc51fecf9a117201ff1d87ba956294e2d840019408ba6c4e428e17fL11-R11)

### Minor code cleanup

* Removed unused imports in several files, including `AbstractCrawlerClient.java`, `ExtractData.java`, `CrawlerContextTest.java`, `RuleManagerTest.java`, `TransformerTest.java`, `AbstractTransformerTest.java`, and `SmbClientTest.java`. [[1]](diffhunk://#diff-0eb3b7f7c587eceb0abb95d268befcde665125b53562f5331efe91460e2d5b15L28) [[2]](diffhunk://#diff-73c8284179b0bd6b6665b69cc3057e1ff237ac7ccea262c7f77d16d5b22bc686L31) [[3]](diffhunk://#diff-495fb40d66731d4a463ea894f3b7ea429f65d15fd6af38eafe1b0b3695faa152L27) [[4]](diffhunk://#diff-da723cbdc1180c0da8e0457e891b18b6575089681b6792479994f47ff48aebfeL19) [[5]](diffhunk://#diff-174740e0e7d5568ec40c84bce7ebe5cdf451ecf408aec5b766b2c6be50d49d14L20-R21) [[6]](diffhunk://#diff-77f86cb675d4cdcd742dfbd5dceb8aa3573db62b4008ae06cb49e01f6f4ef471L26) [[7]](diffhunk://#diff-37d7317eba019d0228d92dc5cd368db27361dd3279746d68715cca60247a9bd4L34)

### Additional test improvements

* Increased the number of polling iterations and decreased sleep intervals in `test_execute_2instanceTx` to improve reliability when waiting for crawler status changes.
* Removed unnecessary sleep from `test_execute_2instanceTx` to further speed up test execution.

These changes collectively make the test suite faster and more robust, while keeping the codebase clean and up-to-date.