### PR TITLE
fix(smb): improve error handling for group SID resolution

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb/SmbClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb/SmbClient.java
@@ -473,7 +473,6 @@ public class SmbClient extends AbstractCrawlerClient {
                         logger.debug("Could not resolve group SIDs: {}", sid);
                     } else {
                         logger.debug("CIFSException on SID processing.", e);
-
                     }
                 }
             } catch (final Exception e) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb/SmbClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb/SmbClient.java
@@ -456,12 +456,24 @@ public class SmbClient extends AbstractCrawlerClient {
         if (type == SID.SID_TYPE_DOM_GRP || type == SID.SID_TYPE_ALIAS) {
             try {
                 final CIFSContext context = file.getContext();
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Resolving group SIDs: {}", sid);
+                }
                 final SID[] children = context.getSIDResolver()
                         .getGroupMemberSids(context, file.getServer(), sid.getDomainSid(), sid.getRid(),
                                 org.codelibs.jcifs.smb.impl.SID.SID_FLAG_RESOLVE_SIDS);
                 for (final SID child : children) {
                     if (!sidSet.contains(child)) {
                         processAllowedSIDs(file, child, sidSet);
+                    }
+                }
+            } catch (final CIFSException e) {
+                if (logger.isDebugEnabled()) {
+                    if ("Failed to get group member SIDs".equals(e.getMessage())) {
+                        logger.debug("Could not resolve group SIDs: {}", sid);
+                    } else {
+                        logger.debug("CIFSException on SID processing.", e);
+
                     }
                 }
             } catch (final Exception e) {


### PR DESCRIPTION
## Summary

This PR improves error handling in the SMB client when resolving group SIDs. I added specific exception handling for CIFSException to provide better diagnostics and logging when group member SID resolution fails.

## Changes Made

- Added debug logging before attempting group SID resolution to track which SIDs are being processed
- Introduced a separate catch block for `CIFSException` before the general `Exception` handler
- Implemented targeted error messages that distinguish between "Failed to get group member SIDs" errors and other CIFS-related exceptions
- Enhanced debugging capability for diagnosing SID resolution issues in production environments

## Technical Details

The changes focus on the `processAllowedSIDs` method in `SmbClient.java`:

1. **Pre-resolution logging**: Added debug log to track SID resolution attempts
2. **Specific exception handling**: Catch `CIFSException` separately to handle known failure scenarios
3. **Conditional logging**: Different debug messages based on the exception message content

## Testing

- Verified that the code compiles successfully
- Debug logging will only activate when debug level is enabled
- Exception handling maintains backward compatibility with existing behavior

## Breaking Changes

None. This is a non-breaking enhancement that only affects debug logging behavior.

## Additional Notes

This improvement helps with troubleshooting SMB permission issues, particularly in environments where group SID resolution may fail due to network or permission constraints.