### PR TITLE
build(deps): update fess-parent version to 15.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.6.0-SNAPSHOT</version>
+		<version>15.6.0</version>
 	</parent>
 	<modules>
 		<module>fess-crawler</module>


### PR DESCRIPTION
## Summary
Update fess-parent version from 15.6.0-SNAPSHOT to 15.6.0 release version.

## Changes Made
- Updated `fess-parent` version in `pom.xml` from `15.6.0-SNAPSHOT` to `15.6.0`

## Testing
- Build verification with `mvn clean install`

## Breaking Changes
- None

## Additional Notes
- This change pins the parent POM to the stable 15.6.0 release