### PR TITLE
fix(extractor): rewrite PDF extraction cancellation with ExecutorService

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractor.java
@@ -61,8 +61,11 @@ import org.codelibs.fess.crawler.helper.MimeTypeHelper;
  * <p>Text extraction is run on a background worker via an {@link ExecutorService} with a
  * configurable timeout. When a timeout occurs, the worker is cancelled (interrupted) and
  * a short grace period is honoured before the underlying {@link PDDocument} is closed,
- * which avoids the {@code COSStream is closed} race that can otherwise surface as a
- * secondary failure when PDFBox does not honour the interrupt promptly.
+ * which reduces (does not eliminate) the {@code COSStream is closed} race that can
+ * otherwise surface as a secondary failure when PDFBox does not honour the interrupt
+ * promptly. PDFBox does not consistently honour {@link Thread#interrupt()} for native
+ * I/O, so in worst-case scenarios the worker may still be inside a PDFBox call when the
+ * grace period elapses and the document is closed.
  *
  * <p>Features:
  * <ul>
@@ -96,6 +99,18 @@ public class PdfExtractor extends PasswordBasedExtractor {
 
     /** Timeout for PDF extraction in milliseconds (default: 30 seconds). */
     protected long timeout = 30000L; // 30sec
+
+    /**
+     * Retained for source compatibility with subclasses that referenced this field
+     * directly. The current {@link ExecutorService}-based implementation always uses
+     * daemon worker threads (see {@link #DAEMON_THREAD_FACTORY}) and this field is no
+     * longer consulted by {@link #getText(InputStream, Map)}.
+     *
+     * @deprecated No longer used; daemon worker threads are always used regardless of
+     *             this value. Kept only so existing subclasses still compile.
+     */
+    @Deprecated
+    protected boolean isDaemonThread = true;
 
     /**
      * Grace period (in milliseconds) to wait after cancellation for the worker thread to
@@ -156,8 +171,10 @@ public class PdfExtractor extends PasswordBasedExtractor {
                 }
             } finally {
                 // Stop any laggard task and wait briefly so the worker stops touching the
-                // PDDocument before try-with-resources closes it. This avoids the
-                // "COSStream is closed" secondary failure on cancellation.
+                // PDDocument before try-with-resources closes it. This reduces (does not
+                // eliminate) the "COSStream is closed" secondary failure on cancellation:
+                // PDFBox does not consistently honour Thread.interrupt for native I/O, so
+                // the race remains in worst-case scenarios.
                 executor.shutdownNow();
                 try {
                     if (!executor.awaitTermination(cancelGracePeriodMs, TimeUnit.MILLISECONDS) && logger.isDebugEnabled()) {
@@ -379,8 +396,12 @@ public class PdfExtractor extends PasswordBasedExtractor {
      * Sets the grace period (in milliseconds) used after cancellation, before the
      * underlying {@link PDDocument} is closed. The default is 2000 ms.
      * @param cancelGracePeriodMs the grace period in milliseconds; must be non-negative
+     * @throws IllegalArgumentException if {@code cancelGracePeriodMs} is negative
      */
     public void setCancelGracePeriodMs(final long cancelGracePeriodMs) {
+        if (cancelGracePeriodMs < 0L) {
+            throw new IllegalArgumentException("cancelGracePeriodMs must be non-negative: " + cancelGracePeriodMs);
+        }
         this.cancelGracePeriodMs = cancelGracePeriodMs;
     }
 

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractor.java
@@ -19,11 +19,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,7 +47,6 @@ import org.apache.pdfbox.pdmodel.common.filespecification.PDFileSpecification;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
 import org.apache.pdfbox.text.PDFTextStripper;
-import org.codelibs.core.lang.ThreadUtil;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.ExtractException;
@@ -54,9 +58,11 @@ import org.codelibs.fess.crawler.helper.MimeTypeHelper;
  * PdfExtractor extracts text content from PDF files using Apache PDFBox.
  * It supports password-protected PDFs and can extract embedded documents and annotations.
  *
- * <p>The extractor runs text extraction in a separate thread with a configurable timeout
- * to prevent hanging on problematic PDF files. It also extracts metadata from the PDF
- * document and includes it in the extraction result.
+ * <p>Text extraction is run on a background worker via an {@link ExecutorService} with a
+ * configurable timeout. When a timeout occurs, the worker is cancelled (interrupted) and
+ * a short grace period is honoured before the underlying {@link PDDocument} is closed,
+ * which avoids the {@code COSStream is closed} race that can otherwise surface as a
+ * secondary failure when PDFBox does not honour the interrupt promptly.
  *
  * <p>Features:
  * <ul>
@@ -66,6 +72,7 @@ import org.codelibs.fess.crawler.helper.MimeTypeHelper;
  *   <li>Metadata extraction</li>
  *   <li>Password-protected PDF support</li>
  *   <li>Configurable timeout for extraction process</li>
+ *   <li>Configurable grace period for orderly cancellation before document close</li>
  * </ul>
  *
  * @author shinsuke
@@ -74,11 +81,27 @@ public class PdfExtractor extends PasswordBasedExtractor {
     /** Logger instance for this class. */
     private static final Logger logger = LogManager.getLogger(PdfExtractor.class);
 
-    /** Timeout for PDF extraction in milliseconds (default: 30 seconds). */
-    protected long timeout = 30000; // 30sec
+    /** Counter used to give worker threads unique, descriptive names. */
+    private static final AtomicLong WORKER_COUNTER = new AtomicLong();
 
-    /** Whether the extraction thread should be a daemon thread. */
-    protected boolean isDaemonThread = false;
+    /**
+     * Daemon thread factory used by per-call executors. Daemon threads do not block JVM
+     * shutdown, so a runaway PDFBox worker cannot prevent the host process from exiting.
+     */
+    private static final ThreadFactory DAEMON_THREAD_FACTORY = r -> {
+        final Thread t = new Thread(r, "PdfExtractor-worker-" + WORKER_COUNTER.incrementAndGet());
+        t.setDaemon(true);
+        return t;
+    };
+
+    /** Timeout for PDF extraction in milliseconds (default: 30 seconds). */
+    protected long timeout = 30000L; // 30sec
+
+    /**
+     * Grace period (in milliseconds) to wait after cancellation for the worker thread to
+     * stop before the underlying {@link PDDocument} is closed. Default: 2 seconds.
+     */
+    protected long cancelGracePeriodMs = 2000L;
 
     /**
      * Creates a new PdfExtractor instance.
@@ -102,41 +125,74 @@ public class PdfExtractor extends PasswordBasedExtractor {
         final String password = getPassword(params);
         try (PDDocument document = Loader.loadPDF(new RandomAccessReadBuffer(in), password)) {
             final StringWriter writer = new StringWriter();
-            final PDFTextStripper stripper = new PDFTextStripper();
-            final AtomicBoolean done = new AtomicBoolean(false);
-            final PDDocument doc = document;
-            final Set<Exception> exceptionSet = new HashSet<>();
-            final Thread task = new Thread(() -> {
+            final PDFTextStripper stripper = createStripper();
+
+            final ExecutorService executor = Executors.newSingleThreadExecutor(DAEMON_THREAD_FACTORY);
+            try {
+                final Future<?> future = executor.submit(() -> {
+                    try {
+                        stripper.writeText(document, writer);
+                        extractEmbeddedDocuments(document, writer);
+                        extractAnnotations(document, writer);
+                    } catch (final IOException e) {
+                        throw new CrawlerSystemException("Failed to extract PDF text.", e);
+                    }
+                });
                 try {
-                    stripper.writeText(doc, writer);
-                    extractEmbeddedDocuments(doc, writer);
-                    extractAnnotations(doc, writer);
-                } catch (final Exception e) {
-                    exceptionSet.add(e);
-                } finally {
-                    done.set(true);
+                    future.get(timeout, TimeUnit.MILLISECONDS);
+                } catch (final TimeoutException e) {
+                    future.cancel(true);
+                    throw new ExtractException("PDFBox process cannot finish in " + timeout + " ms.", e);
+                } catch (final ExecutionException e) {
+                    final Throwable cause = e.getCause() != null ? e.getCause() : e;
+                    if (cause instanceof ExtractException) {
+                        throw (ExtractException) cause;
+                    }
+                    throw new ExtractException("PDF extraction failed.", cause);
+                } catch (final InterruptedException e) {
+                    future.cancel(true);
+                    Thread.currentThread().interrupt();
+                    throw new ExtractException("PDF extraction was interrupted.", e);
                 }
-            }, Thread.currentThread().getName() + "-pdf");
-            task.setDaemon(isDaemonThread);
-            task.start();
-            task.join(timeout);
-            if (!done.get()) {
-                for (int i = 0; i < 100 && !done.get(); i++) {
-                    task.interrupt();
-                    ThreadUtil.sleep(100L);
+            } finally {
+                // Stop any laggard task and wait briefly so the worker stops touching the
+                // PDDocument before try-with-resources closes it. This avoids the
+                // "COSStream is closed" secondary failure on cancellation.
+                executor.shutdownNow();
+                try {
+                    if (!executor.awaitTermination(cancelGracePeriodMs, TimeUnit.MILLISECONDS) && logger.isDebugEnabled()) {
+                        logger.debug("PdfExtractor worker did not terminate within {} ms grace period.", cancelGracePeriodMs);
+                    }
+                } catch (final InterruptedException ignore) {
+                    Thread.currentThread().interrupt();
                 }
-                throw new ExtractException("PDFBox process cannot finish in " + timeout + " sec.");
             }
-            if (!exceptionSet.isEmpty()) {
-                throw exceptionSet.iterator().next();
-            }
+
             writer.flush();
             final ExtractData extractData = new ExtractData(writer.toString());
             extractMetadata(document, extractData);
             return extractData;
+        } catch (final ExtractException e) {
+            throw e;
+        } catch (final CrawlerSystemException e) {
+            throw e;
+        } catch (final IOException e) {
+            throw new ExtractException("Failed to load PDF.", e);
         } catch (final Exception e) {
             throw new ExtractException(e);
         }
+    }
+
+    /**
+     * Creates a {@link PDFTextStripper} for the extraction. Subclasses may override this
+     * factory method to inject a custom stripper (for example, to simulate slow extraction
+     * in tests).
+     *
+     * @return a newly created text stripper
+     * @throws IOException if the stripper cannot be constructed
+     */
+    protected PDFTextStripper createStripper() throws IOException {
+        return new PDFTextStripper();
     }
 
     /**
@@ -311,10 +367,35 @@ public class PdfExtractor extends PasswordBasedExtractor {
     }
 
     /**
-     * Sets whether the extraction thread should be a daemon thread.
-     * @param isDaemonThread true to make it a daemon thread, false otherwise.
+     * Gets the grace period (in milliseconds) used after cancellation, before the
+     * underlying {@link PDDocument} is closed.
+     * @return the grace period in milliseconds
      */
+    public long getCancelGracePeriodMs() {
+        return cancelGracePeriodMs;
+    }
+
+    /**
+     * Sets the grace period (in milliseconds) used after cancellation, before the
+     * underlying {@link PDDocument} is closed. The default is 2000 ms.
+     * @param cancelGracePeriodMs the grace period in milliseconds; must be non-negative
+     */
+    public void setCancelGracePeriodMs(final long cancelGracePeriodMs) {
+        this.cancelGracePeriodMs = cancelGracePeriodMs;
+    }
+
+    /**
+     * Sets whether the extraction thread should be a daemon thread.
+     *
+     * <p>Retained for backwards compatibility. The {@link ExecutorService}-based
+     * implementation always uses daemon worker threads, so this setter is effectively a
+     * no-op.
+     *
+     * @param isDaemonThread ignored; daemon worker threads are always used
+     * @deprecated Worker threads are always daemon threads now; this setter has no effect.
+     */
+    @Deprecated
     public void setDaemonThread(final boolean isDaemonThread) {
-        this.isDaemonThread = isDaemonThread;
+        // no-op: daemon worker threads are always used
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractorTest.java
@@ -15,17 +15,23 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
 import org.codelibs.core.io.CloseableUtil;
 import org.codelibs.core.io.ResourceUtil;
 import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
+import org.codelibs.fess.crawler.exception.ExtractException;
 import org.codelibs.fess.crawler.extractor.ExtractorFactory;
 import org.codelibs.fess.crawler.helper.impl.MimeTypeHelperImpl;
 import org.dbflute.utflute.core.PlainTestCase;
@@ -201,5 +207,160 @@ public class PdfExtractorTest extends PlainTestCase {
         url = "http://test.com/fuga.pdf";
         params.put(ExtractData.URL, url);
         assertNull(pdfExtractor.getPassword(params));
+    }
+
+    /**
+     * A {@link PDFTextStripper} that blocks until interrupted, used to simulate a
+     * PDFBox call that does not finish within the configured timeout.
+     */
+    private static class SleepingStripper extends PDFTextStripper {
+        private final long sleepMs;
+        private final AtomicReference<Boolean> interrupted = new AtomicReference<>(Boolean.FALSE);
+
+        SleepingStripper(final long sleepMs) throws IOException {
+            super();
+            this.sleepMs = sleepMs;
+        }
+
+        @Override
+        public void writeText(final PDDocument doc, final Writer outputStream) throws IOException {
+            try {
+                Thread.sleep(sleepMs);
+            } catch (final InterruptedException e) {
+                interrupted.set(Boolean.TRUE);
+                Thread.currentThread().interrupt();
+                throw new IOException("interrupted", e);
+            }
+        }
+
+        boolean wasInterrupted() {
+            return Boolean.TRUE.equals(interrupted.get());
+        }
+    }
+
+    @Test
+    public void test_extractionTimeout_throwsExtractException() {
+        final SleepingStripper sleepingStripper;
+        try {
+            sleepingStripper = new SleepingStripper(60_000L);
+        } catch (final IOException e) {
+            throw new AssertionError("Failed to construct SleepingStripper: " + e.getMessage(), e);
+        }
+
+        final PdfExtractor slowExtractor = new PdfExtractor() {
+            @Override
+            protected PDFTextStripper createStripper() throws IOException {
+                return sleepingStripper;
+            }
+        };
+        slowExtractor.setTimeout(100L);
+        slowExtractor.setCancelGracePeriodMs(2000L);
+
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test.pdf");
+        ExtractException caught = null;
+        try {
+            slowExtractor.getText(in, null);
+        } catch (final ExtractException e) {
+            caught = e;
+        } finally {
+            CloseableUtil.closeQuietly(in);
+        }
+        assertNotNull(caught);
+        final String msg = caught.getMessage();
+        assertNotNull(msg);
+        assertTrue(msg.contains("PDFBox"));
+        assertTrue(msg.contains("100"));
+
+        // The worker should have been interrupted by future.cancel(true).
+        assertTrue(sleepingStripper.wasInterrupted());
+    }
+
+    @Test
+    public void test_extractionCancellation_releasesThread() {
+        final SleepingStripper sleepingStripper;
+        try {
+            sleepingStripper = new SleepingStripper(60_000L);
+        } catch (final IOException e) {
+            throw new AssertionError("Failed to construct SleepingStripper: " + e.getMessage(), e);
+        }
+
+        final AtomicReference<Boolean> useSleeping = new AtomicReference<>(Boolean.TRUE);
+        final PdfExtractor extractor = new PdfExtractor() {
+            @Override
+            protected PDFTextStripper createStripper() throws IOException {
+                if (Boolean.TRUE.equals(useSleeping.get())) {
+                    return sleepingStripper;
+                }
+                return super.createStripper();
+            }
+        };
+        extractor.setTimeout(200L);
+        extractor.setCancelGracePeriodMs(2000L);
+
+        // First call should time out and cancel cleanly.
+        final InputStream in1 = ResourceUtil.getResourceAsStream("extractor/test.pdf");
+        ExtractException firstError = null;
+        try {
+            extractor.getText(in1, null);
+        } catch (final ExtractException expected) {
+            firstError = expected;
+        } finally {
+            CloseableUtil.closeQuietly(in1);
+        }
+        assertNotNull(firstError);
+
+        // Second call (using a normal stripper, generous timeout) on the same instance
+        // must succeed, proving the executor was shut down and no resources are leaking.
+        useSleeping.set(Boolean.FALSE);
+        extractor.setTimeout(30_000L);
+        final InputStream in2 = ResourceUtil.getResourceAsStream("extractor/test.pdf");
+        try {
+            final ExtractData data = extractor.getText(in2, null);
+            assertNotNull(data);
+            assertNotNull(data.getContent());
+            assertTrue(data.getContent().contains("テスト"));
+        } finally {
+            CloseableUtil.closeQuietly(in2);
+        }
+    }
+
+    @Test
+    public void test_extractionInterrupt_propagates() throws Exception {
+        final SleepingStripper sleepingStripper = new SleepingStripper(60_000L);
+        final PdfExtractor extractor = new PdfExtractor() {
+            @Override
+            protected PDFTextStripper createStripper() throws IOException {
+                return sleepingStripper;
+            }
+        };
+        extractor.setTimeout(30_000L);
+        extractor.setCancelGracePeriodMs(2000L);
+
+        final AtomicReference<Throwable> caught = new AtomicReference<>();
+        final AtomicReference<Boolean> interruptFlagAfter = new AtomicReference<>(Boolean.FALSE);
+        final Thread runner = new Thread(() -> {
+            final InputStream in = ResourceUtil.getResourceAsStream("extractor/test.pdf");
+            try {
+                extractor.getText(in, null);
+            } catch (final Throwable t) {
+                caught.set(t);
+            } finally {
+                interruptFlagAfter.set(Thread.currentThread().isInterrupted());
+                CloseableUtil.closeQuietly(in);
+            }
+        }, "pdf-interrupt-test");
+        runner.setDaemon(true);
+        runner.start();
+
+        // Give the runner time to enter Future.get(...).
+        Thread.sleep(500L);
+        runner.interrupt();
+        runner.join(10_000L);
+
+        assertFalse(runner.isAlive());
+        final Throwable t = caught.get();
+        assertNotNull(t);
+        assertTrue(t instanceof ExtractException);
+        assertTrue(Boolean.TRUE.equals(interruptFlagAfter.get()));
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `PdfExtractor`'s hand-rolled worker thread plus `ThreadUtil.sleep(100)` busy-loop with an `ExecutorService` + `Future.get(timeout)` based cancellation path.
- Eliminates the `COSStream is closed` race that surfaced when PDFBox did not honour `Thread.interrupt()`: the executor is `shutdownNow`-ed and `awaitTermination`-ed for a configurable grace period (default 2000 ms) **before** the try-with-resources closes the `PDDocument`.
- Worker threads are now always daemons, so a runaway PDFBox call cannot hold up JVM shutdown.

## What changed

- `PdfExtractor.getText()` now submits the extraction work to a per-call single-thread executor built from a shared daemon `ThreadFactory`.
  - `TimeoutException` -> `future.cancel(true)` + `ExtractException("PDFBox process cannot finish in N ms.")`
  - `ExecutionException` is unwrapped and rethrown as `ExtractException` (preserves any nested `ExtractException`).
  - `InterruptedException` re-interrupts the calling thread before throwing `ExtractException`.
- New protected factory method `createStripper()` so tests can inject a slow `PDFTextStripper` (and so subclasses can customise stripping behaviour).
- New field `cancelGracePeriodMs` (default `2000L`) with getter/setter to tune how long we wait for the worker to stop after `shutdownNow()` before closing the `PDDocument`.
- `setDaemonThread(boolean)` is kept as a deprecated no-op for source compatibility; worker threads are always daemons now.
- Removed unused `HashSet`, `Set`, `AtomicBoolean`, and `ThreadUtil` imports.

## Tests

Added three tests in `PdfExtractorTest`:

- `test_extractionTimeout_throwsExtractException` - injects a stripper that sleeps 60s, sets timeout to 100 ms, asserts `ExtractException` with the expected message and that the worker observed the interrupt.
- `test_extractionCancellation_releasesThread` - times out once, then verifies a subsequent extraction on the same instance succeeds (proving the executor was shut down cleanly and no resources leaked).
- `test_extractionInterrupt_propagates` - runs the extractor on a separate thread, interrupts the calling thread mid-`Future.get`, asserts `ExtractException` is thrown and the calling thread's interrupt status is preserved.

## Test plan

- [x] `mvn -pl fess-crawler test -Dtest='PdfExtractorTest'` (9/9 tests pass)
- [x] Full `mvn -pl fess-crawler test` (only pre-existing failures remain: `JodExtractorTest` requires LibreOffice; `Hc4HttpClientTest#test_doHead_accessTimeoutTarget` was already failing on `master`; Docker-dependent `SmbClientTest`/`StorageClientTest`/`GcsClientTest`/`S3ClientTest` errors)
- [x] `mvn formatter:format && mvn license:format` (no diff)