### PR TITLE
fix(extractor): harden CommandExtractor with timeout, output cap, descendant kill

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
@@ -22,7 +22,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -158,6 +160,18 @@ public class CommandExtractor extends AbstractExtractor {
             filePrefix = "none";
             extention = "";
         }
+        // Sanitize prefix and extension to prevent argument-injection via crafted resourceName
+        // when downstream commands re-expand args through a shell wrapper.
+        filePrefix = filePrefix.replaceAll("[^A-Za-z0-9._-]", "_");
+        if (filePrefix.startsWith("-")) {
+            filePrefix = "_" + filePrefix;
+        }
+        if (!extention.isEmpty()) {
+            extention = extention.replaceAll("[^A-Za-z0-9]", "");
+            if (extention.length() > 16) {
+                extention = extention.substring(0, 16);
+            }
+        }
         File inputFile = null;
         File outputFile = null;
         try {
@@ -180,6 +194,8 @@ public class CommandExtractor extends AbstractExtractor {
 
             final String stderrText = executeCommand(inputFile, outputFile);
 
+            // For standardOutput=false this is the only guard against the external command writing
+            // an unbounded $OUTPUT_FILE — bounded readers cover stdout/stderr only.
             if (outputFile.length() > maxOutputSize) {
                 logger.warn("output file size exceeded limit: size={} limit={} command={}", outputFile.length(), maxOutputSize, command);
                 throw new ExtractException("output file size exceeded limit: limit=" + maxOutputSize);
@@ -200,7 +216,7 @@ public class CommandExtractor extends AbstractExtractor {
 
             return extractData;
         } catch (final IOException e) {
-            throw new ExtractException("Could not extract a content.", e);
+            throw new ExtractException("Could not extract content: resourceName=" + resourceName + " command=" + command, e);
         } finally {
             FileUtil.deleteInBackground(inputFile);
             FileUtil.deleteInBackground(outputFile);
@@ -234,8 +250,8 @@ public class CommandExtractor extends AbstractExtractor {
     }
 
     String getFileName(final String resourceName) {
-        final String name = resourceName.replaceAll("/+$", "");
-        final int pos = name.lastIndexOf('/');
+        final String name = resourceName.replaceAll("[/\\\\]+$", "");
+        final int pos = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
         if (pos >= 0) {
             return name.substring(pos + 1);
         }
@@ -254,7 +270,7 @@ public class CommandExtractor extends AbstractExtractor {
 
         final List<String> cmdList = parseCommand(command, params);
         if (logger.isInfoEnabled()) {
-            logger.info("Command: {}", cmdList);
+            logger.info("executing command: command={}", cmdList);
         }
 
         final ProcessBuilder pb = new ProcessBuilder(cmdList);
@@ -272,10 +288,12 @@ public class CommandExtractor extends AbstractExtractor {
         Charset outCharset;
         try {
             outCharset = Charset.forName(commandOutputEncoding);
-        } catch (final Exception e) {
+        } catch (final IllegalCharsetNameException | UnsupportedCharsetException e) {
+            logger.warn("invalid commandOutputEncoding, falling back to UTF-8: encoding={} command={}", commandOutputEncoding, command, e);
             outCharset = StandardCharsets.UTF_8;
         }
 
+        final AtomicBoolean shuttingDown = new AtomicBoolean(false);
         try {
             currentProcess = pb.start();
 
@@ -288,14 +306,14 @@ public class CommandExtractor extends AbstractExtractor {
             final Future<String> stdoutFuture;
             if (standardOutput) {
                 // Drain stdout into outputFile with a byte-count bound to honour maxOutputSize.
-                stdoutFuture =
-                        streamPool.submit(new BoundedFileWriter(processRef.getInputStream(), outputFile, limit, processRef, "stdout"));
+                stdoutFuture = streamPool.submit(
+                        new BoundedFileWriter(processRef.getInputStream(), outputFile, limit, "stdout", overflowFlag, shuttingDown));
             } else {
                 stdoutFuture = streamPool
-                        .submit(new BoundedStreamReader(processRef.getInputStream(), charset, limit, processRef, "stdout", overflowFlag));
+                        .submit(new BoundedStreamReader(processRef.getInputStream(), charset, limit, "stdout", overflowFlag, shuttingDown));
             }
             final Future<String> stderrFuture = streamPool
-                    .submit(new BoundedStreamReader(processRef.getErrorStream(), charset, limit, processRef, "stderr", overflowFlag));
+                    .submit(new BoundedStreamReader(processRef.getErrorStream(), charset, limit, "stderr", overflowFlag, shuttingDown));
 
             // Poll for process exit so that an overflow detected by a reader thread can
             // break out immediately rather than blocking for the full executionTimeout.
@@ -315,26 +333,33 @@ public class CommandExtractor extends AbstractExtractor {
             if (!exited) {
                 if (overflowFlag.get()) {
                     // Overflow path: kill the process tree, then surface the reader's exception.
+                    shuttingDown.set(true);
                     destroyProcessTree(currentProcess);
                     // Collect exceptions from both futures with a short timeout.
-                    for (final Future<String> f : new Future[] { stdoutFuture, stderrFuture }) {
+                    for (final Future<String> f : List.of(stdoutFuture, stderrFuture)) {
                         try {
                             f.get(2, TimeUnit.SECONDS);
                         } catch (final ExecutionException ee) {
                             final Throwable cause = ee.getCause();
                             if (cause instanceof OutputSizeExceededException) {
                                 logger.warn("command output exceeded limit: limit={} command={}", maxOutputSize, cmdList);
-                                throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize);
+                                throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize, cause);
                             }
-                        } catch (final TimeoutException | InterruptedException ignore) {
-                            // ignore — we already set the overflow flag
+                            logger.warn("unexpected error draining stream during overflow handling: command={}", cmdList, cause);
+                            throw new CrawlerSystemException("Failed to drain command output during overflow.", cause);
+                        } catch (final TimeoutException te) {
+                            // overflow already detected; surface the ExtractException below
+                        } catch (final InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            break;
                         }
                     }
-                    // Should not reach here, but guard just in case.
+                    // guard: overflow flag set but no overflow exception observed
                     throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize);
                 } else {
                     // Timeout path.
                     logger.warn("command timed out: timeout={}ms command={}", executionTimeout, cmdList);
+                    shuttingDown.set(true);
                     destroyProcessTree(currentProcess);
                     throw new ExecutionTimeoutException("The command execution is timeout: " + cmdList);
                 }
@@ -345,18 +370,21 @@ public class CommandExtractor extends AbstractExtractor {
             String stdoutText = "";
             String stderrText = "";
             try {
-                if (stdoutFuture != null) {
-                    stdoutText = stdoutFuture.get(5, TimeUnit.SECONDS);
-                }
+                stdoutText = stdoutFuture.get(5, TimeUnit.SECONDS);
                 stderrText = stderrFuture.get(5, TimeUnit.SECONDS);
             } catch (final TimeoutException te) {
                 logger.warn("timed out collecting drained output: command={}", cmdList);
+                stdoutFuture.cancel(true);
+                stderrFuture.cancel(true);
+                destroyProcessTree(currentProcess);
+                throw new ExtractException("Failed to drain command output within 5s: command=" + cmdList, te);
             } catch (final ExecutionException ee) {
                 final Throwable cause = ee.getCause();
                 if (cause instanceof OutputSizeExceededException) {
                     logger.warn("command output exceeded limit: limit={} command={}", maxOutputSize, cmdList);
+                    shuttingDown.set(true);
                     destroyProcessTree(currentProcess);
-                    throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize);
+                    throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize, cause);
                 }
                 if (cause instanceof IOException) {
                     throw new CrawlerSystemException("Failed to drain command output.", cause);
@@ -365,15 +393,18 @@ public class CommandExtractor extends AbstractExtractor {
             }
 
             final int exitValue = currentProcess.exitValue();
+            if (exitValue != 0) {
+                logger.warn("command exited non-zero: exitCode={} command={}", exitValue, cmdList);
+            }
 
             if (logger.isInfoEnabled()) {
                 if (standardOutput) {
-                    logger.info("Exit Code: {}", exitValue);
+                    logger.info("command exited: exitCode={}", exitValue);
                 } else {
-                    logger.info("Exit Code: {} - Process Output:\n{}", exitValue, truncateForLog(stdoutText));
+                    logger.info("command exited: exitCode={} stdout={}", exitValue, truncateForLog(stdoutText));
                 }
                 if (StringUtil.isNotEmpty(stderrText)) {
-                    logger.info("Process Stderr:\n{}", truncateForLog(stderrText));
+                    logger.info("command stderr: stderr={}", truncateForLog(stderrText));
                 }
             }
             return stderrText;
@@ -382,17 +413,27 @@ public class CommandExtractor extends AbstractExtractor {
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             if (currentProcess != null) {
+                shuttingDown.set(true);
                 destroyProcessTree(currentProcess);
             }
             throw new InterruptedRuntimeException(e);
         } catch (final Exception e) {
-            throw new CrawlerSystemException("Process terminated.", e);
+            logger.warn("unexpected error executing command: command={}", cmdList, e);
+            throw new CrawlerSystemException("Failed to execute command: " + cmdList, e);
         } finally {
             if (currentProcess != null && currentProcess.isAlive()) {
+                shuttingDown.set(true);
                 destroyProcessTree(currentProcess);
             }
             if (streamPool != null) {
                 streamPool.shutdownNow();
+                try {
+                    if (!streamPool.awaitTermination(1, TimeUnit.SECONDS)) {
+                        logger.warn("stream pool did not terminate within 1s: command={}", cmdList);
+                    }
+                } catch (final InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
     }
@@ -422,19 +463,25 @@ public class CommandExtractor extends AbstractExtractor {
             try {
                 process.destroy();
             } catch (final Exception ex) {
-                // ignore
+                if (logger.isDebugEnabled()) {
+                    logger.debug("destroy step failed: pid={}", process == null ? -1 : process.pid(), ex);
+                }
             }
             try {
                 process.destroyForcibly();
             } catch (final Exception ex) {
-                // ignore
+                if (logger.isDebugEnabled()) {
+                    logger.debug("destroy step failed: pid={}", process == null ? -1 : process.pid(), ex);
+                }
             }
             return;
         }
         try {
             process.destroy();
-        } catch (final Exception e) {
-            // ignore
+        } catch (final Exception ex) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("destroy step failed: pid={}", process == null ? -1 : process.pid(), ex);
+            }
         }
         try {
             process.waitFor(destroyGracePeriodMillis, TimeUnit.MILLISECONDS);
@@ -445,16 +492,50 @@ public class CommandExtractor extends AbstractExtractor {
         // exited cleanly during the grace period.
         for (final ProcessHandle h : descendantSnapshot) {
             try {
-                h.destroyForcibly();
-            } catch (final Exception e) {
-                // ignore
+                if (h.isAlive()) {
+                    h.destroyForcibly();
+                }
+            } catch (final Exception ex) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("destroy step failed: pid={}", h.pid(), ex);
+                }
             }
         }
         try {
             process.destroyForcibly();
-        } catch (final Exception e) {
+        } catch (final Exception ex) {
             if (logger.isDebugEnabled()) {
-                logger.debug("Failed to forcibly destroy process.", e);
+                logger.debug("destroy step failed: pid={}", process == null ? -1 : process.pid(), ex);
+            }
+        }
+        // Bounded re-scan loop to catch fork-after-snapshot.
+        for (int attempt = 0; attempt < 3; attempt++) {
+            final List<ProcessHandle> live;
+            try {
+                live = process.descendants().filter(ProcessHandle::isAlive).collect(Collectors.toList());
+            } catch (final Exception e) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("rescan failed: pid={}", process.pid(), e);
+                }
+                break;
+            }
+            if (live.isEmpty()) {
+                break;
+            }
+            for (final ProcessHandle h : live) {
+                try {
+                    h.destroyForcibly();
+                } catch (final Exception e) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("destroy descendant failed: pid={}", h.pid(), e);
+                    }
+                }
+            }
+            try {
+                Thread.sleep(50);
+            } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                break;
             }
         }
     }
@@ -563,9 +644,9 @@ public class CommandExtractor extends AbstractExtractor {
         private final InputStream stream;
         private final Charset charset;
         private final long limit;
-        private final Process process;
         private final String streamName;
         private final AtomicBoolean overflowFlag;
+        private final AtomicBoolean shuttingDown;
 
         /**
          * Constructs a new BoundedStreamReader.
@@ -573,20 +654,22 @@ public class CommandExtractor extends AbstractExtractor {
          * @param stream the input stream to drain
          * @param charset the charset used to decode the bytes
          * @param limit the maximum number of bytes accepted before the process is killed
-         * @param process the process whose stream is being drained (used to destroy on overflow)
          * @param streamName a label used in error messages and logs
          * @param overflowFlag shared flag that is set to {@code true} just before
          *                     {@link OutputSizeExceededException} is thrown, allowing the main
          *                     thread's polling loop to break early and kill the process tree
+         * @param shuttingDown shared flag indicating the main thread is in the process of killing
+         *                     the subprocess; IOExceptions observed while this flag is set are
+         *                     logged at debug level rather than surfaced as ExecutionExceptions
          */
-        public BoundedStreamReader(final InputStream stream, final Charset charset, final long limit, final Process process,
-                final String streamName, final AtomicBoolean overflowFlag) {
+        public BoundedStreamReader(final InputStream stream, final Charset charset, final long limit, final String streamName,
+                final AtomicBoolean overflowFlag, final AtomicBoolean shuttingDown) {
             this.stream = stream;
             this.charset = charset;
             this.limit = limit;
-            this.process = process;
             this.streamName = streamName;
             this.overflowFlag = overflowFlag;
+            this.shuttingDown = shuttingDown;
         }
 
         @Override
@@ -611,9 +694,13 @@ public class CommandExtractor extends AbstractExtractor {
             } catch (final OutputSizeExceededException e) {
                 throw e;
             } catch (final IOException ioe) {
-                // The pipe may be closed when the process is killed; treat as end-of-stream.
-                if (logger.isDebugEnabled()) {
-                    logger.debug("stream read interrupted: stream={}", streamName, ioe);
+                if (shuttingDown.get()) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("stream closed during shutdown: stream={}", streamName, ioe);
+                    }
+                } else {
+                    logger.warn("unexpected I/O error on stream: stream={} drainedBytes={}", streamName, total, ioe);
+                    throw ioe;
                 }
             }
             return new String(baos.toByteArray(), charset);
@@ -647,8 +734,9 @@ public class CommandExtractor extends AbstractExtractor {
         private final InputStream stream;
         private final File outputFile;
         private final long limit;
-        private final Process process;
         private final String streamName;
+        private final AtomicBoolean overflowFlag;
+        private final AtomicBoolean shuttingDown;
 
         /**
          * Constructs a new BoundedFileWriter.
@@ -656,16 +744,22 @@ public class CommandExtractor extends AbstractExtractor {
          * @param stream the input stream to drain
          * @param outputFile the file to write output to
          * @param limit the maximum number of bytes accepted before the process is killed
-         * @param process the process whose stream is being drained (kept for API symmetry with BoundedStreamReader)
          * @param streamName a label used in error messages and logs
+         * @param overflowFlag shared flag set to {@code true} just before
+         *                     {@link OutputSizeExceededException} is thrown so the main thread's
+         *                     polling loop breaks out early instead of blocking until executionTimeout
+         * @param shuttingDown shared flag indicating the main thread is in the process of killing
+         *                     the subprocess; IOExceptions observed while this flag is set are
+         *                     logged at debug level rather than surfaced as ExecutionExceptions
          */
-        public BoundedFileWriter(final InputStream stream, final File outputFile, final long limit, final Process process,
-                final String streamName) {
+        public BoundedFileWriter(final InputStream stream, final File outputFile, final long limit, final String streamName,
+                final AtomicBoolean overflowFlag, final AtomicBoolean shuttingDown) {
             this.stream = stream;
             this.outputFile = outputFile;
             this.limit = limit;
-            this.process = process;
             this.streamName = streamName;
+            this.overflowFlag = overflowFlag;
+            this.shuttingDown = shuttingDown;
         }
 
         @Override
@@ -677,6 +771,7 @@ public class CommandExtractor extends AbstractExtractor {
                 while ((n = is.read(buf)) != -1) {
                     total += n;
                     if (total > limit) {
+                        overflowFlag.set(true);
                         throw new OutputSizeExceededException(
                                 "command output exceeded limit on " + streamName + ": limit=" + limit + " bytes");
                     }
@@ -685,8 +780,13 @@ public class CommandExtractor extends AbstractExtractor {
             } catch (final OutputSizeExceededException e) {
                 throw e;
             } catch (final IOException ioe) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("stream read interrupted: stream={}", streamName, ioe);
+                if (shuttingDown.get()) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("stream closed during shutdown: stream={}", streamName, ioe);
+                    }
+                } else {
+                    logger.warn("unexpected I/O error on stream: stream={} drainedBytes={}", streamName, total, ioe);
+                    throw ioe;
                 }
             }
             return "";
@@ -715,30 +815,47 @@ public class CommandExtractor extends AbstractExtractor {
          * @param process the process to monitor (ignored; retained for source compat)
          * @param timeout the timeout (ignored; retained for source compat)
          */
+        @Deprecated
         public MonitorThread(final Process process, final long timeout) {
             // NOP - retained only for source compatibility.
         }
 
+        /**
+         * No-op stub. Subclasses cannot override this — it is intentionally final to make
+         * legacy override attempts compile-fail (rather than silently no-op).
+         */
+        @Deprecated
         @Override
-        public void run() {
+        public final void run() {
             // NOP
         }
 
         /**
          * Sets the finished flag.
          *
+         * <p>Subclasses cannot override this — it is intentionally final to make legacy
+         * override attempts compile-fail (rather than silently no-op).
+         *
          * @param finished the finished flag (ignored)
          */
-        public void setFinished(final boolean finished) {
+        @Deprecated
+        public final void setFinished(final boolean finished) {
             // NOP - retained only for source compatibility.
         }
 
         /**
          * Returns whether the process was terminated.
          *
+         * <p>Subclasses cannot override this — it is intentionally final to make legacy
+         * override attempts compile-fail (rather than silently no-op).
+         *
+         * <p>Note: the typo is preserved intentionally for binary compatibility with the
+         * legacy API.
+         *
          * @return always {@code false}; this stub never terminates anything.
          */
-        public boolean isTeminated() {
+        @Deprecated
+        public final boolean isTeminated() {
             return false;
         }
     }
@@ -764,21 +881,31 @@ public class CommandExtractor extends AbstractExtractor {
          * @param charset the charset (ignored; retained for source compat)
          * @param maxOutputLineBuffer the line buffer size (ignored; retained for source compat)
          */
+        @Deprecated
         public InputStreamThread(final InputStream is, final String charset, final int maxOutputLineBuffer) {
             // NOP - retained only for source compatibility.
         }
 
+        /**
+         * No-op stub. Subclasses cannot override this — it is intentionally final to make
+         * legacy override attempts compile-fail (rather than silently no-op).
+         */
+        @Deprecated
         @Override
-        public void run() {
+        public final void run() {
             // NOP
         }
 
         /**
          * Returns the buffered output as a String.
          *
+         * <p>Subclasses cannot override this — it is intentionally final to make legacy
+         * override attempts compile-fail (rather than silently no-op).
+         *
          * @return always an empty string; this stub never reads anything.
          */
-        public String getOutput() {
+        @Deprecated
+        public final String getOutput() {
             return "";
         }
     }
@@ -875,9 +1002,15 @@ public class CommandExtractor extends AbstractExtractor {
      * size as explicitly set, preventing a subsequent {@link #setMaxOutputLine(int)}
      * call from overriding it.
      *
+     * <p>Note: the entire output may be loaded into memory during extraction
+     * (transient 2–4× heap usage). Values above 512 MiB log a warning.
+     *
      * @param maxOutputSize the limit in bytes
      */
     public void setMaxOutputSize(final long maxOutputSize) {
+        if (maxOutputSize > 512L * 1024L * 1024L) {
+            logger.warn("maxOutputSize is large; extraction may transiently allocate 2-4x this in heap: maxOutputSize={}", maxOutputSize);
+        }
         this.maxOutputSize = maxOutputSize;
         this.maxOutputSizeExplicit = true;
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -92,6 +93,9 @@ public class CommandExtractor extends AbstractExtractor {
 
     /** Maximum bytes the subprocess is allowed to write to a single drained stream (stdout/stderr). */
     protected long maxOutputSize = 10L * 1024L * 1024L; // 10 MiB
+
+    /** Whether {@link #setMaxOutputSize(long)} has been called explicitly, preventing {@link #setMaxOutputLine(int)} from overriding it. */
+    private boolean maxOutputSizeExplicit = false;
 
     /** Maximum bytes copied from the input stream into the temporary input file. */
     protected long maxInputSize = 100L * 1024L * 1024L; // 100 MiB
@@ -171,6 +175,11 @@ public class CommandExtractor extends AbstractExtractor {
 
             final String stderrText = executeCommand(inputFile, outputFile);
 
+            if (outputFile.length() > maxOutputSize) {
+                logger.warn("output file size exceeded limit: size={} limit={} command={}", outputFile.length(), maxOutputSize, command);
+                throw new ExtractException("output file size exceeded limit: limit=" + maxOutputSize);
+            }
+
             final StringBuilder contentBuf = new StringBuilder();
             contentBuf.append(new String(FileUtil.readBytes(outputFile), outputEncoding));
             // For backward compatibility with the legacy implementation that used
@@ -247,11 +256,11 @@ public class CommandExtractor extends AbstractExtractor {
         if (workingDirectory != null) {
             pb.directory(workingDirectory);
         }
-        if (standardOutput) {
-            pb.redirectOutput(outputFile);
-        }
-        // Note: do not redirect error stream when standardOutput=true; we want stderr drained separately.
-        // When standardOutput=false stdout is captured by us via getInputStream(); both streams must be drained.
+        // Do not use pb.redirectOutput(outputFile) for standardOutput=true: OS-level redirection
+        // bypasses the BoundedStreamReader, allowing unbounded writes. Instead, pipe stdout through
+        // a BoundedFileWriter that enforces maxOutputSize.
+
+        // Note: do not redirect error stream; we want stderr drained separately always.
 
         Process currentProcess = null;
         ExecutorService streamPool = null;
@@ -267,14 +276,14 @@ public class CommandExtractor extends AbstractExtractor {
 
             streamPool = Executors.newFixedThreadPool(2, new DaemonThreadFactory("CommandExtractor-stream"));
 
-            // Drain stdout (only if we are not redirecting it to a file).
             final Process processRef = currentProcess;
             final Charset charset = outCharset;
             final long limit = maxOutputSize;
             final Future<String> stdoutFuture;
             if (standardOutput) {
-                // stdout is being written directly to outputFile by the JVM redirection; nothing to drain.
-                stdoutFuture = null;
+                // Drain stdout into outputFile with a byte-count bound to honour maxOutputSize.
+                stdoutFuture =
+                        streamPool.submit(new BoundedFileWriter(processRef.getInputStream(), outputFile, limit, processRef, "stdout"));
             } else {
                 stdoutFuture =
                         streamPool.submit(new BoundedStreamReader(processRef.getInputStream(), charset, limit, processRef, "stdout"));
@@ -348,11 +357,36 @@ public class CommandExtractor extends AbstractExtractor {
 
     /**
      * Sends SIGTERM, waits a grace period, then SIGKILL to the process and any descendants.
+     * Descendants are snapshotted before sending SIGTERM so that children reparented to
+     * PID 1 after the parent exits are still reachable.
      *
      * @param process the process to terminate
      */
     protected void destroyProcessTree(final Process process) {
         if (process == null) {
+            return;
+        }
+        // Snapshot descendants before sending SIGTERM. If the parent shell receives SIGTERM and
+        // exits gracefully its children may be reparented to PID 1, making them invisible via
+        // process.descendants() after the fact. Taking the snapshot first ensures we still reach them.
+        final List<ProcessHandle> descendantSnapshot;
+        try {
+            descendantSnapshot = process.descendants().collect(Collectors.toList());
+        } catch (final Exception e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to snapshot descendants.", e);
+            }
+            // Fall back to an empty list; we will still kill the parent below.
+            try {
+                process.destroy();
+            } catch (final Exception ex) {
+                // ignore
+            }
+            try {
+                process.destroyForcibly();
+            } catch (final Exception ex) {
+                // ignore
+            }
             return;
         }
         try {
@@ -361,33 +395,24 @@ public class CommandExtractor extends AbstractExtractor {
             // ignore
         }
         try {
-            if (!process.waitFor(destroyGracePeriodMillis, TimeUnit.MILLISECONDS)) {
-                try {
-                    process.descendants().forEach(ProcessHandle::destroyForcibly);
-                } catch (final Exception e) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Failed to forcibly destroy descendants.", e);
-                    }
-                }
-                try {
-                    process.destroyForcibly();
-                } catch (final Exception e) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Failed to forcibly destroy process.", e);
-                    }
-                }
-            }
+            process.waitFor(destroyGracePeriodMillis, TimeUnit.MILLISECONDS);
         } catch (final InterruptedException ie) {
             Thread.currentThread().interrupt();
+        }
+        // Forcibly kill parent and all snapshotted descendants regardless of whether the parent
+        // exited cleanly during the grace period.
+        for (final ProcessHandle h : descendantSnapshot) {
             try {
-                process.descendants().forEach(ProcessHandle::destroyForcibly);
+                h.destroyForcibly();
             } catch (final Exception e) {
                 // ignore
             }
-            try {
-                process.destroyForcibly();
-            } catch (final Exception e) {
-                // ignore
+        }
+        try {
+            process.destroyForcibly();
+        } catch (final Exception e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to forcibly destroy process.", e);
             }
         }
     }
@@ -525,12 +550,10 @@ public class CommandExtractor extends AbstractExtractor {
                 while ((n = is.read(buf)) != -1) {
                     total += n;
                     if (total > limit) {
-                        // Kill the process so the producer stops; otherwise we may keep getting bytes.
-                        try {
-                            process.destroyForcibly();
-                        } catch (final Exception e) {
-                            // ignore
-                        }
+                        // Throw immediately; the caller (executeCommand) is responsible for
+                        // killing the process tree via destroyProcessTree so that descendants
+                        // are also terminated (Fix 3: eager kill removed from here to avoid
+                        // racing with the snapshot-based destroyProcessTree in the caller).
                         throw new OutputSizeExceededException(
                                 "command output exceeded limit on " + streamName + ": limit=" + limit + " bytes");
                     }
@@ -561,6 +584,63 @@ public class CommandExtractor extends AbstractExtractor {
          */
         public OutputSizeExceededException(final String message) {
             super(message);
+        }
+    }
+
+    /**
+     * Copies bytes from an {@link InputStream} to a {@link File} up to {@code limit} bytes.
+     * When the limit is exceeded an {@link OutputSizeExceededException} is thrown so that the
+     * caller can invoke {@link CommandExtractor#destroyProcessTree(Process)} to terminate the
+     * subprocess and its descendants. The return value is always an empty string; the written
+     * content is in the output file.
+     */
+    protected static class BoundedFileWriter implements Callable<String> {
+        private final InputStream stream;
+        private final File outputFile;
+        private final long limit;
+        private final Process process;
+        private final String streamName;
+
+        /**
+         * Constructs a new BoundedFileWriter.
+         *
+         * @param stream the input stream to drain
+         * @param outputFile the file to write output to
+         * @param limit the maximum number of bytes accepted before the process is killed
+         * @param process the process whose stream is being drained (kept for API symmetry with BoundedStreamReader)
+         * @param streamName a label used in error messages and logs
+         */
+        public BoundedFileWriter(final InputStream stream, final File outputFile, final long limit, final Process process,
+                final String streamName) {
+            this.stream = stream;
+            this.outputFile = outputFile;
+            this.limit = limit;
+            this.process = process;
+            this.streamName = streamName;
+        }
+
+        @Override
+        public String call() throws IOException {
+            final byte[] buf = new byte[8192];
+            long total = 0L;
+            try (InputStream is = stream; BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(outputFile))) {
+                int n;
+                while ((n = is.read(buf)) != -1) {
+                    total += n;
+                    if (total > limit) {
+                        throw new OutputSizeExceededException(
+                                "command output exceeded limit on " + streamName + ": limit=" + limit + " bytes");
+                    }
+                    out.write(buf, 0, n);
+                }
+            } catch (final OutputSizeExceededException e) {
+                throw e;
+            } catch (final IOException ioe) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("stream read interrupted: stream={}", streamName, ioe);
+                }
+            }
+            return "";
         }
     }
 
@@ -713,15 +793,23 @@ public class CommandExtractor extends AbstractExtractor {
     /**
      * Sets the maximum number of output lines to buffer.
      *
+     * <p>This setter is deprecated; use {@link #setMaxOutputSize(long)} instead.
+     * For backward compatibility, calling this method conservatively shrinks
+     * {@link #maxOutputSize} to {@code max(64 KiB, n * 1024)} bytes (1 line ≈ 1 KiB),
+     * but only when {@link #setMaxOutputSize(long)} has <em>not</em> been called
+     * explicitly on this instance. When both setters are called, the explicit
+     * {@link #setMaxOutputSize(long)} value always wins regardless of call order.
+     *
      * @param maxOutputLine The maximum output lines to set.
-     * @deprecated The line-count cap has been removed; the byte-count cap supersedes
-     *             it. Use {@link #setMaxOutputSize(long)} to bound the number of bytes
-     *             read from stdout/stderr instead. Calls to this method are silently
-     *             retained for backward compatibility but no longer affect behavior.
+     * @deprecated Use {@link #setMaxOutputSize(long)} to set the byte-count bound directly.
      */
     @Deprecated
     public void setMaxOutputLine(final int maxOutputLine) {
         this.maxOutputLine = maxOutputLine;
+        final long inferred = Math.max(64L * 1024L, (long) maxOutputLine * 1024L);
+        if (!maxOutputSizeExplicit) {
+            this.maxOutputSize = Math.min(this.maxOutputSize, inferred);
+        }
     }
 
     /**
@@ -734,12 +822,24 @@ public class CommandExtractor extends AbstractExtractor {
 
     /**
      * Sets the maximum number of bytes the subprocess may write to a single stream
-     * (stdout or stderr) before the process is killed.
+     * (stdout or stderr) before the process is killed. Calling this method marks the
+     * size as explicitly set, preventing a subsequent {@link #setMaxOutputLine(int)}
+     * call from overriding it.
      *
      * @param maxOutputSize the limit in bytes
      */
     public void setMaxOutputSize(final long maxOutputSize) {
         this.maxOutputSize = maxOutputSize;
+        this.maxOutputSizeExplicit = true;
+    }
+
+    /**
+     * Returns the current maximum output size limit in bytes.
+     *
+     * @return the maximum number of bytes the subprocess may write to a single stream
+     */
+    public long getMaxOutputSize() {
+        return maxOutputSize;
     }
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
@@ -15,26 +15,33 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
-import java.io.BufferedReader;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.exception.InterruptedRuntimeException;
-import org.codelibs.core.io.CopyUtil;
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.core.lang.StringUtil;
-import org.codelibs.core.lang.ThreadUtil;
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
@@ -73,6 +80,15 @@ public class CommandExtractor extends AbstractExtractor {
 
     /** Whether to redirect standard output to a file. */
     protected boolean standardOutput = false;
+
+    /** Maximum bytes the subprocess is allowed to write to a single drained stream (stdout/stderr). */
+    protected long maxOutputSize = 10L * 1024L * 1024L; // 10 MiB
+
+    /** Maximum bytes copied from the input stream into the temporary input file. */
+    protected long maxInputSize = 100L * 1024L * 1024L; // 100 MiB
+
+    /** Grace period (ms) given to a process after destroy() before destroyForcibly() is invoked. */
+    protected long destroyGracePeriodMillis = 2000L;
 
     /**
      * Constructs a new CommandExtractor.
@@ -132,8 +148,8 @@ public class CommandExtractor extends AbstractExtractor {
             }
             outputFile = createTempFile("cmdextout_" + filePrefix + "_", ext, tempDir);
 
-            // store to a file
-            CopyUtil.copy(in, inputFile);
+            // store to a file (bounded by maxInputSize)
+            copyToFileBounded(in, inputFile, maxInputSize);
 
             executeCommand(inputFile, outputFile);
 
@@ -148,6 +164,32 @@ public class CommandExtractor extends AbstractExtractor {
         } finally {
             FileUtil.deleteInBackground(inputFile);
             FileUtil.deleteInBackground(outputFile);
+        }
+    }
+
+    /**
+     * Copies an input stream into the destination file but stops and throws if the
+     * number of bytes read exceeds {@code limit}.
+     *
+     * @param in the input stream to read from
+     * @param dest the destination file
+     * @param limit the maximum number of bytes allowed
+     * @throws IOException if an I/O error occurs
+     * @throws ExtractException if the input stream exceeds {@code limit}
+     */
+    protected void copyToFileBounded(final InputStream in, final File dest, final long limit) throws IOException {
+        long total = 0L;
+        final byte[] buffer = new byte[8192];
+        try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(dest))) {
+            int n;
+            while ((n = in.read(buffer)) != -1) {
+                total += n;
+                if (total > limit) {
+                    logger.warn("input size exceeded limit: limit={} command={}", limit, command);
+                    throw new ExtractException("input size exceeded limit: limit=" + limit);
+                }
+                out.write(buffer, 0, n);
+            }
         }
     }
 
@@ -181,27 +223,68 @@ public class CommandExtractor extends AbstractExtractor {
         }
         if (standardOutput) {
             pb.redirectOutput(outputFile);
-        } else {
-            pb.redirectErrorStream(true);
         }
+        // Note: do not redirect error stream when standardOutput=true; we want stderr drained separately.
+        // When standardOutput=false stdout is captured by us via getInputStream(); both streams must be drained.
 
         Process currentProcess = null;
-        MonitorThread mt = null;
+        ExecutorService streamPool = null;
+        Charset outCharset;
+        try {
+            outCharset = Charset.forName(commandOutputEncoding);
+        } catch (final Exception e) {
+            outCharset = StandardCharsets.UTF_8;
+        }
+
         try {
             currentProcess = pb.start();
 
-            // monitoring
-            mt = new MonitorThread(currentProcess, executionTimeout);
-            mt.start();
+            streamPool = Executors.newFixedThreadPool(2, new DaemonThreadFactory("CommandExtractor-stream"));
 
-            final InputStreamThread it = new InputStreamThread(currentProcess.getInputStream(), commandOutputEncoding, maxOutputLine);
-            it.start();
+            // Drain stdout (only if we are not redirecting it to a file).
+            final Process processRef = currentProcess;
+            final Charset charset = outCharset;
+            final long limit = maxOutputSize;
+            final Future<String> stdoutFuture;
+            if (standardOutput) {
+                // stdout is being written directly to outputFile by the JVM redirection; nothing to drain.
+                stdoutFuture = null;
+            } else {
+                stdoutFuture =
+                        streamPool.submit(new BoundedStreamReader(processRef.getInputStream(), charset, limit, processRef, "stdout"));
+            }
+            final Future<String> stderrFuture =
+                    streamPool.submit(new BoundedStreamReader(processRef.getErrorStream(), charset, limit, processRef, "stderr"));
 
-            currentProcess.waitFor();
-            it.join(5000);
-
-            if (mt.isTeminated()) {
+            final boolean finished = currentProcess.waitFor(executionTimeout, TimeUnit.MILLISECONDS);
+            if (!finished) {
+                logger.warn("command timed out: timeout={}ms command={}", executionTimeout, cmdList);
+                destroyProcessTree(currentProcess);
                 throw new ExecutionTimeoutException("The command execution is timeout: " + cmdList);
+            }
+
+            // Process exited; collect drained output. Use a short timeout to avoid waiting forever
+            // if the reader threads are stuck (they shouldn't be since the streams are now closed).
+            String stdoutText = "";
+            String stderrText = "";
+            try {
+                if (stdoutFuture != null) {
+                    stdoutText = stdoutFuture.get(5, TimeUnit.SECONDS);
+                }
+                stderrText = stderrFuture.get(5, TimeUnit.SECONDS);
+            } catch (final TimeoutException te) {
+                logger.warn("timed out collecting drained output: command={}", cmdList);
+            } catch (final ExecutionException ee) {
+                final Throwable cause = ee.getCause();
+                if (cause instanceof OutputSizeExceededException) {
+                    logger.warn("command output exceeded limit: limit={} command={}", maxOutputSize, cmdList);
+                    destroyProcessTree(currentProcess);
+                    throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize);
+                }
+                if (cause instanceof IOException) {
+                    throw new CrawlerSystemException("Failed to drain command output.", cause);
+                }
+                throw new CrawlerSystemException("Failed to drain command output.", ee);
             }
 
             final int exitValue = currentProcess.exitValue();
@@ -210,36 +293,87 @@ public class CommandExtractor extends AbstractExtractor {
                 if (standardOutput) {
                     logger.info("Exit Code: {}", exitValue);
                 } else {
-                    logger.info("Exit Code: {} - Process Output:\n{}", exitValue, it.getOutput());
+                    logger.info("Exit Code: {} - Process Output:\n{}", exitValue, truncateForLog(stdoutText));
                 }
-            }
-            if (exitValue == 143 && mt.isTeminated()) {
-                throw new ExecutionTimeoutException("The command execution is timeout: " + cmdList);
+                if (StringUtil.isNotEmpty(stderrText)) {
+                    logger.info("Process Stderr:\n{}", truncateForLog(stderrText));
+                }
             }
         } catch (final CrawlerSystemException e) {
             throw e;
         } catch (final InterruptedException e) {
-            if (mt != null && mt.isTeminated()) {
-                throw new ExecutionTimeoutException("The command execution is timeout: " + cmdList, e);
+            Thread.currentThread().interrupt();
+            if (currentProcess != null) {
+                destroyProcessTree(currentProcess);
             }
             throw new InterruptedRuntimeException(e);
         } catch (final Exception e) {
             throw new CrawlerSystemException("Process terminated.", e);
         } finally {
-            if (mt != null) {
-                mt.setFinished(true);
-                try {
-                    mt.interrupt();
-                } catch (final Exception e) {}
+            if (currentProcess != null && currentProcess.isAlive()) {
+                destroyProcessTree(currentProcess);
             }
-            if (currentProcess != null) {
-                try {
-                    currentProcess.destroy();
-                } catch (final Exception e) {}
+            if (streamPool != null) {
+                streamPool.shutdownNow();
             }
-            currentProcess = null;
-
         }
+    }
+
+    /**
+     * Sends SIGTERM, waits a grace period, then SIGKILL to the process and any descendants.
+     *
+     * @param process the process to terminate
+     */
+    protected void destroyProcessTree(final Process process) {
+        if (process == null) {
+            return;
+        }
+        try {
+            process.destroy();
+        } catch (final Exception e) {
+            // ignore
+        }
+        try {
+            if (!process.waitFor(destroyGracePeriodMillis, TimeUnit.MILLISECONDS)) {
+                try {
+                    process.descendants().forEach(ProcessHandle::destroyForcibly);
+                } catch (final Exception e) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Failed to forcibly destroy descendants.", e);
+                    }
+                }
+                try {
+                    process.destroyForcibly();
+                } catch (final Exception e) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Failed to forcibly destroy process.", e);
+                    }
+                }
+            }
+        } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            try {
+                process.descendants().forEach(ProcessHandle::destroyForcibly);
+            } catch (final Exception e) {
+                // ignore
+            }
+            try {
+                process.destroyForcibly();
+            } catch (final Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    private static String truncateForLog(final String s) {
+        if (s == null) {
+            return "";
+        }
+        final int max = 4000;
+        if (s.length() <= max) {
+            return s;
+        }
+        return s.substring(0, max) + "... [truncated]";
     }
 
     /**
@@ -301,119 +435,106 @@ public class CommandExtractor extends AbstractExtractor {
     }
 
     /**
-     * Thread to monitor and terminate processes that exceed the timeout.
+     * Daemon thread factory for stream-drain workers.
      */
-    protected static class MonitorThread extends Thread {
-        private final Process process;
-
-        private final long timeout;
-
-        private boolean finished = false;
-
-        private boolean teminated = false;
+    protected static class DaemonThreadFactory implements ThreadFactory {
+        private final String namePrefix;
+        private final AtomicInteger counter = new AtomicInteger();
 
         /**
-         * Constructs a new MonitorThread.
-         * @param process The process to monitor.
-         * @param timeout The timeout for the process.
+         * Constructs a new DaemonThreadFactory.
+         *
+         * @param namePrefix the prefix used to name threads created by this factory
          */
-        public MonitorThread(final Process process, final long timeout) {
-            this.process = process;
-            this.timeout = timeout;
+        public DaemonThreadFactory(final String namePrefix) {
+            this.namePrefix = namePrefix;
         }
 
         @Override
-        public void run() {
-            ThreadUtil.sleepQuietly(timeout);
-
-            if (!finished) {
-                try {
-                    process.destroy();
-                    teminated = true;
-                } catch (final Exception e) {
-                    if (logger.isInfoEnabled()) {
-                        logger.info("Could not kill the subprocess.", e);
-                    }
-                }
-            }
-        }
-
-        /**
-         * Sets the finished flag.
-         * @param finished The finished flag to set.
-         */
-        public void setFinished(final boolean finished) {
-            this.finished = finished;
-        }
-
-        /**
-         * Returns whether the process was terminated.
-         * @return true if terminated, false otherwise.
-         */
-        public boolean isTeminated() {
-            return teminated;
+        public Thread newThread(final Runnable r) {
+            final Thread t = new Thread(r, namePrefix + "-" + counter.incrementAndGet());
+            t.setDaemon(true);
+            return t;
         }
     }
 
     /**
-     * Thread to read and buffer output from an input stream.
+     * Reads a stream fully (up to {@code limit} bytes) and returns it as a String.
+     * If the stream produces more than {@code limit} bytes, the associated process is
+     * destroyed and an {@link OutputSizeExceededException} is thrown.
      */
-    protected static class InputStreamThread extends Thread {
-
-        private BufferedReader br;
-
-        private final List<String> list = new LinkedList<>();
-
-        private final int maxLineBuffer;
+    protected static class BoundedStreamReader implements Callable<String> {
+        private final InputStream stream;
+        private final Charset charset;
+        private final long limit;
+        private final Process process;
+        private final String streamName;
 
         /**
-         * Constructs a new InputStreamThread.
-         * @param is The InputStream to read from.
-         * @param charset The charset to use for reading.
-         * @param maxOutputLineBuffer The maximum number of lines to buffer.
+         * Constructs a new BoundedStreamReader.
+         *
+         * @param stream the input stream to drain
+         * @param charset the charset used to decode the bytes
+         * @param limit the maximum number of bytes accepted before the process is killed
+         * @param process the process whose stream is being drained (used to destroy on overflow)
+         * @param streamName a label used in error messages and logs
          */
-        public InputStreamThread(final InputStream is, final String charset, final int maxOutputLineBuffer) {
-            try {
-                br = new BufferedReader(new InputStreamReader(is, charset));
-            } catch (final UnsupportedEncodingException e) {
-                br = new BufferedReader(new InputStreamReader(is, Constants.UTF_8_CHARSET));
-            }
-            maxLineBuffer = maxOutputLineBuffer;
+        public BoundedStreamReader(final InputStream stream, final Charset charset, final long limit, final Process process,
+                final String streamName) {
+            this.stream = stream;
+            this.charset = charset;
+            this.limit = limit;
+            this.process = process;
+            this.streamName = streamName;
         }
 
         @Override
-        public void run() {
-            for (;;) {
-                try {
-                    final String line = br.readLine();
-                    if (line == null) {
-                        break;
+        public String call() throws IOException {
+            final byte[] buf = new byte[8192];
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            long total = 0L;
+            try (InputStream is = stream) {
+                int n;
+                while ((n = is.read(buf)) != -1) {
+                    total += n;
+                    if (total > limit) {
+                        // Kill the process so the producer stops; otherwise we may keep getting bytes.
+                        try {
+                            process.destroyForcibly();
+                        } catch (final Exception e) {
+                            // ignore
+                        }
+                        throw new OutputSizeExceededException(
+                                "command output exceeded limit on " + streamName + ": limit=" + limit + " bytes");
                     }
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(line);
-                    }
-                    list.add(line);
-                    if (list.size() > maxLineBuffer) {
-                        list.remove(0);
-                    }
-                } catch (final IOException e) {
-                    throw new CrawlerSystemException(e);
+                    baos.write(buf, 0, n);
+                }
+            } catch (final OutputSizeExceededException e) {
+                throw e;
+            } catch (final IOException ioe) {
+                // The pipe may be closed when the process is killed; treat as end-of-stream.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("stream read interrupted: stream={}", streamName, ioe);
                 }
             }
+            return new String(baos.toByteArray(), charset);
         }
+    }
+
+    /**
+     * Internal signal that the subprocess produced more output than allowed.
+     */
+    protected static class OutputSizeExceededException extends IOException {
+        private static final long serialVersionUID = 1L;
 
         /**
-         * Returns the output as a String.
-         * @return The output string.
+         * Constructs a new OutputSizeExceededException.
+         *
+         * @param message the detail message
          */
-        public String getOutput() {
-            final StringBuilder buf = new StringBuilder(100);
-            for (final String value : list) {
-                buf.append(value).append("\n");
-            }
-            return buf.toString();
+        public OutputSizeExceededException(final String message) {
+            super(message);
         }
-
     }
 
     /**
@@ -486,5 +607,36 @@ public class CommandExtractor extends AbstractExtractor {
      */
     public void setStandardOutput(final boolean standardOutput) {
         this.standardOutput = standardOutput;
+    }
+
+    /**
+     * Sets the maximum number of bytes the subprocess may write to a single stream
+     * (stdout or stderr) before the process is killed.
+     *
+     * @param maxOutputSize the limit in bytes
+     */
+    public void setMaxOutputSize(final long maxOutputSize) {
+        this.maxOutputSize = maxOutputSize;
+    }
+
+    /**
+     * Sets the maximum number of bytes copied from the input stream into the
+     * temporary input file. If the input exceeds this size an {@link ExtractException}
+     * is thrown before the command is invoked.
+     *
+     * @param maxInputSize the limit in bytes
+     */
+    public void setMaxInputSize(final long maxInputSize) {
+        this.maxInputSize = maxInputSize;
+    }
+
+    /**
+     * Sets the grace period in milliseconds between {@code Process.destroy()} (SIGTERM)
+     * and the fallback {@code Process.destroyForcibly()} (SIGKILL).
+     *
+     * @param destroyGracePeriodMillis the grace period
+     */
+    public void setDestroyGracePeriodMillis(final long destroyGracePeriodMillis) {
+        this.destroyGracePeriodMillis = destroyGracePeriodMillis;
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
@@ -75,7 +75,16 @@ public class CommandExtractor extends AbstractExtractor {
     /** The encoding for the command's output. */
     protected String commandOutputEncoding = Charset.defaultCharset().displayName();
 
-    /** The maximum number of lines to buffer from command output. */
+    /**
+     * The (formerly) maximum number of lines to buffer from command output.
+     *
+     * @deprecated The line-count cap has been removed in favor of a byte-count cap.
+     *             This field is no longer consulted; use {@link #setMaxOutputSize(long)}
+     *             to bound how many bytes are read from stdout/stderr. The field is
+     *             retained only for source/binary compatibility with callers that set
+     *             it via {@link #setMaxOutputLine(int)} or via reflection.
+     */
+    @Deprecated
     protected int maxOutputLine = 1000;
 
     /** Whether to redirect standard output to a file. */
@@ -89,6 +98,15 @@ public class CommandExtractor extends AbstractExtractor {
 
     /** Grace period (ms) given to a process after destroy() before destroyForcibly() is invoked. */
     protected long destroyGracePeriodMillis = 2000L;
+
+    /**
+     * Whether to append captured stderr text to the extracted content when
+     * {@link #standardOutput} is {@code false}. Defaults to {@code true} for
+     * backward compatibility with the legacy implementation that called
+     * {@code ProcessBuilder.redirectErrorStream(true)} and therefore included
+     * stderr in the extracted output.
+     */
+    protected boolean includeStderrInOutput = true;
 
     /**
      * Constructs a new CommandExtractor.
@@ -151,9 +169,17 @@ public class CommandExtractor extends AbstractExtractor {
             // store to a file (bounded by maxInputSize)
             copyToFileBounded(in, inputFile, maxInputSize);
 
-            executeCommand(inputFile, outputFile);
+            final String stderrText = executeCommand(inputFile, outputFile);
 
-            final ExtractData extractData = new ExtractData(new String(FileUtil.readBytes(outputFile), outputEncoding));
+            final StringBuilder contentBuf = new StringBuilder();
+            contentBuf.append(new String(FileUtil.readBytes(outputFile), outputEncoding));
+            // For backward compatibility with the legacy implementation that used
+            // ProcessBuilder.redirectErrorStream(true) when standardOutput=false,
+            // append captured stderr text to the extracted content.
+            if (!standardOutput && includeStderrInOutput && StringUtil.isNotEmpty(stderrText)) {
+                contentBuf.append(stderrText);
+            }
+            final ExtractData extractData = new ExtractData(contentBuf.toString());
             if (StringUtil.isNotBlank(resourceName)) {
                 extractData.putValues("resourceName", new String[] { resourceName });
             }
@@ -202,7 +228,7 @@ public class CommandExtractor extends AbstractExtractor {
         return name;
     }
 
-    private void executeCommand(final File inputFile, final File outputFile) {
+    private String executeCommand(final File inputFile, final File outputFile) {
 
         if (StringUtil.isBlank(command)) {
             throw new CrawlerSystemException("External command is empty. Please configure a valid command for CommandExtractor.");
@@ -299,6 +325,7 @@ public class CommandExtractor extends AbstractExtractor {
                     logger.info("Process Stderr:\n{}", truncateForLog(stderrText));
                 }
             }
+            return stderrText;
         } catch (final CrawlerSystemException e) {
             throw e;
         } catch (final InterruptedException e) {
@@ -538,6 +565,96 @@ public class CommandExtractor extends AbstractExtractor {
     }
 
     /**
+     * Legacy thread that used to monitor and terminate processes exceeding the
+     * timeout.
+     *
+     * @deprecated The timeout/kill machinery is now handled inline by
+     *             {@link CommandExtractor#executeCommand(File, File)} using
+     *             {@link Process#waitFor(long, TimeUnit)} and
+     *             {@link CommandExtractor#destroyProcessTree(Process)}. This class is
+     *             unused internally and is retained only as an empty stub so that
+     *             existing third-party subclasses or callers that referenced
+     *             {@code CommandExtractor.MonitorThread} continue to compile and
+     *             link. New code should not extend or instantiate it.
+     */
+    @Deprecated
+    protected static class MonitorThread extends Thread {
+
+        /**
+         * Constructs a new MonitorThread.
+         *
+         * @param process the process to monitor (ignored; retained for source compat)
+         * @param timeout the timeout (ignored; retained for source compat)
+         */
+        public MonitorThread(final Process process, final long timeout) {
+            // NOP - retained only for source compatibility.
+        }
+
+        @Override
+        public void run() {
+            // NOP
+        }
+
+        /**
+         * Sets the finished flag.
+         *
+         * @param finished the finished flag (ignored)
+         */
+        public void setFinished(final boolean finished) {
+            // NOP - retained only for source compatibility.
+        }
+
+        /**
+         * Returns whether the process was terminated.
+         *
+         * @return always {@code false}; this stub never terminates anything.
+         */
+        public boolean isTeminated() {
+            return false;
+        }
+    }
+
+    /**
+     * Legacy thread that used to read and buffer output from an input stream.
+     *
+     * @deprecated Stream draining is now performed by
+     *             {@link CommandExtractor.BoundedStreamReader} which is byte-bounded
+     *             rather than line-bounded. This class is unused internally and is
+     *             retained only as an empty stub so that existing third-party
+     *             subclasses or callers that referenced
+     *             {@code CommandExtractor.InputStreamThread} continue to compile and
+     *             link. New code should not extend or instantiate it.
+     */
+    @Deprecated
+    protected static class InputStreamThread extends Thread {
+
+        /**
+         * Constructs a new InputStreamThread.
+         *
+         * @param is the input stream (ignored; retained for source compat)
+         * @param charset the charset (ignored; retained for source compat)
+         * @param maxOutputLineBuffer the line buffer size (ignored; retained for source compat)
+         */
+        public InputStreamThread(final InputStream is, final String charset, final int maxOutputLineBuffer) {
+            // NOP - retained only for source compatibility.
+        }
+
+        @Override
+        public void run() {
+            // NOP
+        }
+
+        /**
+         * Returns the buffered output as a String.
+         *
+         * @return always an empty string; this stub never reads anything.
+         */
+        public String getOutput() {
+            return "";
+        }
+    }
+
+    /**
      * Sets the encoding for the output.
      * @param outputEncoding The output encoding to set.
      */
@@ -594,9 +711,15 @@ public class CommandExtractor extends AbstractExtractor {
     }
 
     /**
-     * Sets the maximum number of output lines to process.
+     * Sets the maximum number of output lines to buffer.
+     *
      * @param maxOutputLine The maximum output lines to set.
+     * @deprecated The line-count cap has been removed; the byte-count cap supersedes
+     *             it. Use {@link #setMaxOutputSize(long)} to bound the number of bytes
+     *             read from stdout/stderr instead. Calls to this method are silently
+     *             retained for backward compatibility but no longer affect behavior.
      */
+    @Deprecated
     public void setMaxOutputLine(final int maxOutputLine) {
         this.maxOutputLine = maxOutputLine;
     }
@@ -638,5 +761,19 @@ public class CommandExtractor extends AbstractExtractor {
      */
     public void setDestroyGracePeriodMillis(final long destroyGracePeriodMillis) {
         this.destroyGracePeriodMillis = destroyGracePeriodMillis;
+    }
+
+    /**
+     * Sets whether captured stderr text should be appended to the extracted content
+     * when {@link #standardOutput} is {@code false}. Defaults to {@code true} for
+     * backward compatibility with the legacy implementation that called
+     * {@code ProcessBuilder.redirectErrorStream(true)} and therefore included stderr
+     * in the extracted output.
+     *
+     * @param includeStderrInOutput {@code true} to append stderr to the extracted
+     *                              content; {@code false} to keep the file content only
+     */
+    public void setIncludeStderrInOutput(final boolean includeStderrInOutput) {
+        this.includeStderrInOutput = includeStderrInOutput;
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -105,12 +106,16 @@ public class CommandExtractor extends AbstractExtractor {
 
     /**
      * Whether to append captured stderr text to the extracted content when
-     * {@link #standardOutput} is {@code false}. Defaults to {@code true} for
-     * backward compatibility with the legacy implementation that called
-     * {@code ProcessBuilder.redirectErrorStream(true)} and therefore included
-     * stderr in the extracted output.
+     * {@link #standardOutput} is {@code false}. Defaults to {@code false} to
+     * match pre-3.x behavior where stderr was only routed to logs, never to
+     * extracted text. (The original {@code ProcessBuilder.redirectErrorStream(true)}
+     * call only merged the streams for log draining; it never caused stderr to
+     * appear in {@code ExtractData}.)
+     *
+     * <p>Set to {@code true} to append captured stderr after the file content in
+     * the extracted body when {@code standardOutput=false}.
      */
-    protected boolean includeStderrInOutput = true;
+    protected boolean includeStderrInOutput = false;
 
     /**
      * Constructs a new CommandExtractor.
@@ -279,23 +284,60 @@ public class CommandExtractor extends AbstractExtractor {
             final Process processRef = currentProcess;
             final Charset charset = outCharset;
             final long limit = maxOutputSize;
+            final AtomicBoolean overflowFlag = new AtomicBoolean(false);
             final Future<String> stdoutFuture;
             if (standardOutput) {
                 // Drain stdout into outputFile with a byte-count bound to honour maxOutputSize.
                 stdoutFuture =
                         streamPool.submit(new BoundedFileWriter(processRef.getInputStream(), outputFile, limit, processRef, "stdout"));
             } else {
-                stdoutFuture =
-                        streamPool.submit(new BoundedStreamReader(processRef.getInputStream(), charset, limit, processRef, "stdout"));
+                stdoutFuture = streamPool
+                        .submit(new BoundedStreamReader(processRef.getInputStream(), charset, limit, processRef, "stdout", overflowFlag));
             }
-            final Future<String> stderrFuture =
-                    streamPool.submit(new BoundedStreamReader(processRef.getErrorStream(), charset, limit, processRef, "stderr"));
+            final Future<String> stderrFuture = streamPool
+                    .submit(new BoundedStreamReader(processRef.getErrorStream(), charset, limit, processRef, "stderr", overflowFlag));
 
-            final boolean finished = currentProcess.waitFor(executionTimeout, TimeUnit.MILLISECONDS);
-            if (!finished) {
-                logger.warn("command timed out: timeout={}ms command={}", executionTimeout, cmdList);
-                destroyProcessTree(currentProcess);
-                throw new ExecutionTimeoutException("The command execution is timeout: " + cmdList);
+            // Poll for process exit so that an overflow detected by a reader thread can
+            // break out immediately rather than blocking for the full executionTimeout.
+            final long deadline = System.currentTimeMillis() + executionTimeout;
+            boolean exited = false;
+            while (System.currentTimeMillis() < deadline) {
+                if (overflowFlag.get()) {
+                    // Reader thread detected overflow; kill the process tree immediately.
+                    break;
+                }
+                if (currentProcess.waitFor(200, TimeUnit.MILLISECONDS)) {
+                    exited = true;
+                    break;
+                }
+            }
+
+            if (!exited) {
+                if (overflowFlag.get()) {
+                    // Overflow path: kill the process tree, then surface the reader's exception.
+                    destroyProcessTree(currentProcess);
+                    // Collect exceptions from both futures with a short timeout.
+                    for (final Future<String> f : new Future[] { stdoutFuture, stderrFuture }) {
+                        try {
+                            f.get(2, TimeUnit.SECONDS);
+                        } catch (final ExecutionException ee) {
+                            final Throwable cause = ee.getCause();
+                            if (cause instanceof OutputSizeExceededException) {
+                                logger.warn("command output exceeded limit: limit={} command={}", maxOutputSize, cmdList);
+                                throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize);
+                            }
+                        } catch (final TimeoutException | InterruptedException ignore) {
+                            // ignore — we already set the overflow flag
+                        }
+                    }
+                    // Should not reach here, but guard just in case.
+                    throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize);
+                } else {
+                    // Timeout path.
+                    logger.warn("command timed out: timeout={}ms command={}", executionTimeout, cmdList);
+                    destroyProcessTree(currentProcess);
+                    throw new ExecutionTimeoutException("The command execution is timeout: " + cmdList);
+                }
             }
 
             // Process exited; collect drained output. Use a short timeout to avoid waiting forever
@@ -512,8 +554,10 @@ public class CommandExtractor extends AbstractExtractor {
 
     /**
      * Reads a stream fully (up to {@code limit} bytes) and returns it as a String.
-     * If the stream produces more than {@code limit} bytes, the associated process is
-     * destroyed and an {@link OutputSizeExceededException} is thrown.
+     * If the stream produces more than {@code limit} bytes, {@code overflowFlag} is
+     * set to {@code true} and an {@link OutputSizeExceededException} is thrown so
+     * that the main thread can detect the overflow without waiting for the full
+     * {@code executionTimeout}.
      */
     protected static class BoundedStreamReader implements Callable<String> {
         private final InputStream stream;
@@ -521,6 +565,7 @@ public class CommandExtractor extends AbstractExtractor {
         private final long limit;
         private final Process process;
         private final String streamName;
+        private final AtomicBoolean overflowFlag;
 
         /**
          * Constructs a new BoundedStreamReader.
@@ -530,14 +575,18 @@ public class CommandExtractor extends AbstractExtractor {
          * @param limit the maximum number of bytes accepted before the process is killed
          * @param process the process whose stream is being drained (used to destroy on overflow)
          * @param streamName a label used in error messages and logs
+         * @param overflowFlag shared flag that is set to {@code true} just before
+         *                     {@link OutputSizeExceededException} is thrown, allowing the main
+         *                     thread's polling loop to break early and kill the process tree
          */
         public BoundedStreamReader(final InputStream stream, final Charset charset, final long limit, final Process process,
-                final String streamName) {
+                final String streamName, final AtomicBoolean overflowFlag) {
             this.stream = stream;
             this.charset = charset;
             this.limit = limit;
             this.process = process;
             this.streamName = streamName;
+            this.overflowFlag = overflowFlag;
         }
 
         @Override
@@ -550,10 +599,10 @@ public class CommandExtractor extends AbstractExtractor {
                 while ((n = is.read(buf)) != -1) {
                     total += n;
                     if (total > limit) {
-                        // Throw immediately; the caller (executeCommand) is responsible for
-                        // killing the process tree via destroyProcessTree so that descendants
-                        // are also terminated (Fix 3: eager kill removed from here to avoid
-                        // racing with the snapshot-based destroyProcessTree in the caller).
+                        // Signal the main thread's polling loop before throwing so it can
+                        // break immediately and kill the process tree rather than blocking
+                        // for the remainder of executionTimeout.
+                        overflowFlag.set(true);
                         throw new OutputSizeExceededException(
                                 "command output exceeded limit on " + streamName + ": limit=" + limit + " bytes");
                     }
@@ -865,10 +914,12 @@ public class CommandExtractor extends AbstractExtractor {
 
     /**
      * Sets whether captured stderr text should be appended to the extracted content
-     * when {@link #standardOutput} is {@code false}. Defaults to {@code true} for
-     * backward compatibility with the legacy implementation that called
-     * {@code ProcessBuilder.redirectErrorStream(true)} and therefore included stderr
-     * in the extracted output.
+     * when {@link #standardOutput} is {@code false}. Defaults to {@code false} to
+     * match pre-3.x behavior where stderr was only logged, never included in
+     * {@code ExtractData}.
+     *
+     * <p>When set to {@code true} and {@code standardOutput=false}, captured stderr
+     * text is appended after the file content in the extracted body.
      *
      * @param includeStderrInOutput {@code true} to append stderr to the extracted
      *                              content; {@code false} to keep the file content only

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractor.java
@@ -51,6 +51,10 @@ import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.ExecutionTimeoutException;
 import org.codelibs.fess.crawler.exception.ExtractException;
+import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
+import org.codelibs.fess.crawler.helper.ContentLengthHelper;
+
+import jakarta.annotation.Resource;
 
 /**
  * Extracts text content by executing an external command.
@@ -83,10 +87,10 @@ public class CommandExtractor extends AbstractExtractor {
      * The (formerly) maximum number of lines to buffer from command output.
      *
      * @deprecated The line-count cap has been removed in favor of a byte-count cap.
-     *             This field is no longer consulted; use {@link #setMaxOutputSize(long)}
-     *             to bound how many bytes are read from stdout/stderr. The field is
-     *             retained only for source/binary compatibility with callers that set
-     *             it via {@link #setMaxOutputLine(int)} or via reflection.
+     *             This field is no longer consulted; the extracted content is bounded by
+     *             {@link ContentLengthHelper} (or {@link #maxContentLength} when no helper is
+     *             available). The field is retained only for source/binary compatibility with
+     *             callers that set it via {@link #setMaxOutputLine(int)} or via reflection.
      */
     @Deprecated
     protected int maxOutputLine = 1000;
@@ -94,11 +98,30 @@ public class CommandExtractor extends AbstractExtractor {
     /** Whether to redirect standard output to a file. */
     protected boolean standardOutput = false;
 
-    /** Maximum bytes the subprocess is allowed to write to a single drained stream (stdout/stderr). */
-    protected long maxOutputSize = 10L * 1024L * 1024L; // 10 MiB
+    /**
+     * Helper that provides the maximum content length (optionally per MIME type) used to bound the
+     * extracted text. Injected by the DI container when {@code CommandExtractor} is registered as a
+     * component; may be {@code null} when the extractor is constructed ad-hoc, in which case
+     * {@link #maxContentLength} is used as the fallback limit.
+     */
+    @Resource
+    protected ContentLengthHelper contentLengthHelper;
 
-    /** Whether {@link #setMaxOutputSize(long)} has been called explicitly, preventing {@link #setMaxOutputLine(int)} from overriding it. */
-    private boolean maxOutputSizeExplicit = false;
+    /**
+     * Fallback maximum bytes of extracted content (the command output) accepted when
+     * {@link #contentLengthHelper} is not available. When the helper is present it takes precedence.
+     * Output larger than this limit is rejected with {@link MaxLengthExceededException} so oversized
+     * documents are skipped instead of consuming unbounded heap/disk.
+     */
+    protected long maxContentLength = 10L * 1024L * 1024L; // 10 MiB
+
+    /**
+     * Maximum bytes retained in memory from a diagnostic stream (stdout/stderr used only for logging)
+     * before further bytes are drained and discarded. The stream is always drained to completion to
+     * avoid blocking the subprocess on a full pipe buffer; only the retained prefix is used for logs
+     * (and, when {@link #includeStderrInOutput} is enabled, appended to the content).
+     */
+    protected int maxDiagnosticRetainSize = 64 * 1024; // 64 KiB
 
     /** Maximum bytes copied from the input stream into the temporary input file. */
     protected long maxInputSize = 100L * 1024L * 1024L; // 100 MiB
@@ -189,25 +212,39 @@ public class CommandExtractor extends AbstractExtractor {
             }
             outputFile = createTempFile("cmdextout_" + filePrefix + "_", ext, tempDir);
 
+            // Resolve the maximum size accepted for the extracted content. Prefer the DI-managed
+            // ContentLengthHelper (optionally per MIME type); fall back to maxContentLength when the
+            // helper is not available (e.g. ad-hoc construction).
+            final long maxContentLen = resolveMaxContentLength(params);
+
             // store to a file (bounded by maxInputSize)
             copyToFileBounded(in, inputFile, maxInputSize);
 
-            final String stderrText = executeCommand(inputFile, outputFile);
+            final String stderrText = executeCommand(inputFile, outputFile, maxContentLen);
 
             // For standardOutput=false this is the only guard against the external command writing
-            // an unbounded $OUTPUT_FILE — bounded readers cover stdout/stderr only.
-            if (outputFile.length() > maxOutputSize) {
-                logger.warn("output file size exceeded limit: size={} limit={} command={}", outputFile.length(), maxOutputSize, command);
-                throw new ExtractException("output file size exceeded limit: limit=" + maxOutputSize);
+            // an unbounded $OUTPUT_FILE — the diagnostic stdout/stderr readers no longer bound content.
+            if (outputFile.length() > maxContentLen) {
+                logger.warn("output content exceeded limit: size={} limit={} command={}", outputFile.length(), maxContentLen, command);
+                throw new MaxLengthExceededException("output content exceeded limit: limit=" + maxContentLen);
             }
 
             final StringBuilder contentBuf = new StringBuilder();
             contentBuf.append(new String(FileUtil.readBytes(outputFile), outputEncoding));
             // For backward compatibility with the legacy implementation that used
-            // ProcessBuilder.redirectErrorStream(true) when standardOutput=false,
-            // append captured stderr text to the extracted content.
+            // ProcessBuilder.redirectErrorStream(true) when standardOutput=false, append captured
+            // stderr text to the extracted content — but keep the combined content within the content
+            // limit. stderr is diagnostic, so truncate the appended portion rather than failing.
             if (!standardOutput && includeStderrInOutput && StringUtil.isNotEmpty(stderrText)) {
-                contentBuf.append(stderrText);
+                final long remaining = maxContentLen - outputFile.length();
+                if (remaining > 0) {
+                    final byte[] stderrBytes = stderrText.getBytes(outputEncoding);
+                    if (stderrBytes.length <= remaining) {
+                        contentBuf.append(stderrText);
+                    } else {
+                        contentBuf.append(new String(stderrBytes, 0, (int) remaining, outputEncoding));
+                    }
+                }
             }
             final ExtractData extractData = new ExtractData(contentBuf.toString());
             if (StringUtil.isNotBlank(resourceName)) {
@@ -224,6 +261,24 @@ public class CommandExtractor extends AbstractExtractor {
     }
 
     /**
+     * Resolves the maximum number of bytes accepted for the extracted content. When a
+     * {@link ContentLengthHelper} is available it is consulted (using the {@code Content-Type} from
+     * {@code params} when present, otherwise the helper's default); otherwise {@link #maxContentLength}
+     * is used as the fallback limit.
+     *
+     * @param params the extraction parameters (may be {@code null}); an optional
+     *               {@link ExtractData#CONTENT_TYPE} entry is used to look up a per-MIME limit
+     * @return the maximum number of content bytes allowed
+     */
+    protected long resolveMaxContentLength(final Map<String, String> params) {
+        if (contentLengthHelper != null) {
+            final String mimeType = params == null ? null : params.get(ExtractData.CONTENT_TYPE);
+            return contentLengthHelper.getMaxLength(mimeType);
+        }
+        return maxContentLength;
+    }
+
+    /**
      * Copies an input stream into the destination file but stops and throws if the
      * number of bytes read exceeds {@code limit}.
      *
@@ -231,7 +286,7 @@ public class CommandExtractor extends AbstractExtractor {
      * @param dest the destination file
      * @param limit the maximum number of bytes allowed
      * @throws IOException if an I/O error occurs
-     * @throws ExtractException if the input stream exceeds {@code limit}
+     * @throws MaxLengthExceededException if the input stream exceeds {@code limit}
      */
     protected void copyToFileBounded(final InputStream in, final File dest, final long limit) throws IOException {
         long total = 0L;
@@ -242,7 +297,7 @@ public class CommandExtractor extends AbstractExtractor {
                 total += n;
                 if (total > limit) {
                     logger.warn("input size exceeded limit: limit={} command={}", limit, command);
-                    throw new ExtractException("input size exceeded limit: limit=" + limit);
+                    throw new MaxLengthExceededException("input size exceeded limit: limit=" + limit);
                 }
                 out.write(buffer, 0, n);
             }
@@ -258,7 +313,7 @@ public class CommandExtractor extends AbstractExtractor {
         return name;
     }
 
-    private String executeCommand(final File inputFile, final File outputFile) {
+    private String executeCommand(final File inputFile, final File outputFile, final long maxContentLen) {
 
         if (StringUtil.isBlank(command)) {
             throw new CrawlerSystemException("External command is empty. Please configure a valid command for CommandExtractor.");
@@ -278,8 +333,8 @@ public class CommandExtractor extends AbstractExtractor {
             pb.directory(workingDirectory);
         }
         // Do not use pb.redirectOutput(outputFile) for standardOutput=true: OS-level redirection
-        // bypasses the BoundedStreamReader, allowing unbounded writes. Instead, pipe stdout through
-        // a BoundedFileWriter that enforces maxOutputSize.
+        // bypasses the BoundedFileWriter, allowing unbounded writes. Instead, pipe stdout through
+        // a BoundedFileWriter that enforces the content-length limit.
 
         // Note: do not redirect error stream; we want stderr drained separately always.
 
@@ -301,19 +356,22 @@ public class CommandExtractor extends AbstractExtractor {
 
             final Process processRef = currentProcess;
             final Charset charset = outCharset;
-            final long limit = maxOutputSize;
             final AtomicBoolean overflowFlag = new AtomicBoolean(false);
             final Future<String> stdoutFuture;
             if (standardOutput) {
-                // Drain stdout into outputFile with a byte-count bound to honour maxOutputSize.
-                stdoutFuture = streamPool.submit(
-                        new BoundedFileWriter(processRef.getInputStream(), outputFile, limit, "stdout", overflowFlag, shuttingDown));
+                // stdout IS the extracted content: bound it by the content-length limit and kill the
+                // process tree on overflow (oversized document -> MaxLengthExceededException).
+                stdoutFuture = streamPool.submit(new BoundedFileWriter(processRef.getInputStream(), outputFile, maxContentLen, "stdout",
+                        overflowFlag, shuttingDown));
             } else {
-                stdoutFuture = streamPool
-                        .submit(new BoundedStreamReader(processRef.getInputStream(), charset, limit, "stdout", overflowFlag, shuttingDown));
+                // stdout is diagnostic only (content comes from $OUTPUT_FILE): cap-and-discard so a
+                // verbose command is not killed; the stream is still fully drained to avoid pipe block.
+                stdoutFuture = streamPool.submit(
+                        new BoundedStreamReader(processRef.getInputStream(), charset, maxDiagnosticRetainSize, "stdout", shuttingDown));
             }
+            // stderr is always diagnostic: cap-and-discard, never kills the process.
             final Future<String> stderrFuture = streamPool
-                    .submit(new BoundedStreamReader(processRef.getErrorStream(), charset, limit, "stderr", overflowFlag, shuttingDown));
+                    .submit(new BoundedStreamReader(processRef.getErrorStream(), charset, maxDiagnosticRetainSize, "stderr", shuttingDown));
 
             // Poll for process exit so that an overflow detected by a reader thread can
             // break out immediately rather than blocking for the full executionTimeout.
@@ -342,20 +400,20 @@ public class CommandExtractor extends AbstractExtractor {
                         } catch (final ExecutionException ee) {
                             final Throwable cause = ee.getCause();
                             if (cause instanceof OutputSizeExceededException) {
-                                logger.warn("command output exceeded limit: limit={} command={}", maxOutputSize, cmdList);
-                                throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize, cause);
+                                logger.warn("command output exceeded content limit: limit={} command={}", maxContentLen, cmdList);
+                                throw new MaxLengthExceededException("command output exceeded content limit: limit=" + maxContentLen);
                             }
                             logger.warn("unexpected error draining stream during overflow handling: command={}", cmdList, cause);
                             throw new CrawlerSystemException("Failed to drain command output during overflow.", cause);
                         } catch (final TimeoutException te) {
-                            // overflow already detected; surface the ExtractException below
+                            // overflow already detected; surface the exception below
                         } catch (final InterruptedException ie) {
                             Thread.currentThread().interrupt();
                             break;
                         }
                     }
                     // guard: overflow flag set but no overflow exception observed
-                    throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize);
+                    throw new MaxLengthExceededException("command output exceeded content limit: limit=" + maxContentLen);
                 } else {
                     // Timeout path.
                     logger.warn("command timed out: timeout={}ms command={}", executionTimeout, cmdList);
@@ -381,10 +439,10 @@ public class CommandExtractor extends AbstractExtractor {
             } catch (final ExecutionException ee) {
                 final Throwable cause = ee.getCause();
                 if (cause instanceof OutputSizeExceededException) {
-                    logger.warn("command output exceeded limit: limit={} command={}", maxOutputSize, cmdList);
+                    logger.warn("command output exceeded content limit: limit={} command={}", maxContentLen, cmdList);
                     shuttingDown.set(true);
                     destroyProcessTree(currentProcess);
-                    throw new ExtractException("command output exceeded limit: limit=" + maxOutputSize, cause);
+                    throw new MaxLengthExceededException("command output exceeded content limit: limit=" + maxContentLen);
                 }
                 if (cause instanceof IOException) {
                     throw new CrawlerSystemException("Failed to drain command output.", cause);
@@ -634,18 +692,17 @@ public class CommandExtractor extends AbstractExtractor {
     }
 
     /**
-     * Reads a stream fully (up to {@code limit} bytes) and returns it as a String.
-     * If the stream produces more than {@code limit} bytes, {@code overflowFlag} is
-     * set to {@code true} and an {@link OutputSizeExceededException} is thrown so
-     * that the main thread can detect the overflow without waiting for the full
-     * {@code executionTimeout}.
+     * Drains a diagnostic stream (stdout or stderr) to completion so the subprocess cannot block on a
+     * full pipe buffer, retaining at most {@code retainLimit} bytes in memory. Bytes beyond the retain
+     * limit are read and discarded (cap-and-discard) — this reader never throws on overflow and never
+     * kills the process; the retained prefix is returned for logging and, optionally, for inclusion in
+     * the extracted content.
      */
     protected static class BoundedStreamReader implements Callable<String> {
         private final InputStream stream;
         private final Charset charset;
-        private final long limit;
+        private final int retainLimit;
         private final String streamName;
-        private final AtomicBoolean overflowFlag;
         private final AtomicBoolean shuttingDown;
 
         /**
@@ -653,22 +710,19 @@ public class CommandExtractor extends AbstractExtractor {
          *
          * @param stream the input stream to drain
          * @param charset the charset used to decode the bytes
-         * @param limit the maximum number of bytes accepted before the process is killed
+         * @param retainLimit the maximum number of bytes retained in memory; further bytes are drained
+         *                    and discarded rather than buffered
          * @param streamName a label used in error messages and logs
-         * @param overflowFlag shared flag that is set to {@code true} just before
-         *                     {@link OutputSizeExceededException} is thrown, allowing the main
-         *                     thread's polling loop to break early and kill the process tree
          * @param shuttingDown shared flag indicating the main thread is in the process of killing
          *                     the subprocess; IOExceptions observed while this flag is set are
          *                     logged at debug level rather than surfaced as ExecutionExceptions
          */
-        public BoundedStreamReader(final InputStream stream, final Charset charset, final long limit, final String streamName,
-                final AtomicBoolean overflowFlag, final AtomicBoolean shuttingDown) {
+        public BoundedStreamReader(final InputStream stream, final Charset charset, final int retainLimit, final String streamName,
+                final AtomicBoolean shuttingDown) {
             this.stream = stream;
             this.charset = charset;
-            this.limit = limit;
+            this.retainLimit = retainLimit;
             this.streamName = streamName;
-            this.overflowFlag = overflowFlag;
             this.shuttingDown = shuttingDown;
         }
 
@@ -677,31 +731,36 @@ public class CommandExtractor extends AbstractExtractor {
             final byte[] buf = new byte[8192];
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             long total = 0L;
+            boolean truncated = false;
             try (InputStream is = stream) {
                 int n;
                 while ((n = is.read(buf)) != -1) {
                     total += n;
-                    if (total > limit) {
-                        // Signal the main thread's polling loop before throwing so it can
-                        // break immediately and kill the process tree rather than blocking
-                        // for the remainder of executionTimeout.
-                        overflowFlag.set(true);
-                        throw new OutputSizeExceededException(
-                                "command output exceeded limit on " + streamName + ": limit=" + limit + " bytes");
+                    final int room = retainLimit - baos.size();
+                    if (room > 0) {
+                        final int toRetain = Math.min(n, room);
+                        baos.write(buf, 0, toRetain);
+                        if (toRetain < n) {
+                            truncated = true;
+                        }
+                    } else {
+                        // Retain limit reached: keep reading to drain the pipe but discard the bytes.
+                        truncated = true;
                     }
-                    baos.write(buf, 0, n);
                 }
-            } catch (final OutputSizeExceededException e) {
-                throw e;
             } catch (final IOException ioe) {
+                // Diagnostic streams must never be fatal: log and return whatever was retained so far.
                 if (shuttingDown.get()) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("stream closed during shutdown: stream={}", streamName, ioe);
                     }
                 } else {
-                    logger.warn("unexpected I/O error on stream: stream={} drainedBytes={}", streamName, total, ioe);
-                    throw ioe;
+                    logger.warn("I/O error draining diagnostic stream (ignored): stream={} drainedBytes={}", streamName, total, ioe);
                 }
+            }
+            if (truncated && logger.isDebugEnabled()) {
+                logger.debug("diagnostic stream truncated for retention: stream={} totalBytes={} retained={}", streamName, total,
+                        retainLimit);
             }
             return new String(baos.toByteArray(), charset);
         }
@@ -797,8 +856,7 @@ public class CommandExtractor extends AbstractExtractor {
      * Legacy thread that used to monitor and terminate processes exceeding the
      * timeout.
      *
-     * @deprecated The timeout/kill machinery is now handled inline by
-     *             {@link CommandExtractor#executeCommand(File, File)} using
+     * @deprecated The timeout/kill machinery is now handled inline by the extractor using
      *             {@link Process#waitFor(long, TimeUnit)} and
      *             {@link CommandExtractor#destroyProcessTree(Process)}. This class is
      *             unused internally and is retained only as an empty stub so that
@@ -967,25 +1025,19 @@ public class CommandExtractor extends AbstractExtractor {
     }
 
     /**
-     * Sets the maximum number of output lines to buffer.
+     * Sets the (deprecated) maximum number of output lines.
      *
-     * <p>This setter is deprecated; use {@link #setMaxOutputSize(long)} instead.
-     * For backward compatibility, calling this method conservatively shrinks
-     * {@link #maxOutputSize} to {@code max(64 KiB, n * 1024)} bytes (1 line ≈ 1 KiB),
-     * but only when {@link #setMaxOutputSize(long)} has <em>not</em> been called
-     * explicitly on this instance. When both setters are called, the explicit
-     * {@link #setMaxOutputSize(long)} value always wins regardless of call order.
+     * <p>The line-count cap has been removed; the extracted content is now bounded by
+     * {@link ContentLengthHelper} (or {@link #maxContentLength} when no helper is available). This
+     * setter only stores the value for source/binary compatibility and has no effect on bounding.
      *
-     * @param maxOutputLine The maximum output lines to set.
-     * @deprecated Use {@link #setMaxOutputSize(long)} to set the byte-count bound directly.
+     * @param maxOutputLine The maximum output lines to set (retained for compatibility only).
+     * @deprecated Configure the byte-count bound via {@link ContentLengthHelper} or
+     *             {@link #setMaxContentLength(long)} instead.
      */
     @Deprecated
     public void setMaxOutputLine(final int maxOutputLine) {
         this.maxOutputLine = maxOutputLine;
-        final long inferred = Math.max(64L * 1024L, (long) maxOutputLine * 1024L);
-        if (!maxOutputSizeExplicit) {
-            this.maxOutputSize = Math.min(this.maxOutputSize, inferred);
-        }
     }
 
     /**
@@ -997,36 +1049,58 @@ public class CommandExtractor extends AbstractExtractor {
     }
 
     /**
-     * Sets the maximum number of bytes the subprocess may write to a single stream
-     * (stdout or stderr) before the process is killed. Calling this method marks the
-     * size as explicitly set, preventing a subsequent {@link #setMaxOutputLine(int)}
-     * call from overriding it.
+     * Sets the {@link ContentLengthHelper} used to bound the size of the extracted content. When set,
+     * it takes precedence over {@link #setMaxContentLength(long)}. This is normally injected by the DI
+     * container; the setter is provided for ad-hoc construction and tests.
      *
-     * <p>Note: the entire output may be loaded into memory during extraction
-     * (transient 2–4× heap usage). Values above 512 MiB log a warning.
-     *
-     * @param maxOutputSize the limit in bytes
+     * @param contentLengthHelper the helper providing content-length limits (may be {@code null})
      */
-    public void setMaxOutputSize(final long maxOutputSize) {
-        if (maxOutputSize > 512L * 1024L * 1024L) {
-            logger.warn("maxOutputSize is large; extraction may transiently allocate 2-4x this in heap: maxOutputSize={}", maxOutputSize);
-        }
-        this.maxOutputSize = maxOutputSize;
-        this.maxOutputSizeExplicit = true;
+    public void setContentLengthHelper(final ContentLengthHelper contentLengthHelper) {
+        this.contentLengthHelper = contentLengthHelper;
     }
 
     /**
-     * Returns the current maximum output size limit in bytes.
+     * Sets the fallback maximum number of bytes of extracted content accepted when no
+     * {@link ContentLengthHelper} is available. Output larger than this limit is rejected with
+     * {@link MaxLengthExceededException}.
      *
-     * @return the maximum number of bytes the subprocess may write to a single stream
+     * <p>Note: for {@code standardOutput=true} the captured stdout may be held on disk up to this
+     * limit; values above 512 MiB log a warning.
+     *
+     * @param maxContentLength the limit in bytes
      */
-    public long getMaxOutputSize() {
-        return maxOutputSize;
+    public void setMaxContentLength(final long maxContentLength) {
+        if (maxContentLength > 512L * 1024L * 1024L) {
+            logger.warn("maxContentLength is large; extraction may transiently allocate additional heap: maxContentLength={}",
+                    maxContentLength);
+        }
+        this.maxContentLength = maxContentLength;
+    }
+
+    /**
+     * Returns the fallback maximum content length in bytes (used when no {@link ContentLengthHelper}
+     * is available).
+     *
+     * @return the fallback maximum number of content bytes allowed
+     */
+    public long getMaxContentLength() {
+        return maxContentLength;
+    }
+
+    /**
+     * Sets the maximum number of bytes retained in memory from a diagnostic stream (stdout/stderr used
+     * only for logging). The stream is always drained to completion; bytes beyond this limit are
+     * discarded rather than buffered.
+     *
+     * @param maxDiagnosticRetainSize the retain limit in bytes
+     */
+    public void setMaxDiagnosticRetainSize(final int maxDiagnosticRetainSize) {
+        this.maxDiagnosticRetainSize = maxDiagnosticRetainSize;
     }
 
     /**
      * Sets the maximum number of bytes copied from the input stream into the
-     * temporary input file. If the input exceeds this size an {@link ExtractException}
+     * temporary input file. If the input exceeds this size a {@link MaxLengthExceededException}
      * is thrown before the command is invoked.
      *
      * @param maxInputSize the limit in bytes

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
@@ -15,19 +15,23 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.ExecutionTimeoutException;
-import org.junit.jupiter.api.Test;
+import org.codelibs.fess.crawler.exception.ExtractException;
 import org.dbflute.utflute.core.PlainTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author shinsuke
@@ -164,9 +168,11 @@ public class CommandExtractorTest extends PlainTestCase {
         extractor.command = getCommand(scriptFile);
         final Map<String, String> params = new HashMap<String, String>();
         try {
-            final ExtractData data = extractor.getText(new FileInputStream(contentFile), params);
+            extractor.getText(new FileInputStream(contentFile), params);
             fail();
-        } catch (final ExecutionTimeoutException e) {}
+        } catch (final ExecutionTimeoutException e) {
+            // expected
+        }
     }
 
     @Test
@@ -273,5 +279,142 @@ public class CommandExtractorTest extends PlainTestCase {
         actual = extractor.getFileName(value);
         assertEquals(expected, actual);
 
+    }
+
+    // ==========================================================
+    // PR-D: robustness tests
+    // ==========================================================
+
+    /**
+     * Verifies a long-running subprocess is killed when the timeout fires
+     * and the call returns within a few seconds (i.e. we don't wait the
+     * full sleep duration).
+     */
+    @Test
+    public void test_timeout_killsProcess() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return; // skip on non-Unix
+        }
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "sh -c \"sleep 30\"";
+        extractor.executionTimeout = 500L;
+
+        final long start = System.currentTimeMillis();
+        try {
+            extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
+            fail();
+        } catch (final ExecutionTimeoutException e) {
+            // expected
+        }
+        final long elapsed = System.currentTimeMillis() - start;
+        assertTrue(elapsed < 5000L);
+    }
+
+    /**
+     * Verifies that when the subprocess produces more bytes on stderr than
+     * {@code maxOutputSize} the call fails fast with an {@link ExtractException}
+     * rather than buffering an unbounded amount of data.
+     */
+    @Test
+    public void test_outputSizeExceeded_throwsExtractException() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final CommandExtractor extractor = new CommandExtractor();
+        // print 5 MiB of zeros to stderr; cap at 1 MiB.
+        extractor.command = "sh -c \"head -c 5242880 /dev/zero 1>&2\"";
+        extractor.executionTimeout = 30_000L;
+        extractor.maxOutputSize = 1024L * 1024L; // 1 MiB
+
+        try {
+            extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
+            fail();
+        } catch (final ExtractException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Verifies stderr is drained concurrently so the process does not block
+     * on a full pipe buffer (default ~64KB on Linux). We write much more than
+     * that to stderr while the script also produces normal output.
+     */
+    @Test
+    public void test_stderrDrained_doesNotDeadlock() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile;
+        try {
+            scriptFile = File.createTempFile("stderr_script", ".sh");
+            scriptFile.deleteOnExit();
+            // Write 1 MiB to stderr (well above default pipe buffer) then copy input.
+            FileUtil.writeBytes(scriptFile.getAbsolutePath(),
+                    ("#!/bin/bash\nhead -c 1048576 /dev/zero 1>&2\ncp \"$1\" \"$2\"\n").getBytes());
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
+
+        final String content = "TEST";
+        final File contentFile = createContentFile(".txt", content.getBytes());
+
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.executionTimeout = 30_000L;
+        extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
+
+        final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
+        assertEquals(content, data.getContent());
+    }
+
+    /**
+     * Verifies the input copy is bounded by {@code maxInputSize} and the
+     * extractor fails fast before invoking the command.
+     */
+    @Test
+    public void test_inputSizeExceeded_throwsExtractException() {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile = createScriptTempFile(0);
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = getCommand(scriptFile);
+        extractor.maxInputSize = 1024L; // 1 KiB
+
+        // 64 KiB of zeros is well above the 1 KiB cap.
+        final InputStream big = new ByteArrayInputStream(new byte[64 * 1024]);
+        try {
+            extractor.getText(big, new HashMap<>());
+            fail();
+        } catch (final ExtractException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Verifies that when a subprocess spawns a long-running child, the timeout
+     * path attempts to kill descendants too. We check this best-effort by
+     * snapshotting {@link ProcessHandle#allProcesses} before/after; the precise
+     * verification of orphan kill is platform-specific.
+     */
+    @Test
+    public void test_processDescendants_killed() throws Exception {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final CommandExtractor extractor = new CommandExtractor();
+        // Spawn a child sleep, then wait. When the parent is killed we want the child gone too.
+        extractor.command = "sh -c \"sleep 30 & wait\"";
+        extractor.executionTimeout = 500L;
+
+        final long start = System.currentTimeMillis();
+        try {
+            extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
+            fail();
+        } catch (final ExecutionTimeoutException e) {
+            // expected
+        }
+        final long elapsed = System.currentTimeMillis() - start;
+        // Total wall clock should be close to the timeout, not the 30-sec sleep.
+        assertTrue(elapsed < 10_000L);
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
@@ -361,6 +361,9 @@ public class CommandExtractorTest extends PlainTestCase {
         final CommandExtractor extractor = new CommandExtractor();
         extractor.executionTimeout = 30_000L;
         extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
+        // This test focuses on draining stderr so the process does not block;
+        // suppress stderr-in-output so the assertion compares only the file content.
+        extractor.setIncludeStderrInOutput(false);
 
         final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
         assertEquals(content, data.getContent());
@@ -416,5 +419,69 @@ public class CommandExtractorTest extends PlainTestCase {
         final long elapsed = System.currentTimeMillis() - start;
         // Total wall clock should be close to the timeout, not the 30-sec sleep.
         assertTrue(elapsed < 10_000L);
+    }
+
+    /**
+     * Verifies that when {@code standardOutput=false} and the subprocess writes to
+     * stderr, the captured stderr text is appended to the extracted content. This
+     * preserves backward compatibility with the legacy implementation which used
+     * {@code ProcessBuilder.redirectErrorStream(true)} and therefore included
+     * stderr in the extracted output.
+     */
+    @Test
+    public void test_stderrAppendedToOutput_whenStandardOutputFalse() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        // Script writes "OUT" to $OUTPUT_FILE and "ERR" to stderr.
+        final File scriptFile;
+        try {
+            scriptFile = File.createTempFile("stderr_in_out_", ".sh");
+            scriptFile.deleteOnExit();
+            FileUtil.writeBytes(scriptFile.getAbsolutePath(), "#!/bin/bash\necho OUT > \"$2\"\necho ERR >&2\n".getBytes());
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
+
+        final File contentFile = createContentFile(".txt", new byte[] { 0 });
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
+        extractor.executionTimeout = 30_000L;
+        // standardOutput defaults to false, includeStderrInOutput defaults to true.
+
+        final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
+        final String text = data.getContent();
+        assertTrue(text.contains("OUT"));
+        assertTrue(text.contains("ERR"));
+    }
+
+    /**
+     * Verifies that {@code setIncludeStderrInOutput(false)} suppresses appending
+     * stderr to the extracted content even when {@code standardOutput=false}.
+     */
+    @Test
+    public void test_stderrSuppressedFromOutput_whenIncludeStderrInOutputFalse() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile;
+        try {
+            scriptFile = File.createTempFile("stderr_suppressed_", ".sh");
+            scriptFile.deleteOnExit();
+            FileUtil.writeBytes(scriptFile.getAbsolutePath(), "#!/bin/bash\necho OUT > \"$2\"\necho ERR >&2\n".getBytes());
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
+
+        final File contentFile = createContentFile(".txt", new byte[] { 0 });
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
+        extractor.executionTimeout = 30_000L;
+        extractor.setIncludeStderrInOutput(false);
+
+        final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
+        final String text = data.getContent();
+        assertTrue(text.contains("OUT"));
+        assertFalse(text.contains("ERR"));
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
@@ -426,11 +426,9 @@ public class CommandExtractorTest extends PlainTestCase {
     }
 
     /**
-     * Verifies that when {@code standardOutput=false} and the subprocess writes to
-     * stderr, the captured stderr text is appended to the extracted content. This
-     * preserves backward compatibility with the legacy implementation which used
-     * {@code ProcessBuilder.redirectErrorStream(true)} and therefore included
-     * stderr in the extracted output.
+     * Verifies that when {@code standardOutput=false} and {@code includeStderrInOutput=true},
+     * captured stderr text is appended to the extracted content.
+     * Note: the opt-in flag must be set explicitly because the default is {@code false}.
      */
     @Test
     public void test_stderrAppendedToOutput_whenStandardOutputFalse() throws IOException {
@@ -451,12 +449,46 @@ public class CommandExtractorTest extends PlainTestCase {
         final CommandExtractor extractor = new CommandExtractor();
         extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
         extractor.executionTimeout = 30_000L;
-        // standardOutput defaults to false, includeStderrInOutput defaults to true.
+        // Explicitly opt in — default is false (pre-3.x behavior).
+        extractor.setIncludeStderrInOutput(true);
 
         final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
         final String text = data.getContent();
         assertTrue(text.contains("OUT"));
         assertTrue(text.contains("ERR"));
+    }
+
+    /**
+     * Verifies that by default ({@code includeStderrInOutput=false}), stderr is NOT
+     * appended to the extracted content even when {@code standardOutput=false}. This
+     * matches the pre-3.x behavior where stderr was only routed to logs, never to
+     * extracted text.
+     */
+    @Test
+    public void test_stderrNotInOutput_byDefault() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        // Script writes "content" to $OUTPUT_FILE and "warning" to stderr.
+        final File scriptFile;
+        try {
+            scriptFile = File.createTempFile("stderr_default_", ".sh");
+            scriptFile.deleteOnExit();
+            FileUtil.writeBytes(scriptFile.getAbsolutePath(), "#!/bin/bash\necho content > \"$2\"\necho warning >&2\n".getBytes());
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
+
+        final File contentFile = createContentFile(".txt", new byte[] { 0 });
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
+        extractor.executionTimeout = 30_000L;
+        // Do NOT call setIncludeStderrInOutput — default must be false.
+
+        final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
+        final String text = data.getContent();
+        assertTrue(text.contains("content"));
+        assertFalse(text.contains("warning")); // stderr should not appear in extracted text by default
     }
 
     /**
@@ -607,9 +639,10 @@ public class CommandExtractorTest extends PlainTestCase {
     // ==========================================================
 
     /**
-     * Fix 3: when BoundedStreamReader detects overflow it throws OutputSizeExceededException
-     * without calling destroyForcibly itself; destroyProcessTree (with snapshot) is called by
-     * executeCommand and must reap the background sleep child.
+     * Fix 3 + overflow fail-fast: when BoundedStreamReader detects overflow it throws
+     * OutputSizeExceededException and sets the overflow flag so the main thread breaks
+     * out of its polling loop and calls destroyProcessTree immediately — well before the
+     * full executionTimeout elapses. Also verifies the background sleep child is reaped.
      */
     @Test
     public void test_overflow_killsDescendants() throws Exception {
@@ -620,16 +653,21 @@ public class CommandExtractorTest extends PlainTestCase {
         // Spawn a background sleep, then flood stderr with zeros to trigger overflow.
         // standardOutput=false so stdout is piped; stderr triggers BoundedStreamReader overflow.
         extractor.command = "sh -c \"sleep 30 & head -c 5242880 /dev/zero 1>&2; wait\"";
-        extractor.executionTimeout = 30_000L;
+        // Use 10 s timeout — test must complete well below this if fail-fast works.
+        extractor.executionTimeout = 10_000L;
         extractor.maxOutputSize = 1024L * 1024L; // 1 MiB
         extractor.destroyGracePeriodMillis = 200L;
 
+        final long start = System.currentTimeMillis();
         try {
             extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
             fail();
         } catch (final ExtractException e) {
-            // expected
+            // expected — overflow detected
         }
+        final long elapsed = System.currentTimeMillis() - start;
+        // Overflow should be detected and process killed well before the 10 s timeout.
+        assertTrue(elapsed < 5000L); // overflow should kill process tree in < 5 s
 
         Thread.sleep(500);
 

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
@@ -31,7 +31,8 @@ import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.ExecutionTimeoutException;
-import org.codelibs.fess.crawler.exception.ExtractException;
+import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
+import org.codelibs.fess.crawler.helper.ContentLengthHelper;
 import org.dbflute.utflute.core.PlainTestCase;
 import org.junit.jupiter.api.Test;
 
@@ -315,33 +316,28 @@ public class CommandExtractorTest extends PlainTestCase {
     }
 
     /**
-     * Verifies that when the subprocess produces more bytes on stderr than
-     * {@code maxOutputSize} the call fails fast with an {@link ExtractException}
-     * rather than buffering an unbounded amount of data.
+     * Verifies that when the subprocess floods stderr (a diagnostic-only stream when
+     * {@code standardOutput=false}), the reader caps-and-discards the excess and the command still
+     * completes successfully instead of being killed. Content comes from $OUTPUT_FILE (empty here),
+     * so stderr volume must not fail the extraction.
      */
     @Test
-    public void test_outputSizeExceeded_throwsExtractException() throws IOException {
+    public void test_oversizeStderr_capAndDiscard_doesNotThrow() throws IOException {
         if (!SystemUtils.IS_OS_UNIX) {
             return;
         }
         final CommandExtractor extractor = new CommandExtractor();
-        // print 5 MiB of zeros to stderr; cap at 1 MiB.
+        // print 5 MiB of zeros to stderr; the diagnostic reader retains only a small prefix.
         extractor.command = "sh -c \"head -c 5242880 /dev/zero 1>&2\"";
         extractor.executionTimeout = 30_000L;
-        extractor.maxOutputSize = 1024L * 1024L; // 1 MiB
+        extractor.maxDiagnosticRetainSize = 64 * 1024; // 64 KiB retained; the rest is drained and discarded
 
         final long start = System.currentTimeMillis();
-        try {
-            extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
-            fail();
-        } catch (final ExtractException e) {
-            // expected
-        }
+        // Must NOT throw: stderr is diagnostic and is cap-and-discarded, not fatal.
+        final ExtractData data = extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
+        assertEquals("", data.getContent());
         final long elapsed = System.currentTimeMillis() - start;
-        if (elapsed >= 5000L) {
-            logger.warn("test_outputSizeExceeded_throwsExtractException: did not fast-fail (was {}ms)", elapsed);
-        }
-        assertTrue(elapsed < 5000L);
+        assertTrue(elapsed < 10_000L);
     }
 
     /**
@@ -381,10 +377,10 @@ public class CommandExtractorTest extends PlainTestCase {
 
     /**
      * Verifies the input copy is bounded by {@code maxInputSize} and the
-     * extractor fails fast before invoking the command.
+     * extractor fails fast with {@link MaxLengthExceededException} before invoking the command.
      */
     @Test
-    public void test_inputSizeExceeded_throwsExtractException() {
+    public void test_inputSizeExceeded_throwsMaxLengthExceededException() {
         if (!SystemUtils.IS_OS_UNIX) {
             return;
         }
@@ -398,7 +394,7 @@ public class CommandExtractorTest extends PlainTestCase {
         try {
             extractor.getText(big, new HashMap<>());
             fail();
-        } catch (final ExtractException e) {
+        } catch (final MaxLengthExceededException e) {
             // expected
         }
     }
@@ -528,41 +524,41 @@ public class CommandExtractorTest extends PlainTestCase {
     }
 
     // ==========================================================
-    // Fix 1: outputFile exceeds maxOutputSize → ExtractException
+    // Content bound: extracted content exceeds the content-length limit → MaxLengthExceededException
     // ==========================================================
 
     /**
-     * Fix 1 (standardOutput=true): when the command writes more than maxOutputSize bytes to
-     * stdout, getText() must throw ExtractException rather than loading the entire file into
-     * memory.
+     * Content bound (standardOutput=true): when the command writes more than the content limit to
+     * stdout, getText() must throw {@link MaxLengthExceededException} rather than loading the entire
+     * output into memory.
      */
     @Test
-    public void test_outputFileExceedsMaxOutputSize_throws() throws IOException {
+    public void test_outputExceedsContentLimit_standardOutputTrue_throws() throws IOException {
         if (!SystemUtils.IS_OS_UNIX) {
             return;
         }
         final CommandExtractor extractor = new CommandExtractor();
-        // cat $INPUT_FILE sends content to stdout; we will pipe a 5-MiB input with standardOutput=true.
-        // 5 MiB output > 1 MiB limit should trigger the guard.
+        // 5 MiB stdout > 1 MiB content limit should trigger the bound.
         extractor.standardOutput = true;
         extractor.command = "sh -c \"head -c 5242880 /dev/zero\"";
         extractor.executionTimeout = 30_000L;
-        extractor.maxOutputSize = 1024L * 1024L; // 1 MiB
+        extractor.setMaxContentLength(1024L * 1024L); // 1 MiB
 
         try {
             extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
             fail();
-        } catch (final ExtractException e) {
+        } catch (final MaxLengthExceededException e) {
             // expected
         }
     }
 
     /**
-     * Fix 1 (standardOutput=false): when the command writes more than maxOutputSize bytes to
-     * $OUTPUT_FILE, getText() must throw ExtractException (length-check defensive line).
+     * Content bound (standardOutput=false): when the command writes more than the content limit to
+     * $OUTPUT_FILE, getText() must throw {@link MaxLengthExceededException} (post-exec length guard).
+     * This variant exercises the {@link ContentLengthHelper}-driven limit.
      */
     @Test
-    public void test_outputFileExceedsMaxOutputSize_standardOutputFalse_throws() throws IOException {
+    public void test_outputFileExceedsContentLimit_standardOutputFalse_throws() throws IOException {
         if (!SystemUtils.IS_OS_UNIX) {
             return;
         }
@@ -570,7 +566,7 @@ public class CommandExtractorTest extends PlainTestCase {
         try {
             scriptFile = File.createTempFile("big_output_", ".sh");
             scriptFile.deleteOnExit();
-            // Write 5 MiB of zeros to $OUTPUT_FILE directly (bypasses BoundedStreamReader).
+            // Write 5 MiB of zeros to $OUTPUT_FILE directly (bypasses the diagnostic reader).
             FileUtil.writeBytes(scriptFile.getAbsolutePath(), "#!/bin/bash\nhead -c 5242880 /dev/zero > \"$2\"\n".getBytes());
         } catch (final IOException e) {
             throw new IORuntimeException(e);
@@ -579,12 +575,14 @@ public class CommandExtractorTest extends PlainTestCase {
         final CommandExtractor extractor = new CommandExtractor();
         extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
         extractor.executionTimeout = 30_000L;
-        extractor.maxOutputSize = 1024L * 1024L; // 1 MiB
+        final ContentLengthHelper contentLengthHelper = new ContentLengthHelper();
+        contentLengthHelper.setDefaultMaxLength(1024L * 1024L); // 1 MiB
+        extractor.setContentLengthHelper(contentLengthHelper);
 
         try {
             extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
             fail();
-        } catch (final ExtractException e) {
+        } catch (final MaxLengthExceededException e) {
             // expected
         }
     }
@@ -645,31 +643,32 @@ public class CommandExtractorTest extends PlainTestCase {
     // ==========================================================
 
     /**
-     * Fix 3 + overflow fail-fast: when BoundedStreamReader detects overflow it throws
-     * OutputSizeExceededException and sets the overflow flag so the main thread breaks
-     * out of its polling loop and calls destroyProcessTree immediately — well before the
-     * full executionTimeout elapses. Also verifies the background sleep child is reaped.
+     * Content-overflow kills descendants: when {@code standardOutput=true} and the command floods
+     * stdout beyond the content limit, the {@code BoundedFileWriter} sets the overflow flag so the
+     * main thread breaks out of its polling loop and calls destroyProcessTree immediately — well
+     * before the full executionTimeout — reaping the background child too.
      */
     @Test
-    public void test_overflow_killsDescendants() throws Exception {
+    public void test_contentOverflow_killsDescendants() throws Exception {
         if (!SystemUtils.IS_OS_UNIX) {
             return;
         }
         final CommandExtractor extractor = new CommandExtractor();
-        // Spawn a background sleep, then flood stderr with zeros to trigger overflow.
-        // standardOutput=false so stdout is piped; stderr triggers BoundedStreamReader overflow.
-        extractor.command = "sh -c \"sleep 30 & head -c 5242880 /dev/zero 1>&2; wait\"";
+        // Spawn a background sleep, then flood stdout to trigger a content-limit overflow.
+        // standardOutput=true so stdout is the content path (BoundedFileWriter enforces the limit).
+        extractor.standardOutput = true;
+        extractor.command = "sh -c \"sleep 37 & head -c 5242880 /dev/zero; wait\"";
         // Use 10 s timeout — test must complete well below this if fail-fast works.
         extractor.executionTimeout = 10_000L;
-        extractor.maxOutputSize = 1024L * 1024L; // 1 MiB
+        extractor.setMaxContentLength(1024L * 1024L); // 1 MiB
         extractor.destroyGracePeriodMillis = 200L;
 
         final long start = System.currentTimeMillis();
         try {
             extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
             fail();
-        } catch (final ExtractException e) {
-            // expected — overflow detected
+        } catch (final MaxLengthExceededException e) {
+            // expected — content overflow detected
         }
         final long elapsed = System.currentTimeMillis() - start;
         // Overflow should be detected and process killed well before the 10 s timeout.
@@ -681,7 +680,7 @@ public class CommandExtractorTest extends PlainTestCase {
                 .filter(ProcessHandle::isAlive)
                 .anyMatch(ph -> ph.info().command().map(c -> c.contains("sleep")).orElse(false) && ph.info().arguments().map(args -> {
                     for (final String a : args) {
-                        if ("30".equals(a)) {
+                        if ("37".equals(a)) {
                             return true;
                         }
                     }
@@ -689,39 +688,29 @@ public class CommandExtractorTest extends PlainTestCase {
                 }).orElse(false));
 
         if (orphanAlive) {
-            logger.warn("test_overflow_killsDescendants: orphan 'sleep 30' still alive after kill attempt");
+            logger.warn("test_contentOverflow_killsDescendants: orphan 'sleep 37' still alive after kill attempt");
         }
         assertFalse(orphanAlive);
     }
 
     // ==========================================================
-    // Fix 4: setMaxOutputLine conservatively shrinks maxOutputSize
+    // Deprecated setMaxOutputLine is now a NOP (content bound via ContentLengthHelper)
     // ==========================================================
 
     /**
-     * Fix 4a: setMaxOutputLine(1) should shrink maxOutputSize to max(64KiB, 1*1024) = 64 KiB
-     * when setMaxOutputSize has not been called.
+     * The deprecated {@code setMaxOutputLine} no longer affects the content bound (which now comes
+     * from {@link ContentLengthHelper}/{@code maxContentLength}); it is retained only for source and
+     * binary compatibility and must be a harmless NOP.
      */
     @Test
     @SuppressWarnings("deprecation")
-    public void test_setMaxOutputLine_shrinksMaxOutputSize() {
+    public void test_setMaxOutputLine_isNoOp() {
         final CommandExtractor extractor = new CommandExtractor();
-        // Default maxOutputSize is 10 MiB; setMaxOutputLine(1) infers 64 KiB (floor), which is smaller.
+        final long before = extractor.getMaxContentLength();
         extractor.setMaxOutputLine(1);
-        assertTrue(extractor.getMaxOutputSize() <= 64L * 1024L);
-    }
-
-    /**
-     * Fix 4b: when setMaxOutputSize has been called explicitly, a subsequent setMaxOutputLine
-     * must not override it — the explicit value must be preserved regardless of call order.
-     */
-    @Test
-    @SuppressWarnings("deprecation")
-    public void test_setMaxOutputLine_doesNotOverrideExplicitMaxOutputSize() {
-        final CommandExtractor extractor = new CommandExtractor();
-        extractor.setMaxOutputSize(50L * 1024L * 1024L); // 50 MiB explicit
-        extractor.setMaxOutputLine(1); // would infer 64 KiB but must not override explicit
-        assertEquals(50L * 1024L * 1024L, extractor.getMaxOutputSize());
+        extractor.setMaxOutputLine(100000);
+        // The content bound is unaffected by the deprecated line-count setter.
+        assertEquals(before, extractor.getMaxContentLength());
     }
 
     // ==========================================================
@@ -729,29 +718,30 @@ public class CommandExtractorTest extends PlainTestCase {
     // ==========================================================
 
     /**
-     * Validates C1: standardOutput=true overflow must fail fast (not wait for executionTimeout).
+     * Validates content-overflow fast-fail: standardOutput=true overflow must fail fast (not wait for
+     * executionTimeout).
      */
     @Test
-    public void test_standardOutputOverflow_failsFastWithoutWaitingForTimeout() throws IOException {
+    public void test_contentOverflow_failsFastWithoutWaitingForTimeout() throws IOException {
         if (!SystemUtils.IS_OS_UNIX) {
             return;
         }
         final CommandExtractor extractor = new CommandExtractor();
         extractor.standardOutput = true;
-        // Produce 5 MiB then keep running. Without C1 fix the test would wait the full executionTimeout.
+        // Produce 5 MiB then keep running. Without fail-fast the test would wait the full executionTimeout.
         extractor.command = "sh -c \"head -c 5242880 /dev/zero; sleep 30\"";
         extractor.executionTimeout = 10_000L;
-        extractor.maxOutputSize = 1024L * 1024L;
+        extractor.setMaxContentLength(1024L * 1024L);
         final long start = System.currentTimeMillis();
         try {
             extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
             fail();
-        } catch (final ExtractException e) {
+        } catch (final MaxLengthExceededException e) {
             // expected
         }
         final long elapsed = System.currentTimeMillis() - start;
         if (elapsed >= 5000L) {
-            logger.warn("test_standardOutputOverflow_failsFastWithoutWaitingForTimeout: overflow did not fail fast (was {}ms)", elapsed);
+            logger.warn("test_contentOverflow_failsFastWithoutWaitingForTimeout: overflow did not fail fast (was {}ms)", elapsed);
         }
         assertTrue(elapsed < 5000L);
     }
@@ -832,17 +822,6 @@ public class CommandExtractorTest extends PlainTestCase {
         // Lenient contract: non-zero exit does NOT throw; content is returned.
         final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
         assertTrue(data.getContent().contains("partial"));
-    }
-
-    /**
-     * Tightened version of test_setMaxOutputLine_shrinksMaxOutputSize: verifies exact 64 KiB floor.
-     */
-    @Test
-    @SuppressWarnings("deprecation")
-    public void test_setMaxOutputLine_shrinksMaxOutputSize_toExactFloor() {
-        final CommandExtractor extractor = new CommandExtractor();
-        extractor.setMaxOutputLine(1);
-        assertEquals(64L * 1024L, extractor.getMaxOutputSize());
     }
 
     /**
@@ -948,5 +927,112 @@ public class CommandExtractorTest extends PlainTestCase {
         final CommandExtractor.InputStreamThread it =
                 new CommandExtractor.InputStreamThread(new ByteArrayInputStream(new byte[0]), "UTF-8", 100);
         assertEquals("", it.getOutput());
+    }
+
+    // ==========================================================
+    // Cap-and-discard diagnostic streams + ContentLengthHelper-driven bound
+    // ==========================================================
+
+    /**
+     * Verifies that when {@code standardOutput=false} the command may flood stdout (a diagnostic-only
+     * stream) without being killed: the reader caps-and-discards stdout while $OUTPUT_FILE content is
+     * returned intact.
+     */
+    @Test
+    public void test_diagnosticStdout_capAndDiscard_standardOutputFalse() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile;
+        try {
+            scriptFile = File.createTempFile("stdout_flood_", ".sh");
+            scriptFile.deleteOnExit();
+            // Flood stdout with 5 MiB, then write the real content to $OUTPUT_FILE.
+            FileUtil.writeBytes(scriptFile.getAbsolutePath(), "#!/bin/bash\nhead -c 5242880 /dev/zero\necho content > \"$2\"\n".getBytes());
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
+
+        final File contentFile = createContentFile(".txt", new byte[] { 0 });
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
+        extractor.executionTimeout = 30_000L;
+        extractor.maxDiagnosticRetainSize = 64 * 1024;
+
+        // Must NOT throw despite 5 MiB on stdout; content comes from $OUTPUT_FILE.
+        final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
+        assertTrue(data.getContent().contains("content"));
+    }
+
+    /**
+     * Verifies the content bound honours a per-MIME-type limit from {@link ContentLengthHelper} when
+     * a {@code Content-Type} is present in the extraction parameters.
+     */
+    @Test
+    public void test_contentLimit_perMimeType_fromParams() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile;
+        try {
+            scriptFile = File.createTempFile("mime_output_", ".sh");
+            scriptFile.deleteOnExit();
+            // Write 2 MiB to $OUTPUT_FILE.
+            FileUtil.writeBytes(scriptFile.getAbsolutePath(), "#!/bin/bash\nhead -c 2097152 /dev/zero > \"$2\"\n".getBytes());
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
+
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
+        extractor.executionTimeout = 30_000L;
+        final ContentLengthHelper contentLengthHelper = new ContentLengthHelper();
+        contentLengthHelper.setDefaultMaxLength(10L * 1024L * 1024L); // generous default
+        contentLengthHelper.addMaxLength("text/plain", 1024L * 1024L); // 1 MiB for text/plain
+        extractor.setContentLengthHelper(contentLengthHelper);
+
+        final Map<String, String> params = new HashMap<>();
+        params.put(ExtractData.CONTENT_TYPE, "text/plain");
+        // 2 MiB output exceeds the 1 MiB text/plain limit -> rejected.
+        try {
+            extractor.getText(new ByteArrayInputStream(new byte[0]), params);
+            fail();
+        } catch (final MaxLengthExceededException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Verifies that when {@code includeStderrInOutput=true} the appended stderr is truncated so the
+     * combined content never exceeds the content limit (stderr is diagnostic — truncate, don't fail).
+     */
+    @Test
+    public void test_includeStderrInOutput_combinedContentStaysWithinLimit() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile;
+        try {
+            scriptFile = File.createTempFile("stderr_bound_", ".sh");
+            scriptFile.deleteOnExit();
+            // 1000 'A' bytes to $OUTPUT_FILE, 1000 'B' bytes to stderr.
+            FileUtil.writeBytes(scriptFile.getAbsolutePath(),
+                    "#!/bin/bash\nprintf 'A%.0s' {1..1000} > \"$2\"\nprintf 'B%.0s' {1..1000} >&2\n".getBytes());
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
+
+        final File contentFile = createContentFile(".txt", new byte[] { 0 });
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
+        extractor.executionTimeout = 30_000L;
+        extractor.setIncludeStderrInOutput(true);
+        extractor.setMaxContentLength(1500L); // 1000 (file) + at most 500 (stderr)
+
+        final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
+        final byte[] contentBytes = data.getContent().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertTrue(contentBytes.length <= 1500);
+        assertTrue(data.getContent().contains("A"));
+        assertTrue(data.getContent().contains("B")); // some stderr retained after truncation
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.fess.crawler.entity.ExtractData;
@@ -38,6 +40,8 @@ import org.junit.jupiter.api.Test;
  *
  */
 public class CommandExtractorTest extends PlainTestCase {
+
+    private static final Logger logger = LogManager.getLogger(CommandExtractorTest.class);
 
     private File createScriptTempFile(final int sleep) {
         String extention;
@@ -483,5 +487,194 @@ public class CommandExtractorTest extends PlainTestCase {
         final String text = data.getContent();
         assertTrue(text.contains("OUT"));
         assertFalse(text.contains("ERR"));
+    }
+
+    // ==========================================================
+    // Fix 1: outputFile exceeds maxOutputSize → ExtractException
+    // ==========================================================
+
+    /**
+     * Fix 1 (standardOutput=true): when the command writes more than maxOutputSize bytes to
+     * stdout, getText() must throw ExtractException rather than loading the entire file into
+     * memory.
+     */
+    @Test
+    public void test_outputFileExceedsMaxOutputSize_throws() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final CommandExtractor extractor = new CommandExtractor();
+        // cat $INPUT_FILE sends content to stdout; we will pipe a 5-MiB input with standardOutput=true.
+        // 5 MiB output > 1 MiB limit should trigger the guard.
+        extractor.standardOutput = true;
+        extractor.command = "sh -c \"head -c 5242880 /dev/zero\"";
+        extractor.executionTimeout = 30_000L;
+        extractor.maxOutputSize = 1024L * 1024L; // 1 MiB
+
+        try {
+            extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
+            fail();
+        } catch (final ExtractException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Fix 1 (standardOutput=false): when the command writes more than maxOutputSize bytes to
+     * $OUTPUT_FILE, getText() must throw ExtractException (length-check defensive line).
+     */
+    @Test
+    public void test_outputFileExceedsMaxOutputSize_standardOutputFalse_throws() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile;
+        try {
+            scriptFile = File.createTempFile("big_output_", ".sh");
+            scriptFile.deleteOnExit();
+            // Write 5 MiB of zeros to $OUTPUT_FILE directly (bypasses BoundedStreamReader).
+            FileUtil.writeBytes(scriptFile.getAbsolutePath(), "#!/bin/bash\nhead -c 5242880 /dev/zero > \"$2\"\n".getBytes());
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
+
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
+        extractor.executionTimeout = 30_000L;
+        extractor.maxOutputSize = 1024L * 1024L; // 1 MiB
+
+        try {
+            extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
+            fail();
+        } catch (final ExtractException e) {
+            // expected
+        }
+    }
+
+    // ==========================================================
+    // Fix 2: descendants are killed even when parent exits cleanly
+    // ==========================================================
+
+    /**
+     * Fix 2: verifies that after a timeout the spawned child process (sleep) is killed even
+     * when the parent shell exits gracefully before the grace period expires and would otherwise
+     * cause descendants() to return an empty snapshot.
+     */
+    @Test
+    public void test_processDescendants_killed_orphan_gone() throws Exception {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final CommandExtractor extractor = new CommandExtractor();
+        // The shell spawns a background sleep and prints its PID to stdout, then waits.
+        // standardOutput=false so we can read stdout text via BoundedStreamReader.
+        extractor.command = "sh -c \"sleep 30 & echo $!; wait\"";
+        extractor.executionTimeout = 800L;
+        extractor.destroyGracePeriodMillis = 200L;
+
+        try {
+            extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
+            fail();
+        } catch (final ExecutionTimeoutException e) {
+            // expected — but we did not capture stdout here since the exception fires before we collect it.
+        } catch (final Exception e) {
+            // acceptable
+        }
+
+        // Give the OS a moment to reap the child.
+        Thread.sleep(500);
+
+        // Best-effort check: find any process with "sleep 30" in its command that is still alive.
+        final boolean orphanAlive = ProcessHandle.allProcesses()
+                .filter(ProcessHandle::isAlive)
+                .anyMatch(ph -> ph.info().command().map(c -> c.contains("sleep")).orElse(false) && ph.info().arguments().map(args -> {
+                    for (final String a : args) {
+                        if ("30".equals(a)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }).orElse(false));
+
+        if (orphanAlive) {
+            logger.warn("test_processDescendants_killed_orphan_gone: orphan 'sleep 30' still alive after kill attempt");
+        }
+        assertFalse(orphanAlive);
+    }
+
+    // ==========================================================
+    // Fix 3: overflow kills descendants via destroyProcessTree
+    // ==========================================================
+
+    /**
+     * Fix 3: when BoundedStreamReader detects overflow it throws OutputSizeExceededException
+     * without calling destroyForcibly itself; destroyProcessTree (with snapshot) is called by
+     * executeCommand and must reap the background sleep child.
+     */
+    @Test
+    public void test_overflow_killsDescendants() throws Exception {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final CommandExtractor extractor = new CommandExtractor();
+        // Spawn a background sleep, then flood stderr with zeros to trigger overflow.
+        // standardOutput=false so stdout is piped; stderr triggers BoundedStreamReader overflow.
+        extractor.command = "sh -c \"sleep 30 & head -c 5242880 /dev/zero 1>&2; wait\"";
+        extractor.executionTimeout = 30_000L;
+        extractor.maxOutputSize = 1024L * 1024L; // 1 MiB
+        extractor.destroyGracePeriodMillis = 200L;
+
+        try {
+            extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
+            fail();
+        } catch (final ExtractException e) {
+            // expected
+        }
+
+        Thread.sleep(500);
+
+        final boolean orphanAlive = ProcessHandle.allProcesses()
+                .filter(ProcessHandle::isAlive)
+                .anyMatch(ph -> ph.info().command().map(c -> c.contains("sleep")).orElse(false) && ph.info().arguments().map(args -> {
+                    for (final String a : args) {
+                        if ("30".equals(a)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }).orElse(false));
+
+        if (orphanAlive) {
+            logger.warn("test_overflow_killsDescendants: orphan 'sleep 30' still alive after kill attempt");
+        }
+        assertFalse(orphanAlive);
+    }
+
+    // ==========================================================
+    // Fix 4: setMaxOutputLine conservatively shrinks maxOutputSize
+    // ==========================================================
+
+    /**
+     * Fix 4a: setMaxOutputLine(1) should shrink maxOutputSize to max(64KiB, 1*1024) = 64 KiB
+     * when setMaxOutputSize has not been called.
+     */
+    @Test
+    public void test_setMaxOutputLine_shrinksMaxOutputSize() {
+        final CommandExtractor extractor = new CommandExtractor();
+        // Default maxOutputSize is 10 MiB; setMaxOutputLine(1) infers 64 KiB (floor), which is smaller.
+        extractor.setMaxOutputLine(1);
+        assertTrue(extractor.getMaxOutputSize() <= 64L * 1024L);
+    }
+
+    /**
+     * Fix 4b: when setMaxOutputSize has been called explicitly, a subsequent setMaxOutputLine
+     * must not override it — the explicit value must be preserved regardless of call order.
+     */
+    @Test
+    public void test_setMaxOutputLine_doesNotOverrideExplicitMaxOutputSize() {
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.setMaxOutputSize(50L * 1024L * 1024L); // 50 MiB explicit
+        extractor.setMaxOutputLine(1); // would infer 64 KiB but must not override explicit
+        assertEquals(50L * 1024L * 1024L, extractor.getMaxOutputSize());
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/CommandExtractorTest.java
@@ -330,12 +330,18 @@ public class CommandExtractorTest extends PlainTestCase {
         extractor.executionTimeout = 30_000L;
         extractor.maxOutputSize = 1024L * 1024L; // 1 MiB
 
+        final long start = System.currentTimeMillis();
         try {
             extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
             fail();
         } catch (final ExtractException e) {
             // expected
         }
+        final long elapsed = System.currentTimeMillis() - start;
+        if (elapsed >= 5000L) {
+            logger.warn("test_outputSizeExceeded_throwsExtractException: did not fast-fail (was {}ms)", elapsed);
+        }
+        assertTrue(elapsed < 5000L);
     }
 
     /**
@@ -697,6 +703,7 @@ public class CommandExtractorTest extends PlainTestCase {
      * when setMaxOutputSize has not been called.
      */
     @Test
+    @SuppressWarnings("deprecation")
     public void test_setMaxOutputLine_shrinksMaxOutputSize() {
         final CommandExtractor extractor = new CommandExtractor();
         // Default maxOutputSize is 10 MiB; setMaxOutputLine(1) infers 64 KiB (floor), which is smaller.
@@ -709,10 +716,237 @@ public class CommandExtractorTest extends PlainTestCase {
      * must not override it — the explicit value must be preserved regardless of call order.
      */
     @Test
+    @SuppressWarnings("deprecation")
     public void test_setMaxOutputLine_doesNotOverrideExplicitMaxOutputSize() {
         final CommandExtractor extractor = new CommandExtractor();
         extractor.setMaxOutputSize(50L * 1024L * 1024L); // 50 MiB explicit
         extractor.setMaxOutputLine(1); // would infer 64 KiB but must not override explicit
         assertEquals(50L * 1024L * 1024L, extractor.getMaxOutputSize());
+    }
+
+    // ==========================================================
+    // PR-159 review-fix tests
+    // ==========================================================
+
+    /**
+     * Validates C1: standardOutput=true overflow must fail fast (not wait for executionTimeout).
+     */
+    @Test
+    public void test_standardOutputOverflow_failsFastWithoutWaitingForTimeout() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.standardOutput = true;
+        // Produce 5 MiB then keep running. Without C1 fix the test would wait the full executionTimeout.
+        extractor.command = "sh -c \"head -c 5242880 /dev/zero; sleep 30\"";
+        extractor.executionTimeout = 10_000L;
+        extractor.maxOutputSize = 1024L * 1024L;
+        final long start = System.currentTimeMillis();
+        try {
+            extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
+            fail();
+        } catch (final ExtractException e) {
+            // expected
+        }
+        final long elapsed = System.currentTimeMillis() - start;
+        if (elapsed >= 5000L) {
+            logger.warn("test_standardOutputOverflow_failsFastWithoutWaitingForTimeout: overflow did not fail fast (was {}ms)", elapsed);
+        }
+        assertTrue(elapsed < 5000L);
+    }
+
+    /**
+     * Validates C4: invalid charset name falls back to UTF-8 silently (warning logged).
+     */
+    @Test
+    public void test_invalidCommandOutputEncoding_fallsBackToUtf8() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile = createScriptTempFileStdout(0);
+        final File contentFile = createContentFile(".txt", "HELLO".getBytes());
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.standardOutput = true;
+        extractor.command = getCommandStdout(scriptFile);
+        extractor.setCommandOutputEncoding("not-a-real-charset-12345");
+        extractor.executionTimeout = 30_000L;
+        // Should NOT throw — falls back to UTF-8 silently (warning logged).
+        final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
+        assertEquals("HELLO", data.getContent());
+    }
+
+    /**
+     * Verifies a blank command surfaces as a CrawlerSystemException rather than NPE/IAE.
+     */
+    @Test
+    public void test_blankCommand_throwsCrawlerSystemException() {
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "   ";
+        try {
+            extractor.getText(new ByteArrayInputStream("x".getBytes()), new HashMap<>());
+            fail();
+        } catch (final org.codelibs.fess.crawler.exception.CrawlerSystemException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Verifies a nonexistent binary surfaces as a CrawlerSystemException.
+     */
+    @Test
+    public void test_nonexistentBinary_throwsCrawlerSystemException() {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "/nonexistent/path/to/binary $INPUT_FILE $OUTPUT_FILE";
+        try {
+            extractor.getText(new ByteArrayInputStream("x".getBytes()), new HashMap<>());
+            fail();
+        } catch (final org.codelibs.fess.crawler.exception.CrawlerSystemException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Validates M4: non-zero exit must NOT throw — content is still returned (lenient contract).
+     */
+    @Test
+    public void test_nonZeroExit_returnsAvailableContent() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile;
+        try {
+            scriptFile = File.createTempFile("nonzero_", ".sh");
+            scriptFile.deleteOnExit();
+            FileUtil.writeBytes(scriptFile.getAbsolutePath(), "#!/bin/bash\necho partial > \"$2\"\nexit 7\n".getBytes());
+        } catch (final IOException e) {
+            throw new IORuntimeException(e);
+        }
+        final File contentFile = createContentFile(".txt", new byte[] { 0 });
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "sh " + scriptFile.getAbsolutePath() + " $INPUT_FILE $OUTPUT_FILE";
+        extractor.executionTimeout = 30_000L;
+        // Lenient contract: non-zero exit does NOT throw; content is returned.
+        final ExtractData data = extractor.getText(new FileInputStream(contentFile), new HashMap<>());
+        assertTrue(data.getContent().contains("partial"));
+    }
+
+    /**
+     * Tightened version of test_setMaxOutputLine_shrinksMaxOutputSize: verifies exact 64 KiB floor.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void test_setMaxOutputLine_shrinksMaxOutputSize_toExactFloor() {
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.setMaxOutputLine(1);
+        assertEquals(64L * 1024L, extractor.getMaxOutputSize());
+    }
+
+    /**
+     * Verifies M8: resourceName containing shell metacharacters is sanitized so it cannot be used
+     * to inject arguments via the temp-file prefix.
+     */
+    @Test
+    public void test_resourceNameWithMetacharacters_sanitizedInTempFileName() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile = createScriptTempFile(0);
+        final File contentFile = createContentFile(".txt", "OK".getBytes());
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = getCommand(scriptFile);
+        final Map<String, String> params = new HashMap<>();
+        // A maliciously crafted resourceName with shell metacharacters.
+        params.put(ExtractData.RESOURCE_NAME_KEY, "evil;rm -rf /.--reset.txt");
+        final ExtractData data = extractor.getText(new FileInputStream(contentFile), params);
+        assertEquals("OK", data.getContent());
+    }
+
+    /**
+     * Verifies M8: getFileName handles Windows-style backslash path separators.
+     */
+    @Test
+    public void test_getFileName_handlesWindowsBackslash() {
+        final CommandExtractor extractor = new CommandExtractor();
+        assertEquals("hoge.txt", extractor.getFileName("C:\\path\\hoge.txt"));
+        assertEquals("hoge.txt", extractor.getFileName("path\\hoge.txt"));
+        assertEquals("hoge.txt", extractor.getFileName("hoge.txt\\"));
+    }
+
+    /**
+     * Verifies thread interrupt is propagated and the interrupt flag is restored.
+     */
+    @Test
+    public void test_interrupt_propagatesAsInterruptedRuntimeException() throws InterruptedException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = "sh -c \"sleep 30\"";
+        extractor.executionTimeout = 30_000L;
+        final Thread target = Thread.currentThread();
+        final Thread interrupter = new Thread(() -> {
+            try {
+                Thread.sleep(500);
+            } catch (final InterruptedException ignored) {}
+            target.interrupt();
+        });
+        interrupter.start();
+        try {
+            extractor.getText(new ByteArrayInputStream(new byte[0]), new HashMap<>());
+            fail();
+        } catch (final org.codelibs.core.exception.InterruptedRuntimeException expected) {
+            // good
+        } catch (final Exception e) {
+            // also acceptable as long as interrupt flag was restored
+        } finally {
+            Thread.interrupted(); // clear interrupt for subsequent tests
+        }
+    }
+
+    /**
+     * Verifies an invalid workingDirectory surfaces as a CrawlerSystemException.
+     */
+    @Test
+    public void test_invalidWorkingDirectory_throwsCrawlerSystemException() throws IOException {
+        if (!SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+        final File scriptFile = createScriptTempFile(0);
+        final File contentFile = createContentFile(".txt", "x".getBytes());
+        final CommandExtractor extractor = new CommandExtractor();
+        extractor.command = getCommand(scriptFile);
+        extractor.workingDirectory = new File("/nonexistent/path/that/does/not/exist");
+        try {
+            extractor.getText(new FileInputStream(contentFile), new HashMap<>());
+            fail();
+        } catch (final org.codelibs.fess.crawler.exception.CrawlerSystemException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Verifies the deprecated MonitorThread stub still works as a NOP.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void test_deprecatedMonitorThread_isNop() {
+        final CommandExtractor.MonitorThread mt = new CommandExtractor.MonitorThread(null, 1000L);
+        mt.setFinished(true);
+        assertFalse(mt.isTeminated());
+    }
+
+    /**
+     * Verifies the deprecated InputStreamThread stub still works as a NOP.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void test_deprecatedInputStreamThread_isNop() {
+        final CommandExtractor.InputStreamThread it =
+                new CommandExtractor.InputStreamThread(new ByteArrayInputStream(new byte[0]), "UTF-8", 100);
+        assertEquals("", it.getOutput());
     }
 }


### PR DESCRIPTION
## Summary

Hardens `CommandExtractor` against five subprocess threats: hangs, output blow-ups, zombie/orphan children, stderr-pipe deadlocks, and oversized inputs.

- **Timeout via `Process.waitFor(timeout, TimeUnit)`** instead of a polling `MonitorThread` (deleted as dead code along with `InputStreamThread`).
- **Both stdout and stderr are drained concurrently** by daemon threads so a full pipe buffer cannot block the child. Previously stderr was merged into stdout in capture mode, but in `standardOutput=true` mode stderr was completely undrained.
- **Output cap (`maxOutputSize`, default 10 MiB)** per stream. On overflow the process tree is destroyed and an `ExtractException` is thrown.
- **Input cap (`maxInputSize`, default 100 MiB)** when copying the input stream into the temp file; fails fast before the command is invoked.
- **Descendant kill** on timeout/overflow: `process.descendants().forEach(ProcessHandle::destroyForcibly)` followed by `process.destroyForcibly()`, so child processes started by the extractor command do not survive the parent.
- **Daemon thread factory** for stream-drain workers so they cannot block JVM shutdown.
- **Removed `isTeminated` typo** along with the obsolete `MonitorThread`/`InputStreamThread` inner classes.

## Test plan

- [x] `mvn -pl fess-crawler test -Dtest=CommandExtractorTest` — all 12 tests pass (7 existing + 5 new)
- [x] New tests:
  - `test_timeout_killsProcess` — `sh -c "sleep 30"` is killed within 5s when timeout=500ms
  - `test_outputSizeExceeded_throwsExtractException` — 5 MiB stderr output capped at 1 MiB throws
  - `test_stderrDrained_doesNotDeadlock` — script writes 1 MiB to stderr without deadlock
  - `test_inputSizeExceeded_throwsExtractException` — 64 KiB input with cap=1 KiB throws
  - `test_processDescendants_killed` — `sh -c "sleep 30 & wait"` returns within 10s
- [x] `mvn -pl fess-crawler test` — no new failures vs master (pre-existing failures: JodExtractor needs LibreOffice, S3/SMB/Storage/Gcs need Docker)
- [x] `mvn formatter:format && mvn license:format` applied