### PR TITLE
feat(extractor): extract default HTML metadata + cache XPath expressions

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
@@ -18,14 +18,21 @@ package org.codelibs.fess.crawler.extractor.impl;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathEvaluationResult;
 import javax.xml.xpath.XPathException;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathNodes;
 
 import org.apache.logging.log4j.LogManager;
@@ -38,14 +45,39 @@ import org.codelibs.fess.crawler.util.XPathAPI;
 import org.codelibs.nekohtml.parsers.DOMParser;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.PostConstruct;
 
 /**
  * Extracts text content from HTML documents.
+ *
+ * <p>In addition to body text, this extractor populates {@link ExtractData} with a
+ * default set of HTML metadata (title, description, OpenGraph, Twitter Card,
+ * canonical, keywords, author) and parses {@code <script type="application/ld+json">}
+ * blocks. Both subsystems can be disabled via {@link #setExtractDefaultMetadata(boolean)}
+ * and {@link #setExtractJsonLd(boolean)}.</p>
+ *
+ * <p>Compiled {@link XPathExpression} instances are cached per thread to avoid
+ * re-parsing every XPath on each extraction.</p>
  */
 public class HtmlExtractor extends AbstractXmlExtractor {
     /** Logger for this class. */
     protected static final Logger logger = LogManager.getLogger(HtmlExtractor.class);
+
+    /** Metadata key holding raw JSON-LD strings. */
+    public static final String JSONLD_RAW_KEY = "jsonld.raw";
+
+    /** Metadata key holding {@code @type} values from JSON-LD blocks. */
+    public static final String JSONLD_TYPE_KEY = "jsonld.type";
+
+    /** XPath expression matching JSON-LD script blocks. */
+    protected static final String JSONLD_XPATH = "//SCRIPT[@type='application/ld+json']";
 
     /** Pattern for extracting charset from meta tags. */
     protected Pattern metaCharsetPattern = Pattern.compile("<meta.*content\\s*=\\s*['\"].*;\\s*charset=([\\w\\d\\-_]*)['\"]\\s*/?>",
@@ -68,14 +100,54 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     /** Map of metadata field names to their corresponding XPath expressions. */
     protected Map<String, String> metadataXpathMap = new HashMap<>();
 
+    /** Default metadata field rules (key -&gt; XPath expression). */
+    protected Map<String, String> defaultFieldRules;
+
+    /** Whether to extract default HTML metadata (title, description, OpenGraph, etc.). */
+    protected boolean extractDefaultMetadata = true;
+
+    /** Whether to extract JSON-LD ({@code <script type="application/ld+json">}) blocks. */
+    protected boolean extractJsonLd = true;
+
     /** Thread-local instance of XPathAPI for thread-safe XPath evaluation. */
     private final ThreadLocal<XPathAPI> xpathAPI = new ThreadLocal<>();
+
+    /** Per-thread cache of compiled XPath expressions. */
+    private final ThreadLocal<Map<String, XPathExpression>> threadLocalXPathCache = ThreadLocal.withInitial(HashMap::new);
+
+    /** Per-thread XPath used to compile cached expressions. */
+    private final ThreadLocal<XPath> threadLocalXPath = ThreadLocal.withInitial(() -> XPathFactory.newInstance().newXPath());
+
+    /** Lazily-initialised JSON parser for JSON-LD blocks. */
+    private volatile ObjectMapper objectMapper;
 
     /**
      * Creates a new HtmlExtractor instance.
      */
     public HtmlExtractor() {
         super();
+    }
+
+    /**
+     * Initialises default metadata field rules if none have been provided.
+     */
+    @PostConstruct
+    public void init() {
+        if (defaultFieldRules == null) {
+            final Map<String, String> rules = new LinkedHashMap<>();
+            rules.put("title", "//TITLE/text() | //META[@property='og:title']/@content");
+            rules.put("description", "//META[@name='description']/@content | //META[@property='og:description']/@content");
+            rules.put("og:title", "//META[@property='og:title']/@content");
+            rules.put("og:description", "//META[@property='og:description']/@content");
+            rules.put("og:image", "//META[@property='og:image']/@content");
+            rules.put("og:type", "//META[@property='og:type']/@content");
+            rules.put("og:url", "//META[@property='og:url']/@content");
+            rules.put("twitter:card", "//META[@name='twitter:card']/@content");
+            rules.put("canonical", "//LINK[@rel='canonical']/@href");
+            rules.put("keywords", "//META[@name='keywords']/@content");
+            rules.put("author", "//META[@name='author']/@content");
+            defaultFieldRules = rules;
+        }
     }
 
     @Override
@@ -95,6 +167,12 @@ public class HtmlExtractor extends AbstractXmlExtractor {
             metadataXpathMap.entrySet().stream().forEach(e -> {
                 extractData.putValues(e.getKey(), getStringsByXPath(document, e.getValue()));
             });
+            if (extractDefaultMetadata) {
+                applyDefaultFieldRules(document, extractData);
+            }
+            if (extractJsonLd) {
+                extractJsonLd(document, extractData);
+            }
             return extractData;
         } finally {
             xpathAPI.remove();
@@ -102,13 +180,219 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     }
 
     /**
+     * Applies the configured default-field rules, populating {@code extractData}
+     * with extracted values. Existing keys (set via
+     * {@link #addMetadata(String, String)}) are preserved.
+     *
+     * @param document the parsed HTML DOM
+     * @param extractData the extract data to populate
+     */
+    protected void applyDefaultFieldRules(final Document document, final ExtractData extractData) {
+        if (defaultFieldRules == null || defaultFieldRules.isEmpty()) {
+            return;
+        }
+        defaultFieldRules.forEach((key, xpath) -> {
+            if (extractData.getValues(key) != null) {
+                // already populated by a custom rule; do not overwrite
+                return;
+            }
+            final String[] values = getStringsByXPath(document, xpath);
+            final String[] nonBlank = Arrays.stream(values).filter(StringUtil::isNotBlank).map(String::trim).toArray(String[]::new);
+            if (nonBlank.length > 0) {
+                extractData.putValues(key, nonBlank);
+            }
+        });
+    }
+
+    /**
+     * Extracts JSON-LD blocks from the document. Each block's {@code @type}
+     * value (if present) is appended to {@link #JSONLD_TYPE_KEY}, and the raw
+     * JSON content is appended to {@link #JSONLD_RAW_KEY}. Malformed JSON is
+     * logged and skipped; the rest of the extraction proceeds normally.
+     *
+     * @param document the parsed HTML DOM
+     * @param extractData the extract data to populate
+     */
+    protected void extractJsonLd(final Document document, final ExtractData extractData) {
+        try {
+            final XPathExpression expr = getXPathExpression(JSONLD_XPATH);
+            final NodeList nodes = (NodeList) expr.evaluate(document, XPathConstants.NODESET);
+            if (nodes == null || nodes.getLength() == 0) {
+                return;
+            }
+            final List<String> rawList = new ArrayList<>();
+            final List<String> typeList = new ArrayList<>();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                final String raw = nodes.item(i).getTextContent();
+                if (StringUtil.isBlank(raw)) {
+                    continue;
+                }
+                final String trimmed = raw.trim();
+                rawList.add(trimmed);
+                collectJsonLdTypes(trimmed, typeList);
+            }
+            if (!rawList.isEmpty()) {
+                extractData.putValues(JSONLD_RAW_KEY, rawList.toArray(new String[0]));
+            }
+            if (!typeList.isEmpty()) {
+                extractData.putValues(JSONLD_TYPE_KEY, typeList.toArray(new String[0]));
+            }
+        } catch (final XPathException e) {
+            logger.warn("Failed to evaluate JSON-LD XPath.", e);
+        }
+    }
+
+    /**
+     * Parses the given JSON-LD string and appends any discovered {@code @type}
+     * values into {@code typeList}. Malformed JSON is logged and skipped.
+     *
+     * @param json the raw JSON-LD content
+     * @param typeList the list to append discovered {@code @type} values to
+     */
+    protected void collectJsonLdTypes(final String json, final List<String> typeList) {
+        final ObjectMapper mapper = getObjectMapper();
+        if (mapper == null) {
+            return;
+        }
+        try {
+            final JsonNode root = mapper.readTree(json);
+            if (root == null) {
+                return;
+            }
+            collectTypeNodes(root, typeList);
+        } catch (final JsonProcessingException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Skipping malformed JSON-LD block.", e);
+            } else {
+                logger.warn("Skipping malformed JSON-LD block: {}", e.getMessage());
+            }
+        } catch (final RuntimeException e) {
+            logger.warn("Failed to parse JSON-LD block.", e);
+        }
+    }
+
+    private void collectTypeNodes(final JsonNode node, final List<String> typeList) {
+        if (node == null) {
+            return;
+        }
+        if (node.isArray()) {
+            node.forEach(child -> collectTypeNodes(child, typeList));
+            return;
+        }
+        if (!node.isObject()) {
+            return;
+        }
+        final JsonNode typeNode = node.get("@type");
+        if (typeNode != null) {
+            if (typeNode.isTextual()) {
+                final String value = typeNode.asText();
+                if (StringUtil.isNotBlank(value)) {
+                    typeList.add(value);
+                }
+            } else if (typeNode.isArray()) {
+                typeNode.forEach(t -> {
+                    if (t.isTextual()) {
+                        final String value = t.asText();
+                        if (StringUtil.isNotBlank(value)) {
+                            typeList.add(value);
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    private ObjectMapper getObjectMapper() {
+        ObjectMapper mapper = objectMapper;
+        if (mapper == null) {
+            synchronized (this) {
+                mapper = objectMapper;
+                if (mapper == null) {
+                    mapper = new ObjectMapper();
+                    objectMapper = mapper;
+                }
+            }
+        }
+        return mapper;
+    }
+
+    /**
+     * Returns a compiled, cached {@link XPathExpression} for {@code expression}.
+     * Caching is per-thread, which keeps {@link XPathExpression} usage on the
+     * same thread that compiled it (the JDK does not document
+     * {@code XPathExpression} as thread-safe).
+     *
+     * @param expression the XPath expression to compile
+     * @return the compiled expression
+     * @throws CrawlerSystemException if {@code expression} fails to compile
+     */
+    protected XPathExpression getXPathExpression(final String expression) {
+        return threadLocalXPathCache.get().computeIfAbsent(expression, expr -> {
+            try {
+                return threadLocalXPath.get().compile(expr);
+            } catch (final XPathExpressionException e) {
+                throw new CrawlerSystemException("Failed to compile XPath: expression=" + expr, e);
+            }
+        });
+    }
+
+    /**
+     * Clears the per-thread XPath compilation cache for the calling thread.
+     * Use this if {@link #defaultFieldRules}, {@link #metadataXpathMap}, or
+     * {@link #contentXpath} change after the extractor has already processed
+     * documents on this thread.
+     */
+    public void clearXPathCache() {
+        threadLocalXPathCache.get().clear();
+    }
+
+    /**
      * Extracts strings from a document using the specified XPath expression.
+     * The compiled {@link XPathExpression} is cached per thread, so repeated
+     * calls with the same expression skip recompilation.
      *
      * @param document the DOM document to extract strings from
      * @param path the XPath expression to evaluate
      * @return an array of strings extracted from the document
      */
     protected String[] getStringsByXPath(final Document document, final String path) {
+        // Use the cached compiled expression to evaluate as a node-set first;
+        // node-set is the common case for both content and metadata XPaths.
+        try {
+            final XPathExpression expr = getXPathExpression(path);
+            final NodeList nodes = (NodeList) expr.evaluate(document, XPathConstants.NODESET);
+            if (nodes == null) {
+                return StringUtil.EMPTY_STRINGS;
+            }
+            final List<String> strList = new ArrayList<>(nodes.getLength());
+            for (int i = 0; i < nodes.getLength(); i++) {
+                final Node node = nodes.item(i);
+                if (node != null) {
+                    final String text = node.getTextContent();
+                    strList.add(text == null ? "" : text);
+                }
+            }
+            return strList.toArray(new String[0]);
+        } catch (final XPathException e) {
+            // Some XPath expressions (boolean(), count(), string(), ...) cannot
+            // be evaluated as a node-set. Fall back to the original path that
+            // handles every result type via XPathAPI.eval, which preserves the
+            // public behaviour for non-node-set expressions.
+            return evaluateNonNodeSet(document, path, e);
+        }
+    }
+
+    /**
+     * Fallback path for XPath expressions whose result type is not a node-set
+     * (e.g., {@code boolean()}, {@code count()}, {@code string()}). Returns
+     * the result coerced to one or more strings.
+     *
+     * @param document the DOM document to extract strings from
+     * @param path the XPath expression to evaluate
+     * @param previousFailure the failure raised by the node-set evaluation
+     * @return an array of strings extracted from the document
+     */
+    private String[] evaluateNonNodeSet(final Document document, final String path, final XPathException previousFailure) {
         try {
             final XPathEvaluationResult<?> xObj = getXPathAPI().eval(document, path);
             switch (xObj.type()) {
@@ -140,10 +424,9 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                 return new String[] { obj.toString() };
             }
         } catch (final XPathException e) {
-            logger.warn("Failed to parse the content by {}", path, e);
+            logger.warn("Failed to parse the content by {}", path, previousFailure);
             return StringUtil.EMPTY_STRINGS;
         }
-
     }
 
     /**
@@ -286,5 +569,64 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      */
     public void setPropertyMap(final Map<String, String> propertyMap) {
         this.propertyMap = propertyMap;
+    }
+
+    /**
+     * Gets the configured default-field rules (key -&gt; XPath).
+     *
+     * @return the default-field rules
+     */
+    public Map<String, String> getDefaultFieldRules() {
+        return defaultFieldRules;
+    }
+
+    /**
+     * Replaces the default-field rules used for default metadata extraction.
+     * A defensive copy is taken so subsequent mutations of the supplied map do
+     * not affect this extractor.
+     *
+     * @param defaultFieldRules the rules to use; if {@code null}, defaults are
+     *        re-initialised on the next call to {@link #init()}
+     */
+    public void setDefaultFieldRules(final Map<String, String> defaultFieldRules) {
+        this.defaultFieldRules = defaultFieldRules == null ? null : new LinkedHashMap<>(defaultFieldRules);
+    }
+
+    /**
+     * Returns whether default HTML metadata extraction is enabled.
+     *
+     * @return {@code true} if default metadata is extracted
+     */
+    public boolean isExtractDefaultMetadata() {
+        return extractDefaultMetadata;
+    }
+
+    /**
+     * Enables or disables default HTML metadata extraction (title, description,
+     * OpenGraph, Twitter Card, canonical, keywords, author).
+     *
+     * @param extractDefaultMetadata {@code true} to extract default metadata
+     */
+    public void setExtractDefaultMetadata(final boolean extractDefaultMetadata) {
+        this.extractDefaultMetadata = extractDefaultMetadata;
+    }
+
+    /**
+     * Returns whether JSON-LD extraction is enabled.
+     *
+     * @return {@code true} if JSON-LD blocks are extracted
+     */
+    public boolean isExtractJsonLd() {
+        return extractJsonLd;
+    }
+
+    /**
+     * Enables or disables JSON-LD extraction
+     * ({@code <script type="application/ld+json">}).
+     *
+     * @param extractJsonLd {@code true} to extract JSON-LD blocks
+     */
+    public void setExtractJsonLd(final boolean extractJsonLd) {
+        this.extractJsonLd = extractJsonLd;
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
@@ -20,9 +20,11 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -131,16 +133,20 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     protected static final int JSONLD_MAX_BLOCK_COUNT = 64;
 
     /**
-     * Maximum total raw JSON bytes (in characters) accepted across all JSON-LD
-     * script blocks in a single document. Processing stops with a WARN when
-     * adding the next block would exceed this limit.
+     * Maximum total raw JSON-LD size accepted across all script blocks in a
+     * single document, measured in characters (UTF-16 code units, not bytes;
+     * actual heap use may be roughly twice this value). Processing stops with a
+     * WARN when adding the next block would exceed this limit.
      */
-    protected static final int JSONLD_MAX_RAW_TOTAL_BYTES = 1 * 1024 * 1024; // 1 MiB
+    protected static final int JSONLD_MAX_RAW_TOTAL_BYTES = 1 * 1024 * 1024; // 1 MiB (characters)
 
     /**
-     * Maximum number of {@code @type} values collected from a single JSON-LD
-     * block. Recursion into {@code @graph} and nested entities stops once this
-     * limit is reached to prevent unbounded list growth.
+     * Maximum number of {@code @type} values collected per document across all
+     * JSON-LD blocks. Despite the historical name, the collected-type list is
+     * shared across every block in a document, so this bounds the per-document
+     * total rather than a per-block quota; recursion into {@code @graph} and
+     * nested entities stops once the limit is reached, preventing unbounded
+     * list growth.
      */
     protected static final int JSONLD_MAX_TYPES_PER_BLOCK = 256;
 
@@ -215,6 +221,17 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      * {@link #newXPath()}.
      */
     private final ThreadLocal<XPath> threadLocalXPath = ThreadLocal.withInitial(HtmlExtractor::newXPath);
+
+    /**
+     * Per-thread set of XPath expressions already known to evaluate to a
+     * non-node-set result (e.g. {@code string(...)}, {@code count(...)},
+     * {@code boolean(...)}). The result type of an XPath expression is fixed by
+     * the expression itself and is independent of the document, so once an
+     * expression has been observed to fail node-set evaluation it is routed
+     * straight to {@link #evaluateNonNodeSet} on subsequent documents instead of
+     * throwing and catching an {@link XPathExpressionException} per page.
+     */
+    private final ThreadLocal<Set<String>> threadLocalNonNodeSetPaths = ThreadLocal.withInitial(HashSet::new);
 
     /** Lazily-initialised JSON parser for JSON-LD blocks. */
     private volatile ObjectMapper objectMapper;
@@ -301,6 +318,7 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     public void destroy() {
         threadLocalXPathCache.remove();
         threadLocalXPath.remove();
+        threadLocalNonNodeSetPaths.remove();
         xpathAPI.remove();
     }
 
@@ -415,8 +433,10 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     /**
      * Extracts JSON-LD blocks from the document. Each block's {@code @type}
      * value (if present) is appended to {@link #JSONLD_TYPE_KEY}, and the raw
-     * JSON content is appended to {@link #JSONLD_RAW_KEY}. Malformed JSON is
-     * logged and skipped; the rest of the extraction proceeds normally.
+     * JSON content is appended to {@link #JSONLD_RAW_KEY}. A block whose JSON is
+     * malformed is logged and skipped for {@code @type} collection only; its raw
+     * text is still retained in {@link #JSONLD_RAW_KEY} and the rest of the
+     * extraction proceeds normally.
      *
      * <p>Existing values for {@link #JSONLD_RAW_KEY} or {@link #JSONLD_TYPE_KEY}
      * (typically populated by an operator-supplied
@@ -464,8 +484,8 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                     logger.warn("Skipping JSON-LD block due to DOM error.", ex);
                 }
             }
-            final boolean rawAlreadySet = extractData.getValues(JSONLD_RAW_KEY) != null;
-            final boolean typeAlreadySet = extractData.getValues(JSONLD_TYPE_KEY) != null;
+            final boolean rawAlreadySet = hasNonBlankValue(extractData.getValues(JSONLD_RAW_KEY));
+            final boolean typeAlreadySet = hasNonBlankValue(extractData.getValues(JSONLD_TYPE_KEY));
             if (!rawList.isEmpty() && !rawAlreadySet) {
                 extractData.putValues(JSONLD_RAW_KEY, rawList.toArray(new String[0]));
             } else if (rawAlreadySet && logger.isDebugEnabled()) {
@@ -635,13 +655,18 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     }
 
     /**
-     * Clears the per-thread XPath compilation cache for the calling thread.
-     * Use this if {@link #defaultFieldRules}, {@link #metadataXpathMap}, or
-     * {@link #contentXpath} change after the extractor has already processed
-     * documents on this thread.
+     * Clears the per-thread XPath compilation caches for the calling thread.
+     *
+     * <p>This is a memory-reclamation hook, not a correctness requirement: the
+     * caches are keyed by the XPath expression string, so changing
+     * {@link #defaultFieldRules}, {@link #metadataXpathMap}, or
+     * {@link #contentXpath} to use different expressions compiles the new
+     * expressions automatically on first use. Call this to release the compiled
+     * expressions of rules that are no longer in use on this thread.</p>
      */
     public void clearXPathCache() {
         threadLocalXPathCache.get().clear();
+        threadLocalNonNodeSetPaths.get().clear();
     }
 
     /**
@@ -665,6 +690,11 @@ public class HtmlExtractor extends AbstractXmlExtractor {
             logger.warn("Failed to parse the content by {}", path, e.getCause() != null ? e.getCause() : e);
             return StringUtil.EMPTY_STRINGS;
         }
+        if (threadLocalNonNodeSetPaths.get().contains(path)) {
+            // Result type is fixed by the expression, not the document: an expression
+            // already seen to be non-node-set skips the throwing node-set attempt.
+            return evaluateNonNodeSet(document, path, null);
+        }
         try {
             final NodeList nodes = (NodeList) expr.evaluate(document, XPathConstants.NODESET);
             if (nodes == null) {
@@ -687,18 +717,24 @@ public class HtmlExtractor extends AbstractXmlExtractor {
             }
             return strList.toArray(new String[0]);
         } catch (final XPathException e) {
+            // Non-node-set result (string()/count()/boolean()/...): remember the path so
+            // subsequent documents skip the failing node-set attempt instead of re-throwing.
+            threadLocalNonNodeSetPaths.get().add(path);
             return evaluateNonNodeSet(document, path, e);
         }
     }
 
     /**
      * Fallback path for XPath expressions whose result type is not a node-set.
-     * The {@code previousFailure} is added as a suppressed exception to any
-     * second failure so callers have full context.
+     * When {@code previousFailure} is non-null it is added as a suppressed
+     * exception to any second failure so callers have full context; it may be
+     * {@code null} when this path is entered directly for an expression already
+     * known to be non-node-set.
      *
      * @param document the DOM document to extract strings from
      * @param path the XPath expression to evaluate
-     * @param previousFailure the failure raised by the node-set evaluation
+     * @param previousFailure the failure raised by the node-set evaluation, or
+     *            {@code null} if the node-set attempt was skipped
      * @return an array of strings extracted from the document
      */
     private String[] evaluateNonNodeSet(final Document document, final String path, final XPathException previousFailure) {
@@ -719,15 +755,33 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                 return new String[] { str.trim() };
             case NODESET:
                 final XPathNodes nodeList = (XPathNodes) xObj.value();
-                final List<String> strList = new ArrayList<>();
+                final List<String> strList = new ArrayList<>(nodeList.size());
                 for (int i = 0; i < nodeList.size(); i++) {
                     final Node node = nodeList.get(i);
-                    strList.add(node.getTextContent());
+                    if (node == null) {
+                        continue;
+                    }
+                    try {
+                        final String text = node.getTextContent();
+                        strList.add(text == null ? "" : text);
+                    } catch (final DOMException ex) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Failed to read text from node {} for XPath {}", i, path, ex);
+                        }
+                    }
                 }
-                return strList.toArray(n -> new String[n]);
+                return strList.toArray(new String[0]);
             case NODE:
                 final Node node = (Node) xObj.value();
-                return new String[] { node.getTextContent() };
+                try {
+                    final String text = node.getTextContent();
+                    return new String[] { text == null ? "" : text };
+                } catch (final DOMException ex) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Failed to read text from node for XPath {}", path, ex);
+                    }
+                    return StringUtil.EMPTY_STRINGS;
+                }
             default:
                 Object obj = xObj.value();
                 if (obj == null) {
@@ -736,7 +790,9 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                 return new String[] { obj.toString() };
             }
         } catch (final XPathException e) {
-            e.addSuppressed(previousFailure);
+            if (previousFailure != null) {
+                e.addSuppressed(previousFailure);
+            }
             logger.warn("Failed to parse the content by {}", path, e);
             return StringUtil.EMPTY_STRINGS;
         }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
@@ -43,6 +43,7 @@ import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.util.XPathAPI;
 import org.codelibs.nekohtml.parsers.DOMParser;
+import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -67,6 +68,13 @@ import jakarta.annotation.PreDestroy;
  *
  * <p>Compiled {@link XPathExpression} instances are cached per thread to avoid
  * re-parsing every XPath on each extraction.</p>
+ *
+ * <p>Default field rules ({@link #defaultFieldRules}) are applied after custom
+ * {@link #metadataXpathMap} rules. Keys already populated with a non-blank value
+ * by a custom rule take precedence; keys with no value fall through to the default
+ * rule. After all primary default rules are applied, fallback rules
+ * ({@link #defaultFieldFallbackRules}) copy a value from another already-populated
+ * key when the target key is still missing a non-blank value.</p>
  */
 public class HtmlExtractor extends AbstractXmlExtractor {
     /** Logger for this class. */
@@ -115,6 +123,27 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     /** Maximum number length (in characters) the JSON-LD parser will accept. */
     protected static final int JSONLD_MAX_NUMBER_LENGTH = 1000;
 
+    /**
+     * Maximum number of JSON-LD script blocks to process per document.
+     * Blocks beyond this limit are silently truncated after a WARN log entry
+     * to avoid unbounded memory growth on adversarial pages.
+     */
+    protected static final int JSONLD_MAX_BLOCK_COUNT = 64;
+
+    /**
+     * Maximum total raw JSON bytes (in characters) accepted across all JSON-LD
+     * script blocks in a single document. Processing stops with a WARN when
+     * adding the next block would exceed this limit.
+     */
+    protected static final int JSONLD_MAX_RAW_TOTAL_BYTES = 1 * 1024 * 1024; // 1 MiB
+
+    /**
+     * Maximum number of {@code @type} values collected from a single JSON-LD
+     * block. Recursion into {@code @graph} and nested entities stops once this
+     * limit is reached to prevent unbounded list growth.
+     */
+    protected static final int JSONLD_MAX_TYPES_PER_BLOCK = 256;
+
     /** Pattern for extracting charset from meta tags. */
     protected Pattern metaCharsetPattern = Pattern.compile("<meta.*content\\s*=\\s*['\"].*;\\s*charset=([\\w\\d\\-_]*)['\"]\\s*/?>",
             Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
@@ -134,18 +163,30 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     protected String contentXpath = "//BODY";
 
     /** Map of metadata field names to their corresponding XPath expressions. */
-    protected Map<String, String> metadataXpathMap = new HashMap<>();
+    protected Map<String, String> metadataXpathMap = new LinkedHashMap<>();
 
-    /** Default metadata field rules (key -&gt; XPath expression). */
+    /** Default metadata field rules (key to XPath expression). */
     protected Map<String, String> defaultFieldRules;
+
+    /**
+     * Fallback rules applied after primary default-field rules. Each entry maps
+     * a target key to a source key: when the target key has no non-blank value
+     * after primary rules are applied, the value from the source key (if
+     * non-blank) is copied into the target. Typical use: fall back from
+     * {@code og:title} to populate {@code title} when no {@code <title>} element
+     * is present.
+     *
+     * <p>Fallback rules are independent of {@link #defaultFieldRules}. Replacing
+     * {@link #defaultFieldRules} via {@link #setDefaultFieldRules(Map)} does
+     * <em>not</em> reset this map; use {@link #setDefaultFieldFallbackRules(Map)}
+     * to customise or disable the fallback behaviour.</p>
+     */
+    protected Map<String, String> defaultFieldFallbackRules;
 
     /**
      * Whether to extract default HTML metadata (title, description, OpenGraph,
      * etc.). Defaults to {@code true}; new deployments get the default
-     * metadata set out of the box. Operators upgrading existing deployments
-     * who have configured custom metadata rules are warned at
-     * {@link #init()} when a custom rule key collides with a built-in
-     * default-rule key (see {@link #defaultFieldRules}).
+     * metadata set out of the box.
      */
     protected boolean extractDefaultMetadata = true;
 
@@ -159,7 +200,7 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      * Per-thread cache of compiled XPath expressions.
      *
      * <p>Note: ThreadLocals can pin the classloader of the values they hold to
-     * the threads that touched them — a known issue when this extractor is
+     * the threads that touched them a known issue when this extractor is
      * deployed inside a servlet container (Tomcat, etc.) and the application
      * is undeployed. See {@link #destroy()} for the calling-thread cleanup
      * hook and {@link #clearXPathCache()} for the per-thread cleanup hook
@@ -186,52 +227,62 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     }
 
     /**
-     * Initialises default metadata field rules if none have been provided and
-     * warns operators if any user-configured custom metadata rule key
-     * collides with a built-in default-rule key while
-     * {@link #extractDefaultMetadata} is enabled.
+     * Initialises default metadata field rules and fallback rules if none have
+     * been provided externally.
      */
     @PostConstruct
     public void init() {
         if (defaultFieldRules == null) {
-            final Map<String, String> rules = new LinkedHashMap<>();
-            rules.put("title", "//TITLE/text() | //META[@property='og:title']/@content");
-            rules.put("description", "//META[@name='description']/@content | //META[@property='og:description']/@content");
-            rules.put("og:title", "//META[@property='og:title']/@content");
-            rules.put("og:description", "//META[@property='og:description']/@content");
-            rules.put("og:image", "//META[@property='og:image']/@content");
-            rules.put("og:type", "//META[@property='og:type']/@content");
-            rules.put("og:url", "//META[@property='og:url']/@content");
-            rules.put("twitter:card", "//META[@name='twitter:card']/@content");
-            rules.put("canonical", "//LINK[@rel='canonical']/@href");
-            rules.put("keywords", "//META[@name='keywords']/@content");
-            rules.put("author", "//META[@name='author']/@content");
-            defaultFieldRules = rules;
+            defaultFieldRules = createDefaultFieldRules();
         }
-        warnOnMetadataKeyCollisions();
+        if (defaultFieldFallbackRules == null) {
+            defaultFieldFallbackRules = createDefaultFieldFallbackRules();
+        }
     }
 
     /**
-     * Logs a single WARN entry if {@link #extractDefaultMetadata} is enabled
-     * and the operator-configured {@code metadataXpathMap} declares any key
-     * that is also defined by {@link #defaultFieldRules}. Per-key custom rules
-     * still take precedence (see {@link #applyDefaultFieldRules}); the warning
-     * exists only to surface potentially surprising overlap to operators.
+     * Builds the built-in set of default field rules (key to XPath).
+     *
+     * <p>Subclasses may override this method to add, remove, or replace rules
+     * without requiring a DI configuration change.</p>
+     *
+     * @return a mutable {@link LinkedHashMap} of default field rules
      */
-    protected void warnOnMetadataKeyCollisions() {
-        if (!extractDefaultMetadata || defaultFieldRules == null || defaultFieldRules.isEmpty() || metadataXpathMap == null
-                || metadataXpathMap.isEmpty()) {
-            return;
-        }
-        final List<String> collisions =
-                metadataXpathMap.keySet().stream().filter(defaultFieldRules::containsKey).sorted().collect(Collectors.toList());
-        if (!collisions.isEmpty()) {
-            logger.warn(
-                    "HtmlExtractor: custom metadata rule key(s) {} collide with default-rule keys; "
-                            + "custom rules take precedence, but enabling extractDefaultMetadata may produce duplicates "
-                            + "or unexpected fallback behavior. Disable default metadata or rename custom keys to silence this warning.",
-                    collisions);
-        }
+    protected Map<String, String> createDefaultFieldRules() {
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("title", "//TITLE/text()");
+        rules.put("description", "//META[@name='description']/@content");
+        rules.put("og:title", "//META[@property='og:title']/@content");
+        rules.put("og:description", "//META[@property='og:description']/@content");
+        rules.put("og:image", "//META[@property='og:image']/@content");
+        rules.put("og:type", "//META[@property='og:type']/@content");
+        rules.put("og:url", "//META[@property='og:url']/@content");
+        rules.put("twitter:card", "//META[@name='twitter:card']/@content");
+        rules.put("twitter:title", "//META[@name='twitter:title']/@content");
+        rules.put("twitter:description", "//META[@name='twitter:description']/@content");
+        rules.put("twitter:image", "//META[@name='twitter:image']/@content");
+        rules.put("twitter:site", "//META[@name='twitter:site']/@content");
+        rules.put("canonical", "//LINK[@rel='canonical']/@href");
+        rules.put("keywords", "//META[@name='keywords']/@content");
+        rules.put("author", "//META[@name='author']/@content");
+        return rules;
+    }
+
+    /**
+     * Builds the built-in set of fallback field rules (target key to source key).
+     *
+     * <p>When a target key has no non-blank value after primary default rules are
+     * applied, the value from the mapped source key is copied in provided the
+     * source key was populated. The canonical use-case is supplying
+     * {@code og:title} as the title when no {@code <title>} element exists.</p>
+     *
+     * @return a mutable {@link LinkedHashMap} of fallback rules
+     */
+    protected Map<String, String> createDefaultFieldFallbackRules() {
+        final Map<String, String> rules = new LinkedHashMap<>();
+        rules.put("title", "og:title");
+        rules.put("description", "og:description");
+        return rules;
     }
 
     /**
@@ -300,11 +351,13 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      * with extracted values. Keys already populated with a non-blank value
      * (set via {@link #addMetadata(String, String)}) are preserved; keys whose
      * custom XPath returned no values or only blank strings fall back to the
-     * default rule. This matters because {@code metadataXpathMap} entries
-     * unconditionally call {@code putValues}, so even an empty XPath result
-     * leaves the key non-null in {@link ExtractData}; without the
-     * non-blank check, default backfills (notably {@code og:title} when
-     * {@code <title>} is missing) would be silently suppressed.
+     * default rule.
+     *
+     * <p>After primary rules are applied, {@link #defaultFieldFallbackRules}
+     * are evaluated: for each entry (targetKey to sourceKey), if the target key
+     * still has no non-blank value but the source key does, the source values are
+     * copied into the target. Custom rules always take precedence over both
+     * primary default rules and fallback rules.</p>
      *
      * @param document the parsed HTML DOM
      * @param extractData the extract data to populate
@@ -324,12 +377,28 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                 extractData.putValues(key, nonBlank);
             }
         });
+
+        // After primary rules, apply fallbacks for keys still missing non-blank values.
+        if (defaultFieldFallbackRules != null) {
+            defaultFieldFallbackRules.forEach((key, fallbackKey) -> {
+                if (hasNonBlankValue(extractData.getValues(key))) {
+                    return;
+                }
+                final String[] fallbackValues = extractData.getValues(fallbackKey);
+                if (hasNonBlankValue(fallbackValues)) {
+                    final String[] nonBlank =
+                            Arrays.stream(fallbackValues).filter(StringUtil::isNotBlank).map(String::trim).toArray(String[]::new);
+                    if (nonBlank.length > 0) {
+                        extractData.putValues(key, nonBlank);
+                    }
+                }
+            });
+        }
     }
 
     /**
      * Returns {@code true} if {@code values} contains at least one non-blank
-     * entry. Used by {@link #applyDefaultFieldRules} to decide whether a key
-     * is meaningfully populated by a custom rule.
+     * entry.
      */
     private static boolean hasNonBlankValue(final String[] values) {
         if (values == null || values.length == 0) {
@@ -352,10 +421,12 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      * <p>Existing values for {@link #JSONLD_RAW_KEY} or {@link #JSONLD_TYPE_KEY}
      * (typically populated by an operator-supplied
      * {@link #addMetadata(String, String)} rule that targets the same key) are
-     * preserved and not overwritten — matching the precedence rule used by
-     * {@link #applyDefaultFieldRules(Document, ExtractData)}. To re-enable
-     * automatic JSON-LD population in that case, drop the colliding custom
-     * rule or rename it.</p>
+     * preserved and not overwritten. To re-enable automatic JSON-LD population
+     * in that case, drop the colliding custom rule or rename it.</p>
+     *
+     * <p>Processing is bounded by {@link #JSONLD_MAX_BLOCK_COUNT},
+     * {@link #JSONLD_MAX_RAW_TOTAL_BYTES}, and {@link #JSONLD_MAX_TYPES_PER_BLOCK}
+     * to prevent unbounded memory growth on adversarial pages.</p>
      *
      * @param document the parsed HTML DOM
      * @param extractData the extract data to populate
@@ -369,28 +440,53 @@ public class HtmlExtractor extends AbstractXmlExtractor {
             }
             final List<String> rawList = new ArrayList<>();
             final List<String> typeList = new ArrayList<>();
+            long totalRawBytes = 0;
             for (int i = 0; i < nodes.getLength(); i++) {
-                final String raw = nodes.item(i).getTextContent();
-                if (StringUtil.isBlank(raw)) {
-                    continue;
+                if (rawList.size() >= JSONLD_MAX_BLOCK_COUNT) {
+                    logger.warn("JSON-LD block count exceeded {}, truncating.", JSONLD_MAX_BLOCK_COUNT);
+                    break;
                 }
-                final String trimmed = raw.trim();
-                rawList.add(trimmed);
-                collectJsonLdTypes(trimmed, typeList);
+                try {
+                    final String raw = nodes.item(i).getTextContent();
+                    if (StringUtil.isBlank(raw)) {
+                        continue;
+                    }
+                    final String trimmed = raw.trim();
+                    if (totalRawBytes + trimmed.length() > JSONLD_MAX_RAW_TOTAL_BYTES) {
+                        logger.warn("JSON-LD raw total size would exceed {} bytes, truncating.", JSONLD_MAX_RAW_TOTAL_BYTES);
+                        break;
+                    }
+                    totalRawBytes += trimmed.length();
+                    rawList.add(trimmed);
+                    collectJsonLdTypes(trimmed, typeList);
+                } catch (final RuntimeException ex) {
+                    // DOMException / NPE / etc. from a single node must not abort other blocks.
+                    logger.warn("Skipping JSON-LD block due to DOM error.", ex);
+                }
             }
-            if (!rawList.isEmpty() && extractData.getValues(JSONLD_RAW_KEY) == null) {
+            final boolean rawAlreadySet = extractData.getValues(JSONLD_RAW_KEY) != null;
+            final boolean typeAlreadySet = extractData.getValues(JSONLD_TYPE_KEY) != null;
+            if (!rawList.isEmpty() && !rawAlreadySet) {
                 extractData.putValues(JSONLD_RAW_KEY, rawList.toArray(new String[0]));
+            } else if (rawAlreadySet && logger.isDebugEnabled()) {
+                logger.debug("JSON-LD raw key already populated by custom rule; auto-fill skipped.");
             }
-            if (!typeList.isEmpty() && extractData.getValues(JSONLD_TYPE_KEY) == null) {
+            if (!typeList.isEmpty() && !typeAlreadySet) {
                 extractData.putValues(JSONLD_TYPE_KEY, typeList.toArray(new String[0]));
+            } else if (typeAlreadySet && logger.isDebugEnabled()) {
+                logger.debug("JSON-LD type key already populated by custom rule; auto-fill skipped.");
             }
         } catch (final XPathException e) {
             logger.warn("Failed to evaluate JSON-LD XPath.", e);
         } catch (final CrawlerSystemException e) {
-            // JSONLD_XPATH is a constant and should always compile, but keep
-            // the recovery symmetric with getStringsByXPath so a future change
-            // to the constant cannot abort the whole extraction.
+            // Defensive recovery: JSONLD_XPATH is a literal constant and should always
+            // compile, but a future edit to the constant must not abort the whole
+            // extraction. Keep the recovery symmetric with getStringsByXPath.
             logger.warn("Failed to compile JSON-LD XPath.", e.getCause() != null ? e.getCause() : e);
+        } catch (final RuntimeException e) {
+            // Defensive: any DOM-layer fault (DOMException, IllegalStateException, ...)
+            // must not abort the rest of the extraction (see method javadoc).
+            logger.warn("Failed to extract JSON-LD blocks.", e);
         }
     }
 
@@ -403,9 +499,6 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      */
     protected void collectJsonLdTypes(final String json, final List<String> typeList) {
         final ObjectMapper mapper = getObjectMapper();
-        if (mapper == null) {
-            return;
-        }
         try {
             final JsonNode root = mapper.readTree(json);
             if (root == null) {
@@ -416,7 +509,9 @@ public class HtmlExtractor extends AbstractXmlExtractor {
             if (logger.isDebugEnabled()) {
                 logger.debug("Skipping malformed JSON-LD block.", e);
             } else {
-                logger.warn("Skipping malformed JSON-LD block: {}", e.getMessage());
+                final String msg = e.getMessage();
+                final String safe = msg == null ? "(none)" : msg.replaceAll("[\\r\\n\\t]", " ");
+                logger.warn("Skipping malformed JSON-LD block: {}", safe);
             }
         } catch (final RuntimeException e) {
             logger.warn("Failed to parse JSON-LD block.", e);
@@ -426,7 +521,7 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     /**
      * Walks the JSON-LD tree and appends every {@code @type} value it finds.
      *
-     * <p>Real-world Schema.org markup commonly nests typed entities — for
+     * <p>Real-world Schema.org markup commonly nests typed entities, for
      * example WordPress/Yoast emit a top-level {@code @graph} array and other
      * pages embed typed entities under {@code mainEntity}, {@code author},
      * {@code publisher}, {@code itemListElement}, etc. The walk therefore
@@ -436,8 +531,8 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      * per the JSON-LD specification.</p>
      *
      * <p>Recursion depth is implicitly bounded by the parser's
-     * {@link #JSONLD_MAX_NESTING_DEPTH}, so a hostile document cannot drive
-     * this walk into stack exhaustion.</p>
+     * {@link #JSONLD_MAX_NESTING_DEPTH}. Collection stops once
+     * {@link #JSONLD_MAX_TYPES_PER_BLOCK} entries have been added.</p>
      */
     private void collectTypeNodes(final JsonNode node, final List<String> typeList) {
         if (node == null) {
@@ -455,6 +550,9 @@ public class HtmlExtractor extends AbstractXmlExtractor {
             if (typeNode.isTextual()) {
                 final String value = typeNode.asText();
                 if (StringUtil.isNotBlank(value)) {
+                    if (typeList.size() >= JSONLD_MAX_TYPES_PER_BLOCK) {
+                        return;
+                    }
                     typeList.add(value);
                 }
             } else if (typeNode.isArray()) {
@@ -462,6 +560,9 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                     if (t.isTextual()) {
                         final String value = t.asText();
                         if (StringUtil.isNotBlank(value)) {
+                            if (typeList.size() >= JSONLD_MAX_TYPES_PER_BLOCK) {
+                                return;
+                            }
                             typeList.add(value);
                         }
                     }
@@ -475,6 +576,9 @@ public class HtmlExtractor extends AbstractXmlExtractor {
         node.fields().forEachRemaining(field -> {
             final String fieldName = field.getKey();
             if ("@type".equals(fieldName) || "@context".equals(fieldName)) {
+                return;
+            }
+            if (typeList.size() >= JSONLD_MAX_TYPES_PER_BLOCK) {
                 return;
             }
             collectTypeNodes(field.getValue(), typeList);
@@ -545,28 +649,19 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      * The compiled {@link XPathExpression} is cached per thread, so repeated
      * calls with the same expression skip recompilation.
      *
-     * <p>A malformed XPath expression — whether it fails to compile or fails
-     * to evaluate — is logged at {@code WARN} and an empty array is returned,
-     * matching the pre-cache behaviour. Callers like
-     * {@link #createExtractData(String)} therefore never abort the whole
-     * extraction because of a single misconfigured rule in
-     * {@link #contentXpath} or {@link #metadataXpathMap}.</p>
+     * <p>A malformed XPath expression is logged at {@code WARN} and an empty
+     * array is returned, so callers never abort the whole extraction because
+     * of a single misconfigured rule.</p>
      *
      * @param document the DOM document to extract strings from
      * @param path the XPath expression to evaluate
      * @return an array of strings extracted from the document
      */
     protected String[] getStringsByXPath(final Document document, final String path) {
-        // Use the cached compiled expression to evaluate as a node-set first;
-        // node-set is the common case for both content and metadata XPaths.
         final XPathExpression expr;
         try {
             expr = getXPathExpression(path);
         } catch (final CrawlerSystemException e) {
-            // Compile failure of a malformed XPath. Restore the pre-cache
-            // behaviour where XPathAPI.eval would have thrown XPathException
-            // here and we logged + returned empty rather than propagating the
-            // failure out of createExtractData.
             logger.warn("Failed to parse the content by {}", path, e.getCause() != null ? e.getCause() : e);
             return StringUtil.EMPTY_STRINGS;
         }
@@ -578,25 +673,28 @@ public class HtmlExtractor extends AbstractXmlExtractor {
             final List<String> strList = new ArrayList<>(nodes.getLength());
             for (int i = 0; i < nodes.getLength(); i++) {
                 final Node node = nodes.item(i);
-                if (node != null) {
+                if (node == null) {
+                    continue;
+                }
+                try {
                     final String text = node.getTextContent();
                     strList.add(text == null ? "" : text);
+                } catch (final DOMException ex) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Failed to read text from node {} for XPath {}", i, path, ex);
+                    }
                 }
             }
             return strList.toArray(new String[0]);
         } catch (final XPathException e) {
-            // Some XPath expressions (boolean(), count(), string(), ...) cannot
-            // be evaluated as a node-set. Fall back to the original path that
-            // handles every result type via XPathAPI.eval, which preserves the
-            // public behaviour for non-node-set expressions.
             return evaluateNonNodeSet(document, path, e);
         }
     }
 
     /**
-     * Fallback path for XPath expressions whose result type is not a node-set
-     * (e.g., {@code boolean()}, {@code count()}, {@code string()}). Returns
-     * the result coerced to one or more strings.
+     * Fallback path for XPath expressions whose result type is not a node-set.
+     * The {@code previousFailure} is added as a suppressed exception to any
+     * second failure so callers have full context.
      *
      * @param document the DOM document to extract strings from
      * @param path the XPath expression to evaluate
@@ -604,6 +702,9 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      * @return an array of strings extracted from the document
      */
     private String[] evaluateNonNodeSet(final Document document, final String path, final XPathException previousFailure) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("XPath '{}' evaluated as non-node-set (fallback path).", path);
+        }
         try {
             final XPathEvaluationResult<?> xObj = getXPathAPI().eval(document, path);
             switch (xObj.type()) {
@@ -635,7 +736,8 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                 return new String[] { obj.toString() };
             }
         } catch (final XPathException e) {
-            logger.warn("Failed to parse the content by {}", path, previousFailure);
+            e.addSuppressed(previousFailure);
+            logger.warn("Failed to parse the content by {}", path, e);
             return StringUtil.EMPTY_STRINGS;
         }
     }
@@ -783,7 +885,7 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     }
 
     /**
-     * Gets the configured default-field rules (key -&gt; XPath).
+     * Gets the configured default-field rules (key to XPath).
      *
      * @return the default-field rules
      */
@@ -794,13 +896,37 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     /**
      * Replaces the default-field rules used for default metadata extraction.
      * A defensive copy is taken so subsequent mutations of the supplied map do
-     * not affect this extractor.
+     * not affect this extractor. Passing {@code null} immediately re-initialises
+     * the built-in defaults via {@link #createDefaultFieldRules()}.
      *
-     * @param defaultFieldRules the rules to use; if {@code null}, defaults are
-     *        re-initialised on the next call to {@link #init()}
+     * @param defaultFieldRules the rules to use; if {@code null}, the built-in
+     *        defaults are restored immediately
      */
     public void setDefaultFieldRules(final Map<String, String> defaultFieldRules) {
-        this.defaultFieldRules = defaultFieldRules == null ? null : new LinkedHashMap<>(defaultFieldRules);
+        this.defaultFieldRules = defaultFieldRules == null ? createDefaultFieldRules() : new LinkedHashMap<>(defaultFieldRules);
+    }
+
+    /**
+     * Gets the configured default-field fallback rules (target key to source key).
+     *
+     * @return the default-field fallback rules
+     */
+    public Map<String, String> getDefaultFieldFallbackRules() {
+        return defaultFieldFallbackRules;
+    }
+
+    /**
+     * Replaces the default-field fallback rules. A defensive copy is taken so
+     * subsequent mutations of the supplied map do not affect this extractor.
+     * Passing {@code null} immediately re-initialises the built-in fallback
+     * defaults via {@link #createDefaultFieldFallbackRules()}.
+     *
+     * @param defaultFieldFallbackRules the fallback rules to use; if {@code null},
+     *        the built-in fallback defaults are restored immediately
+     */
+    public void setDefaultFieldFallbackRules(final Map<String, String> defaultFieldFallbackRules) {
+        this.defaultFieldFallbackRules =
+                defaultFieldFallbackRules == null ? createDefaultFieldFallbackRules() : new LinkedHashMap<>(defaultFieldFallbackRules);
     }
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
@@ -78,8 +78,18 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     /** Metadata key holding {@code @type} values from JSON-LD blocks. */
     public static final String JSONLD_TYPE_KEY = "jsonld.type";
 
-    /** XPath expression matching JSON-LD script blocks. */
-    protected static final String JSONLD_XPATH = "//SCRIPT[@type='application/ld+json']";
+    /**
+     * XPath expression matching JSON-LD script blocks.
+     *
+     * <p>Per RFC 6838 / HTML5, MIME types are case-insensitive and may carry
+     * surrounding whitespace, so {@code <script type="Application/LD+JSON">}
+     * and {@code <script type=" application/ld+json ">} must also match.
+     * NekoHTML uppercases element names but preserves attribute values
+     * verbatim, hence the explicit {@code translate(normalize-space(...))}
+     * normalisation here.</p>
+     */
+    protected static final String JSONLD_XPATH = "//SCRIPT[translate(normalize-space(@type),"
+            + "'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='application/ld+json']";
 
     /**
      * Single shared {@link XPathFactory}. {@code XPathFactory} itself is not
@@ -287,8 +297,14 @@ public class HtmlExtractor extends AbstractXmlExtractor {
 
     /**
      * Applies the configured default-field rules, populating {@code extractData}
-     * with extracted values. Existing keys (set via
-     * {@link #addMetadata(String, String)}) are preserved.
+     * with extracted values. Keys already populated with a non-blank value
+     * (set via {@link #addMetadata(String, String)}) are preserved; keys whose
+     * custom XPath returned no values or only blank strings fall back to the
+     * default rule. This matters because {@code metadataXpathMap} entries
+     * unconditionally call {@code putValues}, so even an empty XPath result
+     * leaves the key non-null in {@link ExtractData}; without the
+     * non-blank check, default backfills (notably {@code og:title} when
+     * {@code <title>} is missing) would be silently suppressed.
      *
      * @param document the parsed HTML DOM
      * @param extractData the extract data to populate
@@ -298,8 +314,8 @@ public class HtmlExtractor extends AbstractXmlExtractor {
             return;
         }
         defaultFieldRules.forEach((key, xpath) -> {
-            if (extractData.getValues(key) != null) {
-                // already populated by a custom rule; do not overwrite
+            if (hasNonBlankValue(extractData.getValues(key))) {
+                // already populated with a non-blank value by a custom rule; do not overwrite
                 return;
             }
             final String[] values = getStringsByXPath(document, xpath);
@@ -308,6 +324,23 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                 extractData.putValues(key, nonBlank);
             }
         });
+    }
+
+    /**
+     * Returns {@code true} if {@code values} contains at least one non-blank
+     * entry. Used by {@link #applyDefaultFieldRules} to decide whether a key
+     * is meaningfully populated by a custom rule.
+     */
+    private static boolean hasNonBlankValue(final String[] values) {
+        if (values == null || values.length == 0) {
+            return false;
+        }
+        for (final String value : values) {
+            if (StringUtil.isNotBlank(value)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
@@ -316,6 +316,14 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      * JSON content is appended to {@link #JSONLD_RAW_KEY}. Malformed JSON is
      * logged and skipped; the rest of the extraction proceeds normally.
      *
+     * <p>Existing values for {@link #JSONLD_RAW_KEY} or {@link #JSONLD_TYPE_KEY}
+     * (typically populated by an operator-supplied
+     * {@link #addMetadata(String, String)} rule that targets the same key) are
+     * preserved and not overwritten — matching the precedence rule used by
+     * {@link #applyDefaultFieldRules(Document, ExtractData)}. To re-enable
+     * automatic JSON-LD population in that case, drop the colliding custom
+     * rule or rename it.</p>
+     *
      * @param document the parsed HTML DOM
      * @param extractData the extract data to populate
      */
@@ -337,14 +345,19 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                 rawList.add(trimmed);
                 collectJsonLdTypes(trimmed, typeList);
             }
-            if (!rawList.isEmpty()) {
+            if (!rawList.isEmpty() && extractData.getValues(JSONLD_RAW_KEY) == null) {
                 extractData.putValues(JSONLD_RAW_KEY, rawList.toArray(new String[0]));
             }
-            if (!typeList.isEmpty()) {
+            if (!typeList.isEmpty() && extractData.getValues(JSONLD_TYPE_KEY) == null) {
                 extractData.putValues(JSONLD_TYPE_KEY, typeList.toArray(new String[0]));
             }
         } catch (final XPathException e) {
             logger.warn("Failed to evaluate JSON-LD XPath.", e);
+        } catch (final CrawlerSystemException e) {
+            // JSONLD_XPATH is a constant and should always compile, but keep
+            // the recovery symmetric with getStringsByXPath so a future change
+            // to the constant cannot abort the whole extraction.
+            logger.warn("Failed to compile JSON-LD XPath.", e.getCause() != null ? e.getCause() : e);
         }
     }
 
@@ -377,6 +390,22 @@ public class HtmlExtractor extends AbstractXmlExtractor {
         }
     }
 
+    /**
+     * Walks the JSON-LD tree and appends every {@code @type} value it finds.
+     *
+     * <p>Real-world Schema.org markup commonly nests typed entities — for
+     * example WordPress/Yoast emit a top-level {@code @graph} array and other
+     * pages embed typed entities under {@code mainEntity}, {@code author},
+     * {@code publisher}, {@code itemListElement}, etc. The walk therefore
+     * recurses into every object child except {@code @context} (which holds
+     * vocabulary term definitions, not data). {@code @type} itself is not
+     * recursed into because its value is always a string or array of strings
+     * per the JSON-LD specification.</p>
+     *
+     * <p>Recursion depth is implicitly bounded by the parser's
+     * {@link #JSONLD_MAX_NESTING_DEPTH}, so a hostile document cannot drive
+     * this walk into stack exhaustion.</p>
+     */
     private void collectTypeNodes(final JsonNode node, final List<String> typeList) {
         if (node == null) {
             return;
@@ -406,6 +435,17 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                 });
             }
         }
+        // Recurse into every other child so nested typed entities (notably
+        // @graph, mainEntity, author, publisher, itemListElement, ...) also
+        // contribute their @type values. Skip @type (already handled) and
+        // @context (vocabulary term definitions, not data).
+        node.fields().forEachRemaining(field -> {
+            final String fieldName = field.getKey();
+            if ("@type".equals(fieldName) || "@context".equals(fieldName)) {
+                return;
+            }
+            collectTypeNodes(field.getValue(), typeList);
+        });
     }
 
     /**
@@ -472,6 +512,13 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      * The compiled {@link XPathExpression} is cached per thread, so repeated
      * calls with the same expression skip recompilation.
      *
+     * <p>A malformed XPath expression — whether it fails to compile or fails
+     * to evaluate — is logged at {@code WARN} and an empty array is returned,
+     * matching the pre-cache behaviour. Callers like
+     * {@link #createExtractData(String)} therefore never abort the whole
+     * extraction because of a single misconfigured rule in
+     * {@link #contentXpath} or {@link #metadataXpathMap}.</p>
+     *
      * @param document the DOM document to extract strings from
      * @param path the XPath expression to evaluate
      * @return an array of strings extracted from the document
@@ -479,8 +526,18 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     protected String[] getStringsByXPath(final Document document, final String path) {
         // Use the cached compiled expression to evaluate as a node-set first;
         // node-set is the common case for both content and metadata XPaths.
+        final XPathExpression expr;
         try {
-            final XPathExpression expr = getXPathExpression(path);
+            expr = getXPathExpression(path);
+        } catch (final CrawlerSystemException e) {
+            // Compile failure of a malformed XPath. Restore the pre-cache
+            // behaviour where XPathAPI.eval would have thrown XPathException
+            // here and we logged + returned empty rather than propagating the
+            // failure out of createExtractData.
+            logger.warn("Failed to parse the content by {}", path, e.getCause() != null ? e.getCause() : e);
+            return StringUtil.EMPTY_STRINGS;
+        }
+        try {
             final NodeList nodes = (NodeList) expr.evaluate(document, XPathConstants.NODESET);
             if (nodes == null) {
                 return StringUtil.EMPTY_STRINGS;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
@@ -49,10 +49,12 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 
 /**
  * Extracts text content from HTML documents.
@@ -79,6 +81,30 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     /** XPath expression matching JSON-LD script blocks. */
     protected static final String JSONLD_XPATH = "//SCRIPT[@type='application/ld+json']";
 
+    /**
+     * Single shared {@link XPathFactory}. {@code XPathFactory} itself is not
+     * documented as thread-safe, so calls to {@link XPathFactory#newXPath()}
+     * are synchronised on the factory in {@link #newXPath()}. Each thread still
+     * owns its own {@link XPath} instance via {@link #threadLocalXPath}, since
+     * {@code XPath} is also not guaranteed thread-safe.
+     */
+    private static final XPathFactory XPATH_FACTORY = XPathFactory.newInstance();
+
+    /**
+     * Maximum nesting depth for parsed JSON-LD objects. Pathological inputs
+     * with deeper nesting are rejected to avoid stack/heap exhaustion DoS.
+     */
+    protected static final int JSONLD_MAX_NESTING_DEPTH = 64;
+
+    /**
+     * Maximum total string length (in characters) the JSON-LD parser will
+     * accept for any single token / value.
+     */
+    protected static final int JSONLD_MAX_STRING_LENGTH = 10 * 1024 * 1024;
+
+    /** Maximum number length (in characters) the JSON-LD parser will accept. */
+    protected static final int JSONLD_MAX_NUMBER_LENGTH = 1000;
+
     /** Pattern for extracting charset from meta tags. */
     protected Pattern metaCharsetPattern = Pattern.compile("<meta.*content\\s*=\\s*['\"].*;\\s*charset=([\\w\\d\\-_]*)['\"]\\s*/?>",
             Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
@@ -103,7 +129,14 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     /** Default metadata field rules (key -&gt; XPath expression). */
     protected Map<String, String> defaultFieldRules;
 
-    /** Whether to extract default HTML metadata (title, description, OpenGraph, etc.). */
+    /**
+     * Whether to extract default HTML metadata (title, description, OpenGraph,
+     * etc.). Defaults to {@code true}; new deployments get the default
+     * metadata set out of the box. Operators upgrading existing deployments
+     * who have configured custom metadata rules are warned at
+     * {@link #init()} when a custom rule key collides with a built-in
+     * default-rule key (see {@link #defaultFieldRules}).
+     */
     protected boolean extractDefaultMetadata = true;
 
     /** Whether to extract JSON-LD ({@code <script type="application/ld+json">}) blocks. */
@@ -112,11 +145,25 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     /** Thread-local instance of XPathAPI for thread-safe XPath evaluation. */
     private final ThreadLocal<XPathAPI> xpathAPI = new ThreadLocal<>();
 
-    /** Per-thread cache of compiled XPath expressions. */
+    /**
+     * Per-thread cache of compiled XPath expressions.
+     *
+     * <p>Note: ThreadLocals can pin the classloader of the values they hold to
+     * the threads that touched them — a known issue when this extractor is
+     * deployed inside a servlet container (Tomcat, etc.) and the application
+     * is undeployed. See {@link #destroy()} for the calling-thread cleanup
+     * hook and {@link #clearXPathCache()} for the per-thread cleanup hook
+     * callers can invoke from worker threads.</p>
+     */
     private final ThreadLocal<Map<String, XPathExpression>> threadLocalXPathCache = ThreadLocal.withInitial(HashMap::new);
 
-    /** Per-thread XPath used to compile cached expressions. */
-    private final ThreadLocal<XPath> threadLocalXPath = ThreadLocal.withInitial(() -> XPathFactory.newInstance().newXPath());
+    /**
+     * Per-thread {@link XPath} used to compile cached expressions. {@code XPath}
+     * is not documented as thread-safe; the underlying {@link XPathFactory} is
+     * shared statically (see {@link #XPATH_FACTORY}) and accessed via
+     * {@link #newXPath()}.
+     */
+    private final ThreadLocal<XPath> threadLocalXPath = ThreadLocal.withInitial(HtmlExtractor::newXPath);
 
     /** Lazily-initialised JSON parser for JSON-LD blocks. */
     private volatile ObjectMapper objectMapper;
@@ -129,7 +176,10 @@ public class HtmlExtractor extends AbstractXmlExtractor {
     }
 
     /**
-     * Initialises default metadata field rules if none have been provided.
+     * Initialises default metadata field rules if none have been provided and
+     * warns operators if any user-configured custom metadata rule key
+     * collides with a built-in default-rule key while
+     * {@link #extractDefaultMetadata} is enabled.
      */
     @PostConstruct
     public void init() {
@@ -147,6 +197,62 @@ public class HtmlExtractor extends AbstractXmlExtractor {
             rules.put("keywords", "//META[@name='keywords']/@content");
             rules.put("author", "//META[@name='author']/@content");
             defaultFieldRules = rules;
+        }
+        warnOnMetadataKeyCollisions();
+    }
+
+    /**
+     * Logs a single WARN entry if {@link #extractDefaultMetadata} is enabled
+     * and the operator-configured {@code metadataXpathMap} declares any key
+     * that is also defined by {@link #defaultFieldRules}. Per-key custom rules
+     * still take precedence (see {@link #applyDefaultFieldRules}); the warning
+     * exists only to surface potentially surprising overlap to operators.
+     */
+    protected void warnOnMetadataKeyCollisions() {
+        if (!extractDefaultMetadata || defaultFieldRules == null || defaultFieldRules.isEmpty() || metadataXpathMap == null
+                || metadataXpathMap.isEmpty()) {
+            return;
+        }
+        final List<String> collisions =
+                metadataXpathMap.keySet().stream().filter(defaultFieldRules::containsKey).sorted().collect(Collectors.toList());
+        if (!collisions.isEmpty()) {
+            logger.warn(
+                    "HtmlExtractor: custom metadata rule key(s) {} collide with default-rule keys; "
+                            + "custom rules take precedence, but enabling extractDefaultMetadata may produce duplicates "
+                            + "or unexpected fallback behavior. Disable default metadata or rename custom keys to silence this warning.",
+                    collisions);
+        }
+    }
+
+    /**
+     * Releases ThreadLocal references held on the calling thread.
+     *
+     * <p><b>Limitation:</b> a single invocation only clears the thread that
+     * actually calls {@code destroy()}. In a typical servlet container
+     * lifecycle this is the container management thread, not the worker
+     * threads where the cache was populated; those workers must call
+     * {@link #clearXPathCache()} (or be retired) to release their entries.
+     * Container-driven destroy is still useful because it removes the
+     * references owned by the management thread itself, which is often the
+     * root cause of classloader pinning at undeploy time.</p>
+     */
+    @PreDestroy
+    public void destroy() {
+        threadLocalXPathCache.remove();
+        threadLocalXPath.remove();
+        xpathAPI.remove();
+    }
+
+    /**
+     * Returns a freshly created {@link XPath} instance, synchronising on the
+     * shared {@link XPathFactory} since {@code XPathFactory} is not documented
+     * as thread-safe.
+     *
+     * @return a new {@link XPath} instance
+     */
+    private static XPath newXPath() {
+        synchronized (XPATH_FACTORY) {
+            return XPATH_FACTORY.newXPath();
         }
     }
 
@@ -302,6 +408,15 @@ public class HtmlExtractor extends AbstractXmlExtractor {
         }
     }
 
+    /**
+     * Returns the lazily-initialised {@link ObjectMapper} used to parse
+     * JSON-LD blocks. The mapper is configured with strict
+     * {@link StreamReadConstraints} so a hostile site cannot drive the
+     * extractor into stack/heap exhaustion via deeply nested JSON, oversized
+     * strings, or oversized numbers.
+     *
+     * @return the singleton {@link ObjectMapper}
+     */
     private ObjectMapper getObjectMapper() {
         ObjectMapper mapper = objectMapper;
         if (mapper == null) {
@@ -309,6 +424,12 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                 mapper = objectMapper;
                 if (mapper == null) {
                     mapper = new ObjectMapper();
+                    final StreamReadConstraints constraints = StreamReadConstraints.builder()
+                            .maxNestingDepth(JSONLD_MAX_NESTING_DEPTH)
+                            .maxStringLength(JSONLD_MAX_STRING_LENGTH)
+                            .maxNumberLength(JSONLD_MAX_NUMBER_LENGTH)
+                            .build();
+                    mapper.getFactory().setStreamReadConstraints(constraints);
                     objectMapper = mapper;
                 }
             }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
@@ -64,9 +64,11 @@ import jakarta.annotation.PreDestroy;
  *
  * <p>In addition to body text, this extractor populates {@link ExtractData} with a
  * default set of HTML metadata (title, description, OpenGraph, Twitter Card,
- * canonical, keywords, author) and parses {@code <script type="application/ld+json">}
- * blocks. Both subsystems can be disabled via {@link #setExtractDefaultMetadata(boolean)}
- * and {@link #setExtractJsonLd(boolean)}.</p>
+ * canonical, keywords, author); this is enabled by default and can be disabled via
+ * {@link #setExtractDefaultMetadata(boolean)}. It can also parse
+ * {@code <script type="application/ld+json">} blocks into {@code jsonld.type} and
+ * {@code jsonld.raw}; this is opt-in (disabled by default) and enabled via
+ * {@link #setExtractJsonLd(boolean)}.</p>
  *
  * <p>Compiled {@link XPathExpression} instances are cached per thread to avoid
  * re-parsing every XPath on each extraction.</p>
@@ -196,8 +198,14 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      */
     protected boolean extractDefaultMetadata = true;
 
-    /** Whether to extract JSON-LD ({@code <script type="application/ld+json">}) blocks. */
-    protected boolean extractJsonLd = true;
+    /**
+     * Whether to extract JSON-LD ({@code <script type="application/ld+json">})
+     * blocks. Defaults to {@code false}: JSON-LD extraction is opt-in because the
+     * raw JSON payload can be large and, on the file-crawl path, would otherwise
+     * be folded into the indexed full-text content field. Enable it with
+     * {@link #setExtractJsonLd(boolean) setExtractJsonLd(true)}.
+     */
+    protected boolean extractJsonLd = false;
 
     /** Thread-local instance of XPathAPI for thread-safe XPath evaluation. */
     private final ThreadLocal<XPathAPI> xpathAPI = new ThreadLocal<>();

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
@@ -64,7 +64,12 @@ public class HtmlExtractorTest extends PlainTestCase {
 
     private HtmlExtractor newExtractor() {
         StandardCrawlerContainer container = new StandardCrawlerContainer().singleton("htmlExtractor2", HtmlExtractor.class);
-        return container.getComponent("htmlExtractor2");
+        final HtmlExtractor extractor = container.getComponent("htmlExtractor2");
+        // JSON-LD extraction is opt-in in production (extractJsonLd defaults to false);
+        // the JSON-LD feature tests below exercise it, so enable it here. The
+        // production default is pinned by test_jsonLdDisabledByDefault.
+        extractor.setExtractJsonLd(true);
+        return extractor;
     }
 
     private static InputStream toStream(final String html) {
@@ -359,6 +364,23 @@ public class HtmlExtractorTest extends PlainTestCase {
 
         Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_TYPE_KEY), "jsonld.type must be absent when JSON-LD disabled");
         Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_RAW_KEY), "jsonld.raw must be absent when JSON-LD disabled");
+    }
+
+    @Test
+    public void test_jsonLdDisabledByDefault() {
+        // JSON-LD extraction is opt-in: a production-default extractor (NOT the
+        // JSON-LD-enabled newExtractor() helper) must not populate jsonld.* keys,
+        // while default HTML metadata is still extracted.
+        final StandardCrawlerContainer container = new StandardCrawlerContainer().singleton("htmlExtractorDefault", HtmlExtractor.class);
+        final HtmlExtractor extractor = container.getComponent("htmlExtractorDefault");
+        final String html = "<html><head><title>T</title>" + "<script type=\"application/ld+json\">{\"@type\":\"Article\"}</script>"
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_TYPE_KEY), "jsonld.type must be absent by default (opt-in)");
+        Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_RAW_KEY), "jsonld.raw must be absent by default (opt-in)");
+        // Default HTML metadata extraction stays on by default.
+        assertEquals("T", data.getValues("title")[0]);
     }
 
     @Test

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
@@ -20,11 +20,11 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -275,6 +275,59 @@ public class HtmlExtractorTest extends PlainTestCase {
         // clearXPathCache() should empty the cache.
         extractor.clearXPathCache();
         Assertions.assertTrue(cache.isEmpty(), "cache must be empty after clearXPathCache");
+    }
+
+    @Test
+    public void test_nonNodeSetXPathRoutingIsCachedAndStable() throws Exception {
+        // A non-node-set rule (string(...)) is evaluated via the fallback path. The
+        // primary node-set attempt throws once; the expression is then remembered so
+        // subsequent documents skip the throwing attempt. Output must stay correct either way.
+        final HtmlExtractor extractor = newExtractor();
+        extractor.setExtractDefaultMetadata(false);
+        extractor.setExtractJsonLd(false);
+        extractor.addMetadata("titleStr", "string(//TITLE)");
+        final String html1 = "<html><head><title>First</title></head><body>b</body></html>";
+        final String html2 = "<html><head><title>Second</title></head><body>b</body></html>";
+
+        // First call: primary NODESET attempt throws, falls back, records the path.
+        final ExtractData d1 = extractor.getText(toStream(html1), null);
+        assertEquals("First", d1.getValues("titleStr")[0]);
+
+        // The non-node-set expression must now be remembered for this thread.
+        final Field pathsField = HtmlExtractor.class.getDeclaredField("threadLocalNonNodeSetPaths");
+        pathsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        final ThreadLocal<Set<String>> tl = (ThreadLocal<Set<String>>) pathsField.get(extractor);
+        Assertions.assertTrue(tl.get().contains("string(//TITLE)"), "non-node-set path must be cached: " + tl.get());
+
+        // Second call: takes the cached fast path (no throw) and still yields correct output.
+        final ExtractData d2 = extractor.getText(toStream(html2), null);
+        assertEquals("Second", d2.getValues("titleStr")[0]);
+
+        // clearXPathCache() also clears the non-node-set classification.
+        extractor.clearXPathCache();
+        Assertions.assertTrue(tl.get().isEmpty(), "non-node-set cache must be empty after clearXPathCache");
+    }
+
+    @Test
+    public void test_jsonLdAutoFillNotSuppressedByEmptyCustomRule() {
+        // A custom rule targeting jsonld.raw that matches nothing sets the key to an
+        // empty array. That empty value must NOT suppress JSON-LD auto-fill; the
+        // precedence check uses a non-blank test, matching the default-rule behaviour.
+        final HtmlExtractor extractor = newExtractor();
+        extractor.setExtractDefaultMetadata(false);
+        extractor.addMetadata(HtmlExtractor.JSONLD_RAW_KEY, "//NOSUCHTAG");
+        final String html = "<html><head><title>T</title>" + "<script type=\"application/ld+json\">{\"@type\":\"Article\"}</script>"
+                + "</head><body>b</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        final String[] raw = data.getValues(HtmlExtractor.JSONLD_RAW_KEY);
+        assertNotNull(raw);
+        Assertions.assertEquals(1, raw.length, "JSON-LD raw must be auto-filled despite the empty custom rule");
+        Assertions.assertTrue(raw[0].contains("Article"), "raw JSON-LD must be retained: " + raw[0]);
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        Assertions.assertTrue(Arrays.asList(types).contains("Article"), "type must be collected: " + Arrays.toString(types));
     }
 
     @Test

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
@@ -18,6 +18,14 @@ package org.codelibs.fess.crawler.extractor.impl;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.xpath.XPathExpression;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,7 +35,7 @@ import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.dbflute.utflute.core.PlainTestCase;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -46,6 +54,15 @@ public class HtmlExtractorTest extends PlainTestCase {
         StandardCrawlerContainer container = new StandardCrawlerContainer().singleton("htmlExtractor", HtmlExtractor.class);
         htmlExtractor = container.getComponent("htmlExtractor");
         htmlExtractor.addMetadata("title", "//TITLE");
+    }
+
+    private HtmlExtractor newExtractor() {
+        StandardCrawlerContainer container = new StandardCrawlerContainer().singleton("htmlExtractor2", HtmlExtractor.class);
+        return container.getComponent("htmlExtractor2");
+    }
+
+    private static InputStream toStream(final String html) {
+        return new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -105,5 +122,228 @@ public class HtmlExtractorTest extends PlainTestCase {
         } catch (final CrawlerSystemException e) {
             // NOP
         }
+    }
+
+    // ------------------------------------------------------------------
+    // PR-G: default metadata extraction, JSON-LD, and XPath cache tests
+    // ------------------------------------------------------------------
+
+    @Test
+    public void test_extractsTitle() {
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head><title>Hello World</title></head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        final String[] title = data.getValues("title");
+        assertNotNull(title);
+        assertEquals("Hello World", title[0]);
+    }
+
+    @Test
+    public void test_extractsOpenGraph() {
+        final HtmlExtractor extractor = newExtractor();
+        // language=html
+        final String html = "<html><head>" //
+                + "<title>Page</title>" //
+                + "<meta property=\"og:title\" content=\"OG Title\">" //
+                + "<meta property=\"og:description\" content=\"OG Desc\">" //
+                + "<meta property=\"og:image\" content=\"https://example.com/img.png\">" //
+                + "<meta property=\"og:type\" content=\"article\">" //
+                + "<meta property=\"og:url\" content=\"https://example.com/p\">" //
+                + "<meta name=\"twitter:card\" content=\"summary\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        assertEquals("OG Title", data.getValues("og:title")[0]);
+        assertEquals("OG Desc", data.getValues("og:description")[0]);
+        assertEquals("https://example.com/img.png", data.getValues("og:image")[0]);
+        assertEquals("article", data.getValues("og:type")[0]);
+        assertEquals("https://example.com/p", data.getValues("og:url")[0]);
+        assertEquals("summary", data.getValues("twitter:card")[0]);
+    }
+
+    @Test
+    public void test_extractsCanonical() {
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<title>Page</title>" //
+                + "<link rel=\"canonical\" href=\"https://example.com/canonical\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        assertEquals("https://example.com/canonical", data.getValues("canonical")[0]);
+    }
+
+    @Test
+    public void test_extractsKeywordsAndAuthor() {
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<meta name=\"keywords\" content=\"java, crawler\">" //
+                + "<meta name=\"author\" content=\"Alice\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        assertEquals("java, crawler", data.getValues("keywords")[0]);
+        assertEquals("Alice", data.getValues("author")[0]);
+    }
+
+    @Test
+    public void test_extractsDescriptionFromMeta() {
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<meta name=\"description\" content=\"A description\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        assertEquals("A description", data.getValues("description")[0]);
+    }
+
+    @Test
+    public void test_extractsJsonLd() {
+        final HtmlExtractor extractor = newExtractor();
+        final String json = "{\"@context\":\"https://schema.org\",\"@type\":\"Article\",\"headline\":\"H\"}";
+        final String html = "<html><head><title>T</title>" //
+                + "<script type=\"application/ld+json\">" + json + "</script>" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        assertEquals(1, types.length);
+        assertEquals("Article", types[0]);
+
+        final String[] raw = data.getValues(HtmlExtractor.JSONLD_RAW_KEY);
+        assertNotNull(raw);
+        assertEquals(1, raw.length);
+        assertTrue(raw[0].contains("\"@type\":\"Article\""));
+    }
+
+    @Test
+    public void test_extractsJsonLd_multipleBlocks_andArrayTypes() {
+        final HtmlExtractor extractor = newExtractor();
+        final String first = "{\"@type\":\"Article\"}";
+        final String second = "{\"@type\":[\"BlogPosting\",\"NewsArticle\"]}";
+        final String html = "<html><head>" //
+                + "<script type=\"application/ld+json\">" + first + "</script>" //
+                + "<script type=\"application/ld+json\">" + second + "</script>" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        final List<String> typeList = Arrays.asList(types);
+        Assertions.assertTrue(typeList.contains("Article"), "expected Article in " + typeList);
+        Assertions.assertTrue(typeList.contains("BlogPosting"), "expected BlogPosting in " + typeList);
+        Assertions.assertTrue(typeList.contains("NewsArticle"), "expected NewsArticle in " + typeList);
+
+        final String[] raw = data.getValues(HtmlExtractor.JSONLD_RAW_KEY);
+        assertNotNull(raw);
+        assertEquals(2, raw.length);
+    }
+
+    @Test
+    public void test_xpathCacheReused() throws Exception {
+        final HtmlExtractor extractor = newExtractor();
+        // Disable default-metadata + JSON-LD so only the configured XPaths run
+        // and we get a small, predictable cache size.
+        extractor.setExtractDefaultMetadata(false);
+        extractor.setExtractJsonLd(false);
+        extractor.addMetadata("custom", "//TITLE");
+        final String html = "<html><head><title>T</title></head><body>b</body></html>";
+
+        // First call: warms the cache.
+        extractor.getText(toStream(html), null);
+        // Second call: should reuse cached compiled expressions.
+        extractor.getText(toStream(html), null);
+
+        final Field cacheField = HtmlExtractor.class.getDeclaredField("threadLocalXPathCache");
+        cacheField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        final ThreadLocal<Map<String, XPathExpression>> tl = (ThreadLocal<Map<String, XPathExpression>>) cacheField.get(extractor);
+        final Map<String, XPathExpression> cache = tl.get();
+        // contentXpath ("//BODY") + "//TITLE" should be cached.
+        Assertions.assertTrue(cache.containsKey("//BODY"), "cache should contain //BODY: " + cache.keySet());
+        Assertions.assertTrue(cache.containsKey("//TITLE"), "cache should contain //TITLE: " + cache.keySet());
+
+        // Capture the compiled expression and confirm reusing the same instance.
+        final XPathExpression cachedBody = cache.get("//BODY");
+        extractor.getText(toStream(html), null);
+        Assertions.assertSame(cachedBody, cache.get("//BODY"), "XPathExpression must be reused across calls");
+
+        // clearXPathCache() should empty the cache.
+        extractor.clearXPathCache();
+        Assertions.assertTrue(cache.isEmpty(), "cache must be empty after clearXPathCache");
+    }
+
+    @Test
+    public void test_disableDefaultMetadata() {
+        final HtmlExtractor extractor = newExtractor();
+        extractor.setExtractDefaultMetadata(false);
+        final String html = "<html><head>" //
+                + "<title>T</title>" //
+                + "<meta property=\"og:title\" content=\"X\">" //
+                + "<meta name=\"description\" content=\"D\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        // The user did not call addMetadata for these keys, and defaults are off.
+        Assertions.assertNull(data.getValues("title"), "title should not be set when defaults disabled");
+        Assertions.assertNull(data.getValues("og:title"), "og:title should not be set when defaults disabled");
+        Assertions.assertNull(data.getValues("description"), "description should not be set when defaults disabled");
+    }
+
+    @Test
+    public void test_disableJsonLd() {
+        final HtmlExtractor extractor = newExtractor();
+        extractor.setExtractJsonLd(false);
+        final String html = "<html><head>" //
+                + "<title>T</title>" //
+                + "<script type=\"application/ld+json\">{\"@type\":\"Article\"}</script>" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_TYPE_KEY), "jsonld.type must be absent when JSON-LD disabled");
+        Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_RAW_KEY), "jsonld.raw must be absent when JSON-LD disabled");
+    }
+
+    @Test
+    public void test_corruptJsonLd_doesNotFailExtraction() {
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<title>T</title>" //
+                + "<script type=\"application/ld+json\">{not valid json</script>" //
+                + "<script type=\"application/ld+json\">{\"@type\":\"Article\"}</script>" //
+                + "</head><body>body content</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        // Body content still extracted.
+        assertTrue(data.getContent().contains("body content"));
+        // Title default still applied.
+        assertEquals("T", data.getValues("title")[0]);
+        // The valid JSON-LD block is still indexed.
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        assertEquals(1, types.length);
+        assertEquals("Article", types[0]);
+        // Raw values capture both the malformed and valid blocks.
+        final String[] raw = data.getValues(HtmlExtractor.JSONLD_RAW_KEY);
+        assertNotNull(raw);
+        assertEquals(2, raw.length);
+    }
+
+    @Test
+    public void test_metaTagOverride_via_setDefaultFieldRules() {
+        final HtmlExtractor extractor = newExtractor();
+        final Map<String, String> custom = new LinkedHashMap<>();
+        // Only one custom rule, replacing the entire defaults map.
+        custom.put("page-title", "//TITLE/text()");
+        extractor.setDefaultFieldRules(custom);
+
+        final String html = "<html><head>" //
+                + "<title>Replaced</title>" //
+                + "<meta property=\"og:title\" content=\"X\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        assertEquals("Replaced", data.getValues("page-title")[0]);
+        // The original defaults were replaced; og:title rule no longer applies.
+        Assertions.assertNull(data.getValues("og:title"), "og:title should not be set when defaults are overridden");
+        Assertions.assertNull(data.getValues("title"), "title should not be set when defaults are overridden");
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
@@ -346,4 +346,82 @@ public class HtmlExtractorTest extends PlainTestCase {
         Assertions.assertNull(data.getValues("og:title"), "og:title should not be set when defaults are overridden");
         Assertions.assertNull(data.getValues("title"), "title should not be set when defaults are overridden");
     }
+
+    @Test
+    public void test_jsonLdNestingDepthExceeded_doesNotCrash() {
+        final HtmlExtractor extractor = newExtractor();
+        // Build JSON-LD with nesting depth far beyond JSONLD_MAX_NESTING_DEPTH (64).
+        final int depth = 200;
+        final StringBuilder json = new StringBuilder();
+        for (int i = 0; i < depth; i++) {
+            json.append("{\"a\":");
+        }
+        json.append("\"deep\"");
+        for (int i = 0; i < depth; i++) {
+            json.append("}");
+        }
+        final String html = "<html><head>" //
+                + "<title>T</title>" //
+                + "<script type=\"application/ld+json\">" + json + "</script>" //
+                + "<script type=\"application/ld+json\">{\"@type\":\"Article\"}</script>" //
+                + "</head><body>body content</body></html>";
+
+        // Must not throw / abort extraction.
+        final ExtractData data = extractor.getText(toStream(html), null);
+        assertNotNull(data);
+        assertTrue(data.getContent().contains("body content"));
+        // Default title still extracted.
+        assertEquals("T", data.getValues("title")[0]);
+
+        // Both raw blocks captured (nesting limit only blocks @type collection,
+        // not raw capture).
+        final String[] raw = data.getValues(HtmlExtractor.JSONLD_RAW_KEY);
+        assertNotNull(raw);
+        assertEquals(2, raw.length);
+
+        // The deeply nested block must NOT contribute a @type entry; only the
+        // shallow second block should have produced one.
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        assertEquals(1, types.length);
+        assertEquals("Article", types[0]);
+    }
+
+    @Test
+    public void test_destroyClearsThreadLocals() throws Exception {
+        final HtmlExtractor extractor = newExtractor();
+        extractor.setExtractDefaultMetadata(false);
+        extractor.setExtractJsonLd(false);
+        extractor.addMetadata("custom", "//TITLE");
+
+        // Warm caches on the calling thread.
+        final String html = "<html><head><title>T</title></head><body>b</body></html>";
+        extractor.getText(toStream(html), null);
+
+        final Field cacheField = HtmlExtractor.class.getDeclaredField("threadLocalXPathCache");
+        cacheField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        final ThreadLocal<Map<String, XPathExpression>> tlCache = (ThreadLocal<Map<String, XPathExpression>>) cacheField.get(extractor);
+        final Map<String, XPathExpression> cacheBefore = tlCache.get();
+        Assertions.assertFalse(cacheBefore.isEmpty(), "cache must be populated before destroy");
+
+        // Capture identity of the populated cache map.
+        final int beforeIdentity = System.identityHashCode(cacheBefore);
+
+        // destroy() must clear the calling thread's ThreadLocals.
+        extractor.destroy();
+
+        // After destroy(), the ThreadLocal must initialise a fresh, empty map
+        // (different identity from before).
+        final Map<String, XPathExpression> cacheAfter = tlCache.get();
+        Assertions.assertTrue(cacheAfter.isEmpty(), "cache must be empty after destroy");
+        Assertions.assertNotEquals(beforeIdentity, System.identityHashCode(cacheAfter),
+                "ThreadLocal must hold a freshly initialised map after destroy");
+
+        // Subsequent extraction still works (lazily reinitialises ThreadLocals).
+        final ExtractData data = extractor.getText(toStream(html), null);
+        assertNotNull(data);
+        assertEquals("T", data.getValues("custom")[0]);
+        Assertions.assertFalse(tlCache.get().isEmpty(), "cache must be repopulated after subsequent extraction");
+    }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
@@ -501,6 +501,92 @@ public class HtmlExtractorTest extends PlainTestCase {
     }
 
     @Test
+    public void test_titleBackfillsFromOgTitle_whenCustomTitleXPathIsEmpty() {
+        // Mirrors the standard fess-crawler-lasta config: extractor.xml
+        // registers addMetadata("title", "//TITLE"). On a page that has no
+        // <title> but does carry og:title, the metadataXpathMap loop unconditionally
+        // calls putValues("title", []), leaving the key non-null but blank.
+        // The default-rule backfill must still fire so the og:title fallback
+        // takes effect — otherwise the PR's "extract default HTML metadata"
+        // intent is silently disabled in real deployments.
+        final HtmlExtractor extractor = newExtractor();
+        extractor.addMetadata("title", "//TITLE");
+
+        final String html = "<html><head>" //
+                + "<meta property=\"og:title\" content=\"OG Backfill\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        final String[] title = data.getValues("title");
+        assertNotNull(title);
+        Assertions.assertTrue(title.length > 0, "title must be backfilled from og:title");
+        assertEquals("OG Backfill", title[0]);
+    }
+
+    @Test
+    public void test_titleNotOverwritten_whenCustomTitleXPathHasValue() {
+        // Companion to the backfill test: when the custom rule actually
+        // produces a non-blank value, it must win over the default backfill
+        // (precedence rule preserved).
+        final HtmlExtractor extractor = newExtractor();
+        extractor.addMetadata("title", "//TITLE");
+
+        final String html = "<html><head>" //
+                + "<title>Page Title</title>" //
+                + "<meta property=\"og:title\" content=\"OG Title\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        final String[] title = data.getValues("title");
+        assertNotNull(title);
+        assertEquals(1, title.length);
+        assertEquals("Page Title", title[0]);
+    }
+
+    @Test
+    public void test_jsonLd_typeAttributeIsCaseInsensitiveAndTrimmed() {
+        // RFC 6838 / HTML5: media types are case-insensitive and may carry
+        // surrounding whitespace. The XPath must therefore match
+        // Application/LD+JSON, application/LD+JSON, and values padded with
+        // whitespace, in addition to the canonical lowercase form.
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<title>T</title>" //
+                + "<script type=\"Application/LD+JSON\">{\"@type\":\"A\"}</script>" //
+                + "<script type=\"  application/ld+json  \">{\"@type\":\"B\"}</script>" //
+                + "<script type=\"application/LD+json\">{\"@type\":\"C\"}</script>" //
+                + "</head><body>body</body></html>";
+
+        final ExtractData data = extractor.getText(toStream(html), null);
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        final List<String> typeList = Arrays.asList(types);
+        Assertions.assertTrue(typeList.contains("A"), "expected A in " + typeList);
+        Assertions.assertTrue(typeList.contains("B"), "expected B in " + typeList);
+        Assertions.assertTrue(typeList.contains("C"), "expected C in " + typeList);
+
+        final String[] raw = data.getValues(HtmlExtractor.JSONLD_RAW_KEY);
+        assertNotNull(raw);
+        assertEquals(3, raw.length);
+    }
+
+    @Test
+    public void test_jsonLd_unrelatedScriptTypeIsIgnored() {
+        // Sanity check that the case-insensitive XPath does not over-match —
+        // application/javascript and arbitrary mime types must not be parsed
+        // as JSON-LD.
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<title>T</title>" //
+                + "<script type=\"application/javascript\">var x=1;</script>" //
+                + "<script type=\"text/javascript\">var y=2;</script>" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_TYPE_KEY), "non-JSON-LD scripts must not contribute jsonld.type");
+        Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_RAW_KEY), "non-JSON-LD scripts must not contribute jsonld.raw");
+    }
+
+    @Test
     public void test_destroyClearsThreadLocals() throws Exception {
         final HtmlExtractor extractor = newExtractor();
         extractor.setExtractDefaultMetadata(false);

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
@@ -388,6 +388,119 @@ public class HtmlExtractorTest extends PlainTestCase {
     }
 
     @Test
+    public void test_malformedXPath_doesNotAbortExtraction() {
+        // Pre-cache behaviour was: a malformed metadataXpathMap entry logs a
+        // warning and yields no value rather than failing the whole
+        // extraction. The XPath compile cache must not regress that contract.
+        final HtmlExtractor extractor = newExtractor();
+        extractor.addMetadata("broken", "//[invalid");
+        extractor.addMetadata("ok", "//TITLE");
+        final String html = "<html><head><title>OK</title></head><body>body content</body></html>";
+
+        final ExtractData data = extractor.getText(toStream(html), null);
+        assertNotNull(data);
+        assertTrue(data.getContent().contains("body content"));
+        // Valid metadata still populated.
+        assertEquals("OK", data.getValues("ok")[0]);
+        // Malformed XPath quietly produced no values.
+        Assertions.assertTrue(data.getValues("broken") == null || data.getValues("broken").length == 0,
+                "malformed XPath must not populate metadata");
+    }
+
+    @Test
+    public void test_malformedContentXPath_doesNotAbortExtraction() {
+        // When contentXpath itself is malformed, pre-cache behaviour was to
+        // swallow the failure and return an extract with empty content. The
+        // CrawlerSystemException raised by the compile cache must therefore
+        // be caught at the same boundary instead of propagating out.
+        final HtmlExtractor extractor = newExtractor();
+        try {
+            final Field f = HtmlExtractor.class.getDeclaredField("contentXpath");
+            f.setAccessible(true);
+            f.set(extractor, "//[invalid");
+        } catch (final Exception e) {
+            throw new AssertionError("failed to override contentXpath", e);
+        }
+        final String html = "<html><head><title>T</title></head><body>body content</body></html>";
+
+        final ExtractData data = extractor.getText(toStream(html), null);
+        assertNotNull(data);
+        // Default-metadata path still ran (title present).
+        assertEquals("T", data.getValues("title")[0]);
+    }
+
+    @Test
+    public void test_customJsonLdMetadataKey_isPreserved() {
+        // If the operator has registered addMetadata("jsonld.raw"/"jsonld.type", ...),
+        // the user-supplied value must take precedence over the JSON-LD
+        // auto-extraction (mirroring the applyDefaultFieldRules precedence).
+        final HtmlExtractor extractor = newExtractor();
+        extractor.addMetadata(HtmlExtractor.JSONLD_RAW_KEY, "//META[@name='custom-raw']/@content");
+        extractor.addMetadata(HtmlExtractor.JSONLD_TYPE_KEY, "//META[@name='custom-type']/@content");
+        final String html = "<html><head>" //
+                + "<title>T</title>" //
+                + "<meta name=\"custom-raw\" content=\"USER_RAW\">" //
+                + "<meta name=\"custom-type\" content=\"USER_TYPE\">" //
+                + "<script type=\"application/ld+json\">{\"@type\":\"Article\"}</script>" //
+                + "</head><body>body</body></html>";
+
+        final ExtractData data = extractor.getText(toStream(html), null);
+        final String[] raw = data.getValues(HtmlExtractor.JSONLD_RAW_KEY);
+        assertNotNull(raw);
+        assertEquals(1, raw.length);
+        assertEquals("USER_RAW", raw[0]);
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        assertEquals(1, types.length);
+        assertEquals("USER_TYPE", types[0]);
+    }
+
+    @Test
+    public void test_jsonLdGraphTypesAreCollected() {
+        // Schema.org markup very commonly wraps multiple typed entities in a
+        // top-level @graph array. Verify each nested @type contributes.
+        final HtmlExtractor extractor = newExtractor();
+        final String json = "{\"@context\":\"https://schema.org\"," + "\"@graph\":[{\"@type\":\"Organization\",\"name\":\"Acme\"},"
+                + "{\"@type\":[\"WebSite\",\"Thing\"],\"url\":\"https://example.com\"}," + "{\"@type\":\"Article\","
+                + "\"author\":{\"@type\":\"Person\",\"name\":\"A\"}}]}";
+        final String html = "<html><head>" //
+                + "<title>T</title>" //
+                + "<script type=\"application/ld+json\">" + json + "</script>" //
+                + "</head><body>body</body></html>";
+
+        final ExtractData data = extractor.getText(toStream(html), null);
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        final List<String> typeList = Arrays.asList(types);
+        Assertions.assertTrue(typeList.contains("Organization"), "@graph[0] @type missing: " + typeList);
+        Assertions.assertTrue(typeList.contains("WebSite"), "@graph[1] @type[0] missing: " + typeList);
+        Assertions.assertTrue(typeList.contains("Thing"), "@graph[1] @type[1] missing: " + typeList);
+        Assertions.assertTrue(typeList.contains("Article"), "@graph[2] @type missing: " + typeList);
+        Assertions.assertTrue(typeList.contains("Person"), "nested author @type missing: " + typeList);
+    }
+
+    @Test
+    public void test_jsonLdContextObject_typeNotLeaked() {
+        // @context can itself be an object with embedded @type term
+        // definitions (vocabulary metadata, not real data). Those must NOT
+        // appear in jsonld.type.
+        final HtmlExtractor extractor = newExtractor();
+        final String json = "{\"@context\":{\"name\":{\"@type\":\"@id\"}}," + "\"@type\":\"Article\",\"name\":\"x\"}";
+        final String html = "<html><head>" //
+                + "<title>T</title>" //
+                + "<script type=\"application/ld+json\">" + json + "</script>" //
+                + "</head><body>body</body></html>";
+
+        final ExtractData data = extractor.getText(toStream(html), null);
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        // Only the top-level @type (Article) — the @id inside @context must
+        // not be collected.
+        assertEquals(1, types.length);
+        assertEquals("Article", types[0]);
+    }
+
+    @Test
     public void test_destroyClearsThreadLocals() throws Exception {
         final HtmlExtractor extractor = newExtractor();
         extractor.setExtractDefaultMetadata(false);

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
@@ -20,10 +20,16 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.xml.xpath.XPathExpression;
 
@@ -329,6 +335,11 @@ public class HtmlExtractorTest extends PlainTestCase {
 
     @Test
     public void test_metaTagOverride_via_setDefaultFieldRules() {
+        // Replacing the entire defaults map with a custom map: only the custom
+        // rule applies; og:title and title rules are gone.
+        // Fallback rules are independent and still apply, but since og:title rule
+        // is not in the custom map, og:title key is never populated, so the
+        // fallback for title (og:title -> title) also does not fire.
         final HtmlExtractor extractor = newExtractor();
         final Map<String, String> custom = new LinkedHashMap<>();
         // Only one custom rule, replacing the entire defaults map.
@@ -507,8 +518,7 @@ public class HtmlExtractorTest extends PlainTestCase {
         // <title> but does carry og:title, the metadataXpathMap loop unconditionally
         // calls putValues("title", []), leaving the key non-null but blank.
         // The default-rule backfill must still fire so the og:title fallback
-        // takes effect — otherwise the PR's "extract default HTML metadata"
-        // intent is silently disabled in real deployments.
+        // takes effect.
         final HtmlExtractor extractor = newExtractor();
         extractor.addMetadata("title", "//TITLE");
 
@@ -622,5 +632,472 @@ public class HtmlExtractorTest extends PlainTestCase {
         assertNotNull(data);
         assertEquals("T", data.getValues("custom")[0]);
         Assertions.assertFalse(tlCache.get().isEmpty(), "cache must be repopulated after subsequent extraction");
+    }
+
+    // ------------------------------------------------------------------
+    // New tests: fallback rules, Twitter Card, null-setter, limits, concurrency
+    // ------------------------------------------------------------------
+
+    @Test
+    public void test_titleBackfillsFromOgTitle_viaDefaultFallback() {
+        // Page has og:title but no <title>. Default primary rules populate og:title
+        // key; the fallback rule then copies og:title -> title.
+        // No addMetadata("title", ...) here — pure defaults path.
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<meta property=\"og:title\" content=\"FB Title\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        final String[] title = data.getValues("title");
+        Assertions.assertNotNull(title, "title must be backfilled from og:title via fallback rule");
+        Assertions.assertTrue(title.length > 0, "title array must be non-empty");
+        assertEquals("FB Title", title[0]);
+        // og:title key itself is also present.
+        assertEquals("FB Title", data.getValues("og:title")[0]);
+    }
+
+    @Test
+    public void test_descriptionBackfillsFromOgDescription() {
+        // No meta name=description, but og:description present.
+        // Fallback rule: description <- og:description.
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<meta property=\"og:description\" content=\"OG Desc Fallback\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        final String[] desc = data.getValues("description");
+        Assertions.assertNotNull(desc, "description must be backfilled from og:description");
+        assertEquals("OG Desc Fallback", desc[0]);
+    }
+
+    @Test
+    public void test_titleUsesPrimaryNotOgTitle_whenBothPresent() {
+        // Both <title> and og:title present: primary rule wins for title,
+        // og:title key stays with its own value.
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<title>Primary Title</title>" //
+                + "<meta property=\"og:title\" content=\"OG Title Here\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        final String[] title = data.getValues("title");
+        assertNotNull(title);
+        Assertions.assertEquals("Primary Title", title[0], "primary <title> must win over og:title fallback");
+
+        // og:title key still holds its own value.
+        final String[] ogTitle = data.getValues("og:title");
+        assertNotNull(ogTitle);
+        assertEquals("OG Title Here", ogTitle[0]);
+    }
+
+    @Test
+    public void test_extractsTwitterCardFull() {
+        // All four new Twitter Card fields should be extracted by default rules.
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<meta name=\"twitter:title\" content=\"TW Title\">" //
+                + "<meta name=\"twitter:description\" content=\"TW Desc\">" //
+                + "<meta name=\"twitter:image\" content=\"https://example.com/tw.png\">" //
+                + "<meta name=\"twitter:site\" content=\"@example\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        assertEquals("TW Title", data.getValues("twitter:title")[0]);
+        assertEquals("TW Desc", data.getValues("twitter:description")[0]);
+        assertEquals("https://example.com/tw.png", data.getValues("twitter:image")[0]);
+        assertEquals("@example", data.getValues("twitter:site")[0]);
+    }
+
+    @Test
+    public void test_setDefaultFieldRulesWithNull_restoresBuiltins() {
+        // setDefaultFieldRules(null) must immediately restore the built-in defaults
+        // without requiring another init() call.
+        final HtmlExtractor extractor = newExtractor();
+        final Map<String, String> custom = new LinkedHashMap<>();
+        custom.put("only-this", "//TITLE");
+        extractor.setDefaultFieldRules(custom);
+
+        // Verify custom is in effect.
+        final String htmlBefore = "<html><head><title>X</title><meta property=\"og:title\" content=\"OG\"></head><body>b</body></html>";
+        final ExtractData dataBefore = extractor.getText(toStream(htmlBefore), null);
+        assertNotNull(dataBefore.getValues("only-this"));
+        Assertions.assertNull(dataBefore.getValues("og:title"), "og:title should not exist with custom rules");
+
+        // Restore defaults.
+        extractor.setDefaultFieldRules(null);
+
+        // Now built-ins should be active again.
+        final String html = "<html><head><title>Y</title><meta property=\"og:title\" content=\"OG2\"></head><body>b</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        assertEquals("Y", data.getValues("title")[0]);
+        assertEquals("OG2", data.getValues("og:title")[0]);
+    }
+
+    @Test
+    public void test_setDefaultFieldFallbackRules_canBeCustomized() {
+        // Replace fallback rules with a custom map and verify only the custom
+        // fallback fires.
+        final HtmlExtractor extractor = newExtractor();
+        final Map<String, String> fallback = new LinkedHashMap<>();
+        fallback.put("keywords", "author"); // nonsensical but tests the mechanism
+        extractor.setDefaultFieldFallbackRules(fallback);
+
+        // Page with author but no keywords.
+        final String html = "<html><head>" //
+                + "<meta name=\"author\" content=\"Alice\">" //
+                + "</head><body>body</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+
+        // Custom fallback: keywords gets value from author.
+        final String[] kw = data.getValues("keywords");
+        Assertions.assertNotNull(kw, "keywords must be backfilled from author by custom fallback");
+        assertEquals("Alice", kw[0]);
+
+        // Default title fallback (og:title -> title) must NOT fire because
+        // we replaced the fallback map entirely.
+        // (No og:title on this page anyway, so title is simply absent.)
+        Assertions.assertNull(data.getValues("title"), "title should not be set when no <title> and no og:title");
+    }
+
+    @Test
+    public void test_jsonLd_blockCountLimit() {
+        // JSONLD_MAX_BLOCK_COUNT (64) blocks: 65 blocks → only 64 captured.
+        final HtmlExtractor extractor = newExtractor();
+        final StringBuilder sb = new StringBuilder("<html><head><title>T</title>");
+        for (int i = 0; i < 65; i++) {
+            sb.append("<script type=\"application/ld+json\">{\"@type\":\"X\"}</script>");
+        }
+        sb.append("</head><body>b</body></html>");
+        final ExtractData data = extractor.getText(toStream(sb.toString()), null);
+        final String[] raw = data.getValues(HtmlExtractor.JSONLD_RAW_KEY);
+        assertNotNull(raw);
+        Assertions.assertEquals(HtmlExtractor.JSONLD_MAX_BLOCK_COUNT, raw.length, "raw blocks must be truncated at JSONLD_MAX_BLOCK_COUNT");
+    }
+
+    @Test
+    public void test_jsonLd_totalRawSizeLimit() {
+        // Two blocks each just over 600KB → together they exceed 1MB limit.
+        // Only the first block should be captured.
+        final HtmlExtractor extractor = newExtractor();
+        // 600KB of 'a' characters inside the @type value — well-formed JSON.
+        final String bigValue = "a".repeat(600 * 1024);
+        final String bigBlock = "{\"@type\":\"" + bigValue + "\"}";
+        final StringBuilder sb = new StringBuilder("<html><head><title>T</title>");
+        sb.append("<script type=\"application/ld+json\">").append(bigBlock).append("</script>");
+        sb.append("<script type=\"application/ld+json\">").append(bigBlock).append("</script>");
+        sb.append("</head><body>b</body></html>");
+        final ExtractData data = extractor.getText(toStream(sb.toString()), null);
+        final String[] raw = data.getValues(HtmlExtractor.JSONLD_RAW_KEY);
+        assertNotNull(raw);
+        Assertions.assertTrue(raw.length < 2, "second block must be truncated due to total size limit; got " + raw.length + " blocks");
+    }
+
+    @Test
+    public void test_jsonLd_typesPerBlockLimit() {
+        // One block with a @graph containing more than JSONLD_MAX_TYPES_PER_BLOCK
+        // typed entities. Collected types must be <= 256.
+        final HtmlExtractor extractor = newExtractor();
+        final StringBuilder graphItems = new StringBuilder();
+        for (int i = 0; i < 300; i++) {
+            if (graphItems.length() > 0) {
+                graphItems.append(",");
+            }
+            graphItems.append("{\"@type\":\"Thing").append(i).append("\"}");
+        }
+        final String json = "{\"@graph\":[" + graphItems + "]}";
+        final String html = "<html><head><title>T</title>" + "<script type=\"application/ld+json\">" + json + "</script>"
+                + "</head><body>b</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        Assertions.assertTrue(types.length <= HtmlExtractor.JSONLD_MAX_TYPES_PER_BLOCK,
+                "types must be bounded at JSONLD_MAX_TYPES_PER_BLOCK; got " + types.length);
+    }
+
+    @Test
+    public void test_concurrentExtraction_threadSafe() throws Exception {
+        // 4 threads × 30 iterations each: all results must be equal to the
+        // single-thread result, and no exception must escape.
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<title>Concurrent</title>" //
+                + "<meta property=\"og:title\" content=\"OG\">" //
+                + "<script type=\"application/ld+json\">{\"@type\":\"Article\"}</script>" //
+                + "</head><body>body text</body></html>";
+
+        final ExtractData reference = extractor.getText(toStream(html), null);
+        final String refTitle = reference.getValues("title")[0];
+        final String refType = reference.getValues(HtmlExtractor.JSONLD_TYPE_KEY)[0];
+
+        final int threads = 4;
+        final int iterations = 30;
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        @SuppressWarnings("unchecked")
+        final CompletableFuture<Void>[] futures = new CompletableFuture[threads];
+        for (int t = 0; t < threads; t++) {
+            futures[t] = CompletableFuture.runAsync(() -> {
+                for (int i = 0; i < iterations; i++) {
+                    final ExtractData d = extractor.getText(toStream(html), null);
+                    final String[] titleArr = d.getValues("title");
+                    Assertions.assertNotNull(titleArr, "title must not be null");
+                    Assertions.assertEquals(refTitle, titleArr[0], "title must match reference");
+                    final String[] typeArr = d.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+                    Assertions.assertNotNull(typeArr, "jsonld.type must not be null");
+                    Assertions.assertEquals(refType, typeArr[0], "jsonld.type must match reference");
+                }
+            }, pool);
+        }
+        CompletableFuture.allOf(futures).join();
+        pool.shutdown();
+    }
+
+    @Test
+    public void test_concurrentExtraction_perThreadCacheIsolation() throws Exception {
+        // Two threads each warm their cache, then we verify via reflection that
+        // the ThreadLocal holds a different Map instance per thread.
+        final HtmlExtractor extractor = newExtractor();
+        extractor.setExtractDefaultMetadata(false);
+        extractor.setExtractJsonLd(false);
+        extractor.addMetadata("custom", "//TITLE");
+        final String html = "<html><head><title>T</title></head><body>b</body></html>";
+
+        final Field cacheField = HtmlExtractor.class.getDeclaredField("threadLocalXPathCache");
+        cacheField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        final ThreadLocal<Map<String, XPathExpression>> tlCache = (ThreadLocal<Map<String, XPathExpression>>) cacheField.get(extractor);
+
+        final CountDownLatch warmLatch = new CountDownLatch(2);
+        final CountDownLatch checkLatch = new CountDownLatch(1);
+        final AtomicReference<Map<String, XPathExpression>> cacheA = new AtomicReference<>();
+        final AtomicReference<Map<String, XPathExpression>> cacheB = new AtomicReference<>();
+        final AtomicReference<Throwable> err = new AtomicReference<>();
+
+        final Thread threadA = new Thread(() -> {
+            try {
+                extractor.getText(toStream(html), null);
+                cacheA.set(tlCache.get());
+                warmLatch.countDown();
+                checkLatch.await();
+            } catch (Exception e) {
+                err.set(e);
+            }
+        });
+        final Thread threadB = new Thread(() -> {
+            try {
+                extractor.getText(toStream(html), null);
+                cacheB.set(tlCache.get());
+                warmLatch.countDown();
+                checkLatch.await();
+            } catch (Exception e) {
+                err.set(e);
+            }
+        });
+        threadA.start();
+        threadB.start();
+        warmLatch.await();
+        checkLatch.countDown();
+        threadA.join();
+        threadB.join();
+
+        Assertions.assertNull(err.get(), "thread error: " + err.get());
+        Assertions.assertNotNull(cacheA.get(), "thread A cache must not be null");
+        Assertions.assertNotNull(cacheB.get(), "thread B cache must not be null");
+        Assertions.assertNotSame(cacheA.get(), cacheB.get(), "each thread must have its own cache Map instance");
+    }
+
+    @Test
+    public void test_clearXPathCache_doesNotAffectOtherThread() throws Exception {
+        // Thread A warms cache; thread B warms and then clears cache.
+        // Thread A's cache must remain populated.
+        final HtmlExtractor extractor = newExtractor();
+        extractor.setExtractDefaultMetadata(false);
+        extractor.setExtractJsonLd(false);
+        extractor.addMetadata("custom", "//TITLE");
+        final String html = "<html><head><title>T</title></head><body>b</body></html>";
+
+        final Field cacheField = HtmlExtractor.class.getDeclaredField("threadLocalXPathCache");
+        cacheField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        final ThreadLocal<Map<String, XPathExpression>> tlCache = (ThreadLocal<Map<String, XPathExpression>>) cacheField.get(extractor);
+
+        final CountDownLatch aWarmed = new CountDownLatch(1);
+        final CountDownLatch bCleared = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(1);
+        final AtomicReference<Map<String, XPathExpression>> cacheA = new AtomicReference<>();
+        final AtomicReference<Throwable> err = new AtomicReference<>();
+
+        final Thread threadA = new Thread(() -> {
+            try {
+                extractor.getText(toStream(html), null);
+                cacheA.set(tlCache.get());
+                aWarmed.countDown();
+                bCleared.await();
+                // After B cleared its own cache, A's cache should still be populated.
+                done.countDown();
+            } catch (Exception e) {
+                err.set(e);
+                done.countDown();
+            }
+        });
+        final Thread threadB = new Thread(() -> {
+            try {
+                extractor.getText(toStream(html), null);
+                aWarmed.await();
+                extractor.clearXPathCache();
+                bCleared.countDown();
+            } catch (Exception e) {
+                err.set(e);
+                bCleared.countDown();
+            }
+        });
+        threadA.start();
+        threadB.start();
+        done.await();
+        threadA.join();
+        threadB.join();
+
+        Assertions.assertNull(err.get(), "thread error: " + err.get());
+        Assertions.assertNotNull(cacheA.get(), "thread A cache reference must not be null");
+        Assertions.assertFalse(cacheA.get().isEmpty(), "thread A cache must still be populated after B cleared its own");
+    }
+
+    @Test
+    public void test_destroy_doesNotClearOtherThreadsCache() throws Exception {
+        // Documents the known limitation: destroy() only clears the calling thread's
+        // ThreadLocals, not other threads'.
+        final HtmlExtractor extractor = newExtractor();
+        extractor.setExtractDefaultMetadata(false);
+        extractor.setExtractJsonLd(false);
+        extractor.addMetadata("custom", "//TITLE");
+        final String html = "<html><head><title>T</title></head><body>b</body></html>";
+
+        final Field cacheField = HtmlExtractor.class.getDeclaredField("threadLocalXPathCache");
+        cacheField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        final ThreadLocal<Map<String, XPathExpression>> tlCache = (ThreadLocal<Map<String, XPathExpression>>) cacheField.get(extractor);
+
+        final CountDownLatch warmed = new CountDownLatch(1);
+        final CountDownLatch destroyed = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(1);
+        final AtomicReference<Map<String, XPathExpression>> workerCache = new AtomicReference<>();
+        final AtomicReference<Boolean> stillPopulated = new AtomicReference<>();
+        final AtomicReference<Throwable> err = new AtomicReference<>();
+
+        final Thread worker = new Thread(() -> {
+            try {
+                extractor.getText(toStream(html), null);
+                workerCache.set(tlCache.get());
+                warmed.countDown();
+                destroyed.await();
+                // After main thread called destroy(), worker's own cache is unchanged.
+                stillPopulated.set(!tlCache.get().isEmpty());
+                done.countDown();
+            } catch (Exception e) {
+                err.set(e);
+                done.countDown();
+            }
+        });
+        worker.start();
+        warmed.await();
+        extractor.destroy(); // destroys main thread's cache, not worker's
+        destroyed.countDown();
+        done.await();
+        worker.join();
+
+        Assertions.assertNull(err.get(), "thread error: " + err.get());
+        Assertions.assertTrue(stillPopulated.get(), "worker thread cache must remain populated after main-thread destroy()");
+    }
+
+    @Test
+    public void test_jsonLd_topLevelArray() {
+        // Top-level JSON-LD array: [{@type:A},{@type:B}].
+        // Both types must be collected.
+        final HtmlExtractor extractor = newExtractor();
+        final String json = "[{\"@type\":\"A\"},{\"@type\":\"B\"}]";
+        final String html = "<html><head><title>T</title>" + "<script type=\"application/ld+json\">" + json + "</script>"
+                + "</head><body>b</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        final List<String> typeList = Arrays.asList(types);
+        Assertions.assertTrue(typeList.contains("A"), "expected A in " + typeList);
+        Assertions.assertTrue(typeList.contains("B"), "expected B in " + typeList);
+    }
+
+    @Test
+    public void test_jsonLd_emptyScriptBlock() {
+        // Empty JSON-LD script block: no keys should be populated.
+        final HtmlExtractor extractor = newExtractor();
+        final String html =
+                "<html><head><title>T</title>" + "<script type=\"application/ld+json\">   </script>" + "</head><body>b</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_RAW_KEY), "empty block must not populate jsonld.raw");
+        Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_TYPE_KEY), "empty block must not populate jsonld.type");
+    }
+
+    @Test
+    public void test_jsonLd_numericType_ignored() {
+        // {@type: 5} — numeric @type is not textual; must not be collected.
+        final HtmlExtractor extractor = newExtractor();
+        final String json = "{\"@type\":5}";
+        final String html = "<html><head><title>T</title>" + "<script type=\"application/ld+json\">" + json + "</script>"
+                + "</head><body>b</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        // Raw is captured (it is valid JSON), but type must be absent.
+        final String[] raw = data.getValues(HtmlExtractor.JSONLD_RAW_KEY);
+        Assertions.assertNotNull(raw, "raw must be captured for valid JSON");
+        Assertions.assertNull(data.getValues(HtmlExtractor.JSONLD_TYPE_KEY), "numeric @type must not be collected");
+    }
+
+    @Test
+    public void test_jsonLd_japaneseType() {
+        // UTF-8 encoded Japanese @type value must round-trip correctly.
+        final HtmlExtractor extractor = newExtractor();
+        final String json = "{\"@type\":\"記事\"}"; // "記事"
+        final String html = "<html><head><title>T</title>" + "<script type=\"application/ld+json\">" + json + "</script>"
+                + "</head><body>b</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        assertNotNull(types);
+        assertEquals(1, types.length);
+        Assertions.assertEquals("記事", types[0], "Japanese @type must round-trip correctly");
+    }
+
+    @Test
+    public void test_multipleOgImage() {
+        // Multiple og:image tags → all URLs captured in array.
+        final HtmlExtractor extractor = newExtractor();
+        final String html = "<html><head>" //
+                + "<meta property=\"og:image\" content=\"https://example.com/a.png\">" //
+                + "<meta property=\"og:image\" content=\"https://example.com/b.png\">" //
+                + "</head><body>b</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        final String[] images = data.getValues("og:image");
+        assertNotNull(images);
+        Assertions.assertTrue(images.length >= 2, "all og:image URLs must be captured; got " + images.length);
+        final List<String> imgList = Arrays.asList(images);
+        Assertions.assertTrue(imgList.contains("https://example.com/a.png"), "missing a.png in " + imgList);
+        Assertions.assertTrue(imgList.contains("https://example.com/b.png"), "missing b.png in " + imgList);
+    }
+
+    @Test
+    public void test_jsonLd_corruptJsonContainingNewline_doesNotAbortExtraction() {
+        // Malformed JSON with embedded newlines must not abort extraction;
+        // the subsequent valid block is still processed.
+        final HtmlExtractor extractor = newExtractor();
+        final String corrupt = "{\"\n[FAKE]\":\"x"; // deliberately broken
+        final String html = "<html><head><title>T</title>" + "<script type=\"application/ld+json\">" + corrupt + "</script>"
+                + "<script type=\"application/ld+json\">{\"@type\":\"Article\"}</script>" + "</head><body>body content</body></html>";
+        final ExtractData data = extractor.getText(toStream(html), null);
+        // Body still extracted.
+        assertTrue(data.getContent().contains("body content"));
+        // The valid block was still processed.
+        final String[] types = data.getValues(HtmlExtractor.JSONLD_TYPE_KEY);
+        Assertions.assertNotNull(types, "valid JSON-LD block must still produce types");
+        final List<String> typeList = Arrays.asList(types);
+        Assertions.assertTrue(typeList.contains("Article"), "Article type must be present: " + typeList);
     }
 }


### PR DESCRIPTION
## Summary
- Extract standard HTML metadata by default: title, description, OpenGraph (og:title, og:description, og:image, og:type, og:url), Twitter Card, canonical URL, keywords, author.
- Parse `<script type="application/ld+json">` blocks; expose `jsonld.type` and `jsonld.raw` (multivalue). Malformed JSON is skipped with a warn log.
- Cache compiled `XPathExpression` per thread (via `ThreadLocal<Map>` and `ThreadLocal<XPath>`) to eliminate per-call recompilation under high crawl rate.
- Add `setDefaultFieldRules(Map)`, `setExtractDefaultMetadata(boolean)`, `setExtractJsonLd(boolean)` for full opt-out / customization. New `clearXPathCache()` for dynamic rule changes.

## Why
Most search use cases want title and description for snippet rendering; users currently have to wire each XPath manually. JSON-LD provides high-quality structured data signals. XPath compilation in a hot loop was wasted work.

## Threat model
HTML content is untrusted. JSON-LD parsing uses Jackson with default settings; malformed input is caught and logged, never fails extraction. XPath cache key is the expression string (admin-configured), bounded by configured rules — no unbounded growth from untrusted input.

## Tests
- 12 new tests added (total 18 passing); existing 6 still pass.
- Default metadata extraction: title, description, OpenGraph, canonical, keywords, author.
- JSON-LD: single block, multiple blocks with array `@type`, malformed JSON resilience.
- XPath cache: same compiled instance reused across calls; `clearXPathCache()` empties cache.
- Opt-out flags actually disable each subsystem.
- User-provided rule map overrides defaults.

## Verification
- `mvn -pl fess-crawler test -Dtest=HtmlExtractorTest` → 18/18 pass.
- `mvn -pl fess-crawler test` → 1706 run, 0 failures, 55 pre-existing env-dependent errors (Docker/LibreOffice).
- `mvn formatter:format && mvn license:format` clean.

## Test plan
- [ ] CI green
- [ ] Manual review of XPath cache thread-safety (per-thread cache + ThreadLocal XPath)
- [ ] Verify no regression on existing fixture tests