### PR TITLE
fix(extractor): stream text/markdown/xml extraction with BOM and length cap

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractExtractor.java
@@ -15,11 +15,15 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.crawler.container.CrawlerContainer;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.extractor.Extractor;
@@ -47,6 +51,12 @@ import jakarta.annotation.Resource;
  *
  */
 public abstract class AbstractExtractor implements Extractor {
+
+    /** Logger instance for this class. */
+    private static final Logger logger = LogManager.getLogger(AbstractExtractor.class);
+
+    /** Default read buffer size in characters when streaming reader content. */
+    protected static final int READ_BUFFER_SIZE = 8192;
 
     /** The crawler container. */
     @Resource
@@ -141,5 +151,69 @@ public abstract class AbstractExtractor implements Extractor {
         if (in == null) {
             throw new CrawlerSystemException("The inputstream is null.");
         }
+    }
+
+    /**
+     * Holder for the result of {@link #readWithLimit(Reader, long)}.
+     */
+    protected static final class TextReadResult {
+        /** The decoded content (possibly truncated). */
+        public final String content;
+        /** Whether the content was truncated at the configured limit. */
+        public final boolean truncated;
+
+        /**
+         * Creates a new result holder.
+         * @param content the decoded content
+         * @param truncated whether truncation occurred
+         */
+        TextReadResult(final String content, final boolean truncated) {
+            this.content = content;
+            this.truncated = truncated;
+        }
+    }
+
+    /**
+     * Reads characters from the supplied reader into a string, bounding the number
+     * of characters by {@code maxTextLength}. When the limit is reached the read
+     * stops early, a WARN-level message is logged, and the result is flagged as
+     * truncated. A {@code maxTextLength} less than or equal to zero disables the
+     * limit. At the truncation boundary a trailing unpaired high surrogate is
+     * dropped so the returned string is always a valid UTF-16 sequence.
+     *
+     * <p>The supplied reader is not closed by this method; the caller retains
+     * ownership.
+     *
+     * @param reader the reader to consume
+     * @param maxTextLength the maximum number of characters ({@code char} units) to read
+     * @return a {@link TextReadResult} with the decoded content and the truncation flag
+     * @throws IOException if reading fails
+     */
+    protected TextReadResult readWithLimit(final Reader reader, final long maxTextLength) throws IOException {
+        final BufferedReader br = reader instanceof BufferedReader ? (BufferedReader) reader : new BufferedReader(reader);
+        final StringBuilder sb = new StringBuilder();
+        final char[] buf = new char[READ_BUFFER_SIZE];
+        long total = 0;
+        boolean truncated = false;
+        int n;
+        while ((n = br.read(buf)) >= 0) {
+            if (maxTextLength > 0 && total + n > maxTextLength) {
+                final int remaining = (int) (maxTextLength - total);
+                if (remaining > 0) {
+                    sb.append(buf, 0, remaining);
+                }
+                // Avoid leaving an unpaired high surrogate at the end.
+                if (sb.length() > 0 && Character.isHighSurrogate(sb.charAt(sb.length() - 1))) {
+                    sb.setLength(sb.length() - 1);
+                }
+                logger.warn("Extracted content truncated: extractor={} maxTextLength={} totalChars={}", getClass().getSimpleName(),
+                        maxTextLength, total + n);
+                truncated = true;
+                break;
+            }
+            sb.append(buf, 0, n);
+            total += n;
+        }
+        return new TextReadResult(sb.toString(), truncated);
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
@@ -46,6 +46,14 @@ import org.codelibs.fess.crawler.exception.ExtractException;
  * Provides common functionality for extracting text content from XML-like documents.
  * It handles encoding detection, HTML entity unescaping, and tag-based content extraction.
  *
+ * <p>Features:
+ * <ul>
+ *   <li>BOM detection for UTF-8, UTF-16 LE/BE, UTF-32 LE/BE, and UTF-7</li>
+ *   <li>Reader-based streaming to avoid loading entire documents into memory</li>
+ *   <li>Optional {@code maxTextLength} cap to bound heap usage on very large inputs</li>
+ *   <li>HTML entity unescaping</li>
+ *   <li>Configurable comment-tag suppression</li>
+ * </ul>
  */
 public abstract class AbstractXmlExtractor extends AbstractExtractor {
 
@@ -56,6 +64,8 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
 
     /**
      * UTF-7 Byte Order Mark definition.
+     * Note: 'UTF-7' is not always provided by the JVM. Reading content declared as UTF-7
+     * may fail with {@code UnsupportedEncodingException}.
      */
     protected static final ByteOrderMark BOM_UTF_7 = new ByteOrderMark("UTF-7", 0x2B, 0x2F, 0x76);
 
@@ -82,9 +92,13 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
     protected boolean ignoreCommentTag = false;
 
     /**
-     * Maximum number of characters to read from the input. Defaults to
-     * {@link Long#MAX_VALUE} (effectively unlimited). Values less than or
-     * equal to zero are also interpreted as unlimited.
+     * Maximum number of characters to read from the input. The default is
+     * {@link Long#MAX_VALUE}, which is effectively unlimited. Values less than
+     * or equal to zero explicitly disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
      */
     protected long maxTextLength = Long.MAX_VALUE;
 
@@ -112,6 +126,24 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
      */
     protected abstract Pattern getTagPattern();
 
+    /**
+     * Extracts text from the supplied XML input stream.
+     *
+     * <p>This method detects the character encoding via a leading BOM (UTF-8,
+     * UTF-16 LE/BE, UTF-32 LE/BE, UTF-7) or from the XML declaration, then
+     * streams the content through a {@link BufferedReader}. The raw character
+     * count is bounded by {@link #maxTextLength} before tag-stripping is applied.
+     * When truncation occurs, a WARN-level log message is emitted and the returned
+     * {@link ExtractData} carries {@code truncated=true} and
+     * {@code maxTextLength=<value>} metadata entries. The supplied {@code in} is
+     * closed by this method.
+     *
+     * @param in the XML input stream; must not be {@code null}
+     * @param params optional extraction parameters (may be {@code null})
+     * @return the extracted text and optional truncation metadata
+     * @throws CrawlerSystemException if {@code in} is {@code null}
+     * @throws ExtractException if reading or decoding fails
+     */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
         if (in == null) {
@@ -122,17 +154,38 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
             final String enc = getEncoding(bis);
             // Strip any BOM bytes from the actual stream (the encoding lookup above
             // resets the underlying buffer, so the BOM is still present here).
-            @SuppressWarnings("resource")
-            final BOMInputStream bomStripped = BOMInputStream.builder()
+            try (BOMInputStream bomStripped = BOMInputStream.builder()
                     .setInputStream(bis)
                     .setInclude(false)
                     .setByteOrderMarks(ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE,
                             ByteOrderMark.UTF_32BE, BOM_UTF_7)
-                    .get();
-            final String content = UNESCAPE_HTML4.translate(readAsString(bomStripped, enc));
-            return createExtractData(content);
+                    .get()) {
+                final TruncationResult result = readAsString(bomStripped, enc);
+                final String content = UNESCAPE_HTML4.translate(result.content);
+                final ExtractData extractData = createExtractData(content);
+                if (result.truncated) {
+                    extractData.putValue("truncated", "true");
+                    extractData.putValue("maxTextLength", Long.toString(maxTextLength));
+                }
+                return extractData;
+            }
         } catch (final Exception e) {
             throw new ExtractException(e);
+        }
+    }
+
+    /**
+     * Holder for the result of {@link #readAsString(InputStream, String)}.
+     */
+    protected static final class TruncationResult {
+        /** The decoded content string (possibly truncated). */
+        public final String content;
+        /** Whether the content was truncated at {@code maxTextLength}. */
+        public final boolean truncated;
+
+        TruncationResult(final String content, final boolean truncated) {
+            this.content = content;
+            this.truncated = truncated;
         }
     }
 
@@ -142,14 +195,15 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
      *
      * @param in the input stream
      * @param charset the charset name
-     * @return the decoded content
+     * @return a {@link TruncationResult} containing the decoded content and whether truncation occurred
      * @throws IOException if reading fails
      */
-    protected String readAsString(final InputStream in, final String charset) throws IOException {
+    protected TruncationResult readAsString(final InputStream in, final String charset) throws IOException {
         try (Reader reader = new InputStreamReader(in, charset); BufferedReader br = new BufferedReader(reader)) {
             final StringBuilder sb = new StringBuilder();
             final char[] buf = new char[READ_BUFFER_SIZE];
             long total = 0;
+            boolean truncated = false;
             int n;
             while ((n = br.read(buf)) >= 0) {
                 if (maxTextLength > 0 && total + n > maxTextLength) {
@@ -157,15 +211,19 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
                     if (remaining > 0) {
                         sb.append(buf, 0, remaining);
                     }
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Truncating XML content at maxTextLength={} characters", maxTextLength);
+                    // Avoid leaving an unpaired high surrogate at the end.
+                    if (sb.length() > 0 && Character.isHighSurrogate(sb.charAt(sb.length() - 1))) {
+                        sb.setLength(sb.length() - 1);
                     }
+                    logger.warn("Extracted content truncated: extractor={} maxTextLength={} totalChars={}", getClass().getSimpleName(),
+                            maxTextLength, total + n);
+                    truncated = true;
                     break;
                 }
                 sb.append(buf, 0, n);
                 total += n;
             }
-            return sb.toString();
+            return new TruncationResult(sb.toString(), truncated);
         }
     }
 
@@ -187,9 +245,15 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
         final byte[] b = new byte[preloadSizeForCharset];
         try {
             bis.mark(preloadSizeForCharset);
+            // The wrapping BOMInputStream is intentionally not closed here so the
+            // underlying buffered stream can be reset (see finally) and reused by getText.
             @SuppressWarnings("resource")
-            final BOMInputStream bomIn = new BOMInputStream(bis, false, ByteOrderMark.UTF_8, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE,
-                    ByteOrderMark.UTF_32BE, ByteOrderMark.UTF_32LE, BOM_UTF_7);
+            final BOMInputStream bomIn = BOMInputStream.builder()
+                    .setInputStream(bis)
+                    .setInclude(false)
+                    .setByteOrderMarks(ByteOrderMark.UTF_8, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_32BE,
+                            ByteOrderMark.UTF_32LE, BOM_UTF_7)
+                    .get();
             if (bomIn.hasBOM()) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("BOM: {}", bomIn.getBOMCharsetName());
@@ -316,8 +380,12 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
 
     /**
      * Sets the maximum number of characters that will be read from the input
-     * stream. Values less than or equal to zero, or {@link Long#MAX_VALUE},
-     * are interpreted as unlimited.
+     * stream. The default is {@link Long#MAX_VALUE}, which is effectively
+     * unlimited. Values less than or equal to zero explicitly disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
      *
      * @param maxTextLength the maximum text length
      */

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
@@ -16,7 +16,6 @@
 package org.codelibs.fess.crawler.extractor.impl;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -103,11 +102,6 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
     protected long maxTextLength = Long.MAX_VALUE;
 
     /**
-     * Read buffer size in characters when streaming the XML content.
-     */
-    protected static final int READ_BUFFER_SIZE = 8192;
-
-    /**
      * Constructs a new AbstractXmlExtractor.
      */
     public AbstractXmlExtractor() {
@@ -160,7 +154,7 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
                     .setByteOrderMarks(ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE,
                             ByteOrderMark.UTF_32BE, BOM_UTF_7)
                     .get()) {
-                final TruncationResult result = readAsString(bomStripped, enc);
+                final TextReadResult result = readAsString(bomStripped, enc);
                 final String content = UNESCAPE_HTML4.translate(result.content);
                 final ExtractData extractData = createExtractData(content);
                 if (result.truncated) {
@@ -175,55 +169,17 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
     }
 
     /**
-     * Holder for the result of {@link #readAsString(InputStream, String)}.
-     */
-    protected static final class TruncationResult {
-        /** The decoded content string (possibly truncated). */
-        public final String content;
-        /** Whether the content was truncated at {@code maxTextLength}. */
-        public final boolean truncated;
-
-        TruncationResult(final String content, final boolean truncated) {
-            this.content = content;
-            this.truncated = truncated;
-        }
-    }
-
-    /**
      * Streams the supplied input into a string using the given charset. The
      * total number of characters appended is bounded by {@link #maxTextLength}.
      *
      * @param in the input stream
      * @param charset the charset name
-     * @return a {@link TruncationResult} containing the decoded content and whether truncation occurred
+     * @return a {@link TextReadResult} containing the decoded content and whether truncation occurred
      * @throws IOException if reading fails
      */
-    protected TruncationResult readAsString(final InputStream in, final String charset) throws IOException {
-        try (Reader reader = new InputStreamReader(in, charset); BufferedReader br = new BufferedReader(reader)) {
-            final StringBuilder sb = new StringBuilder();
-            final char[] buf = new char[READ_BUFFER_SIZE];
-            long total = 0;
-            boolean truncated = false;
-            int n;
-            while ((n = br.read(buf)) >= 0) {
-                if (maxTextLength > 0 && total + n > maxTextLength) {
-                    final int remaining = (int) (maxTextLength - total);
-                    if (remaining > 0) {
-                        sb.append(buf, 0, remaining);
-                    }
-                    // Avoid leaving an unpaired high surrogate at the end.
-                    if (sb.length() > 0 && Character.isHighSurrogate(sb.charAt(sb.length() - 1))) {
-                        sb.setLength(sb.length() - 1);
-                    }
-                    logger.warn("Extracted content truncated: extractor={} maxTextLength={} totalChars={}", getClass().getSimpleName(),
-                            maxTextLength, total + n);
-                    truncated = true;
-                    break;
-                }
-                sb.append(buf, 0, n);
-                total += n;
-            }
-            return new TruncationResult(sb.toString(), truncated);
+    protected TextReadResult readAsString(final InputStream in, final String charset) throws IOException {
+        try (Reader reader = new InputStreamReader(in, charset)) {
+            return readWithLimit(reader, maxTextLength);
         }
     }
 

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
@@ -16,8 +16,11 @@
 package org.codelibs.fess.crawler.extractor.impl;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -32,7 +35,6 @@ import org.apache.commons.text.translate.LookupTranslator;
 import org.apache.commons.text.translate.NumericEntityUnescaper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codelibs.core.io.InputStreamUtil;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.crawler.entity.ExtractData;
@@ -80,6 +82,18 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
     protected boolean ignoreCommentTag = false;
 
     /**
+     * Maximum number of characters to read from the input. Defaults to
+     * {@link Long#MAX_VALUE} (effectively unlimited). Values less than or
+     * equal to zero are also interpreted as unlimited.
+     */
+    protected long maxTextLength = Long.MAX_VALUE;
+
+    /**
+     * Read buffer size in characters when streaming the XML content.
+     */
+    protected static final int READ_BUFFER_SIZE = 8192;
+
+    /**
      * Constructs a new AbstractXmlExtractor.
      */
     public AbstractXmlExtractor() {
@@ -106,10 +120,52 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
         try {
             final BufferedInputStream bis = new BufferedInputStream(in);
             final String enc = getEncoding(bis);
-            final String content = UNESCAPE_HTML4.translate(new String(InputStreamUtil.getBytes(bis), enc));
+            // Strip any BOM bytes from the actual stream (the encoding lookup above
+            // resets the underlying buffer, so the BOM is still present here).
+            @SuppressWarnings("resource")
+            final BOMInputStream bomStripped = BOMInputStream.builder()
+                    .setInputStream(bis)
+                    .setInclude(false)
+                    .setByteOrderMarks(ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE,
+                            ByteOrderMark.UTF_32BE, BOM_UTF_7)
+                    .get();
+            final String content = UNESCAPE_HTML4.translate(readAsString(bomStripped, enc));
             return createExtractData(content);
         } catch (final Exception e) {
             throw new ExtractException(e);
+        }
+    }
+
+    /**
+     * Streams the supplied input into a string using the given charset. The
+     * total number of characters appended is bounded by {@link #maxTextLength}.
+     *
+     * @param in the input stream
+     * @param charset the charset name
+     * @return the decoded content
+     * @throws IOException if reading fails
+     */
+    protected String readAsString(final InputStream in, final String charset) throws IOException {
+        try (Reader reader = new InputStreamReader(in, charset); BufferedReader br = new BufferedReader(reader)) {
+            final StringBuilder sb = new StringBuilder();
+            final char[] buf = new char[READ_BUFFER_SIZE];
+            long total = 0;
+            int n;
+            while ((n = br.read(buf)) >= 0) {
+                if (maxTextLength > 0 && total + n > maxTextLength) {
+                    final int remaining = (int) (maxTextLength - total);
+                    if (remaining > 0) {
+                        sb.append(buf, 0, remaining);
+                    }
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Truncating XML content at maxTextLength={} characters", maxTextLength);
+                    }
+                    break;
+                }
+                sb.append(buf, 0, n);
+                total += n;
+            }
+            return sb.toString();
         }
     }
 
@@ -246,6 +302,27 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
      */
     public void setIgnoreCommentTag(final boolean ignoreCommentTag) {
         this.ignoreCommentTag = ignoreCommentTag;
+    }
+
+    /**
+     * Returns the maximum number of characters that will be read from the
+     * input stream before truncation.
+     *
+     * @return the maximum text length
+     */
+    public long getMaxTextLength() {
+        return maxTextLength;
+    }
+
+    /**
+     * Sets the maximum number of characters that will be read from the input
+     * stream. Values less than or equal to zero, or {@link Long#MAX_VALUE},
+     * are interpreted as unlimited.
+     *
+     * @param maxTextLength the maximum text length
+     */
+    public void setMaxTextLength(final long maxTextLength) {
+        this.maxTextLength = maxTextLength;
     }
 
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
@@ -125,7 +125,7 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
      *
      * <p>This method detects the character encoding via a leading BOM (UTF-8,
      * UTF-16 LE/BE, UTF-32 LE/BE, UTF-7) or from the XML declaration, then
-     * streams the content through a {@link BufferedReader}. The raw character
+     * streams the content through a {@code BufferedReader}. The raw character
      * count is bounded by {@link #maxTextLength} before tag-stripping is applied.
      * When truncation occurs, a WARN-level log message is emitted and the returned
      * {@link ExtractData} carries {@code truncated=true} and

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MarkdownExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MarkdownExtractor.java
@@ -15,15 +15,19 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
+import java.io.BufferedReader;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.codelibs.core.io.InputStreamUtil;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.crawler.entity.ExtractData;
@@ -49,12 +53,16 @@ import org.commonmark.renderer.text.TextContentRenderer;
  *   <li>Link URL extraction</li>
  *   <li>Code block content extraction</li>
  *   <li>Clean text conversion from Markdown</li>
- *   <li>Configurable encoding</li>
+ *   <li>Configurable encoding with BOM detection (UTF-8/UTF-16/UTF-32)</li>
+ *   <li>Reader-based streaming with optional length cap to bound heap usage</li>
  * </ul>
  */
 public class MarkdownExtractor extends AbstractExtractor {
     /** Logger instance for this class. */
     private static final Logger logger = LogManager.getLogger(MarkdownExtractor.class);
+
+    /** Default read buffer size in characters. */
+    private static final int READ_BUFFER_SIZE = 8192;
 
     /** Default encoding for Markdown files. */
     protected String encoding = Constants.UTF_8;
@@ -67,6 +75,13 @@ public class MarkdownExtractor extends AbstractExtractor {
 
     /** Whether to extract link URLs as metadata. */
     protected boolean extractLinks = false;
+
+    /**
+     * Maximum number of characters to read from the input. Defaults to
+     * {@link Long#MAX_VALUE} (effectively unlimited). Values less than or
+     * equal to zero are also interpreted as unlimited.
+     */
+    protected long maxTextLength = Long.MAX_VALUE;
 
     /** Markdown parser with extensions. */
     protected Parser parser;
@@ -101,8 +116,8 @@ public class MarkdownExtractor extends AbstractExtractor {
         validateInputStream(in);
 
         try {
-            final String content = new String(InputStreamUtil.getBytes(in), getEncoding());
-            final Node document = parser.parse(content);
+            final String rawMarkdown = readMarkdown(in);
+            final Node document = parser.parse(rawMarkdown);
 
             // Extract plain text
             final String plainText = textRenderer.render(document);
@@ -127,6 +142,46 @@ public class MarkdownExtractor extends AbstractExtractor {
             return extractData;
         } catch (final Exception e) {
             throw new ExtractException("Failed to extract Markdown content", e);
+        }
+    }
+
+    /**
+     * Reads the entire Markdown source from the supplied input stream, honoring
+     * a leading BOM when present and bounding the result by {@link #maxTextLength}.
+     *
+     * @param in the input stream
+     * @return the decoded Markdown source
+     * @throws java.io.IOException if reading fails
+     */
+    protected String readMarkdown(final InputStream in) throws java.io.IOException {
+        final BOMInputStream bomIn = BOMInputStream.builder()
+                .setInputStream(in)
+                .setInclude(false)
+                .setByteOrderMarks(ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE,
+                        ByteOrderMark.UTF_32BE)
+                .get();
+        final String detected = bomIn.getBOMCharsetName();
+        final String charset = detected != null ? detected : getEncoding();
+        try (Reader reader = new InputStreamReader(bomIn, charset); BufferedReader br = new BufferedReader(reader)) {
+            final StringBuilder sb = new StringBuilder();
+            final char[] buf = new char[READ_BUFFER_SIZE];
+            long total = 0;
+            int n;
+            while ((n = br.read(buf)) >= 0) {
+                if (maxTextLength > 0 && total + n > maxTextLength) {
+                    final int remaining = (int) (maxTextLength - total);
+                    if (remaining > 0) {
+                        sb.append(buf, 0, remaining);
+                    }
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Truncating Markdown content at maxTextLength={} characters", maxTextLength);
+                    }
+                    break;
+                }
+                sb.append(buf, 0, n);
+                total += n;
+            }
+            return sb.toString();
         }
     }
 
@@ -250,5 +305,25 @@ public class MarkdownExtractor extends AbstractExtractor {
      */
     public void setExtractLinks(final boolean extractLinks) {
         this.extractLinks = extractLinks;
+    }
+
+    /**
+     * Returns the maximum number of characters that will be extracted.
+     *
+     * @return the maximum text length
+     */
+    public long getMaxTextLength() {
+        return maxTextLength;
+    }
+
+    /**
+     * Sets the maximum number of characters that will be extracted. Values
+     * less than or equal to zero, or {@link Long#MAX_VALUE}, are interpreted
+     * as unlimited.
+     *
+     * @param maxTextLength the maximum text length
+     */
+    public void setMaxTextLength(final long maxTextLength) {
+        this.maxTextLength = maxTextLength;
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MarkdownExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MarkdownExtractor.java
@@ -15,7 +15,6 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -61,9 +60,6 @@ import org.commonmark.renderer.text.TextContentRenderer;
 public class MarkdownExtractor extends AbstractExtractor {
     /** Logger instance for this class. */
     private static final Logger logger = LogManager.getLogger(MarkdownExtractor.class);
-
-    /** Default read buffer size in characters. */
-    private static final int READ_BUFFER_SIZE = 8192;
 
     /** Default encoding for Markdown files. */
     protected String encoding = Constants.UTF_8;
@@ -138,7 +134,7 @@ public class MarkdownExtractor extends AbstractExtractor {
         validateInputStream(in);
 
         try {
-            final ReadResult readResult = readMarkdown(in);
+            final TextReadResult readResult = readMarkdown(in);
             final Node document = parser.parse(readResult.content);
 
             // Extract plain text
@@ -173,21 +169,6 @@ public class MarkdownExtractor extends AbstractExtractor {
     }
 
     /**
-     * Holder for the result of {@link #readMarkdown(InputStream)}.
-     */
-    protected static final class ReadResult {
-        /** The decoded Markdown source (possibly truncated). */
-        public final String content;
-        /** Whether the content was truncated at {@code maxTextLength}. */
-        public final boolean truncated;
-
-        ReadResult(final String content, final boolean truncated) {
-            this.content = content;
-            this.truncated = truncated;
-        }
-    }
-
-    /**
      * Reads the entire Markdown source from the supplied input stream, honoring
      * a leading BOM when present and bounding the result by {@link #maxTextLength}.
      *
@@ -197,10 +178,10 @@ public class MarkdownExtractor extends AbstractExtractor {
      * front matter.
      *
      * @param in the input stream
-     * @return a {@link ReadResult} containing the decoded Markdown source and whether truncation occurred
+     * @return a {@link TextReadResult} containing the decoded Markdown source and whether truncation occurred
      * @throws IOException if reading fails
      */
-    protected ReadResult readMarkdown(final InputStream in) throws IOException {
+    protected TextReadResult readMarkdown(final InputStream in) throws IOException {
         try (BOMInputStream bomIn = BOMInputStream.builder()
                 .setInputStream(in)
                 .setInclude(false)
@@ -209,31 +190,8 @@ public class MarkdownExtractor extends AbstractExtractor {
                 .get()) {
             final String detected = bomIn.getBOMCharsetName();
             final String charset = detected != null ? detected : getEncoding();
-            try (Reader reader = new InputStreamReader(bomIn, charset); BufferedReader br = new BufferedReader(reader)) {
-                final StringBuilder sb = new StringBuilder();
-                final char[] buf = new char[READ_BUFFER_SIZE];
-                long total = 0;
-                boolean truncated = false;
-                int n;
-                while ((n = br.read(buf)) >= 0) {
-                    if (maxTextLength > 0 && total + n > maxTextLength) {
-                        final int remaining = (int) (maxTextLength - total);
-                        if (remaining > 0) {
-                            sb.append(buf, 0, remaining);
-                        }
-                        // Avoid leaving an unpaired high surrogate at the end.
-                        if (sb.length() > 0 && Character.isHighSurrogate(sb.charAt(sb.length() - 1))) {
-                            sb.setLength(sb.length() - 1);
-                        }
-                        logger.warn("Extracted content truncated: extractor={} maxTextLength={} totalChars={}", getClass().getSimpleName(),
-                                maxTextLength, total + n);
-                        truncated = true;
-                        break;
-                    }
-                    sb.append(buf, 0, n);
-                    total += n;
-                }
-                return new ReadResult(sb.toString(), truncated);
+            try (Reader reader = new InputStreamReader(bomIn, charset)) {
+                return readWithLimit(reader, maxTextLength);
             }
         }
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MarkdownExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/MarkdownExtractor.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.crawler.extractor.impl;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -53,7 +54,7 @@ import org.commonmark.renderer.text.TextContentRenderer;
  *   <li>Link URL extraction</li>
  *   <li>Code block content extraction</li>
  *   <li>Clean text conversion from Markdown</li>
- *   <li>Configurable encoding with BOM detection (UTF-8/UTF-16/UTF-32)</li>
+ *   <li>Configurable encoding with BOM detection (UTF-8, UTF-16 LE/BE, UTF-32 LE/BE)</li>
  *   <li>Reader-based streaming with optional length cap to bound heap usage</li>
  * </ul>
  */
@@ -77,9 +78,13 @@ public class MarkdownExtractor extends AbstractExtractor {
     protected boolean extractLinks = false;
 
     /**
-     * Maximum number of characters to read from the input. Defaults to
-     * {@link Long#MAX_VALUE} (effectively unlimited). Values less than or
-     * equal to zero are also interpreted as unlimited.
+     * Maximum number of characters to read from the input. The default is
+     * {@link Long#MAX_VALUE}, which is effectively unlimited. Values less than
+     * or equal to zero explicitly disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
      */
     protected long maxTextLength = Long.MAX_VALUE;
 
@@ -111,18 +116,40 @@ public class MarkdownExtractor extends AbstractExtractor {
         textRenderer = TextContentRenderer.builder().build();
     }
 
+    /**
+     * Extracts text from the supplied Markdown input stream.
+     *
+     * <p>The stream is decoded using the configured {@link #encoding}, overridden
+     * when a BOM (UTF-8, UTF-16 LE/BE, UTF-32 LE/BE) is detected at the start.
+     * The raw character count is bounded by {@link #maxTextLength} before Markdown
+     * parsing begins. When truncation occurs, a WARN-level log message is emitted
+     * and the returned {@link ExtractData} carries {@code truncated=true} and
+     * {@code maxTextLength=<value>} metadata entries. The supplied {@code in} is
+     * closed by this method.
+     *
+     * @param in the Markdown input stream; must not be {@code null}
+     * @param params optional extraction parameters (may be {@code null})
+     * @return the extracted text and metadata
+     * @throws org.codelibs.fess.crawler.exception.CrawlerSystemException if {@code in} is {@code null}
+     * @throws ExtractException if reading or parsing fails
+     */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
         validateInputStream(in);
 
         try {
-            final String rawMarkdown = readMarkdown(in);
-            final Node document = parser.parse(rawMarkdown);
+            final ReadResult readResult = readMarkdown(in);
+            final Node document = parser.parse(readResult.content);
 
             // Extract plain text
             final String plainText = textRenderer.render(document);
 
             final ExtractData extractData = new ExtractData(plainText);
+
+            if (readResult.truncated) {
+                extractData.putValue("truncated", "true");
+                extractData.putValue("maxTextLength", Long.toString(maxTextLength));
+            }
 
             // Extract front matter metadata
             if (extractFrontMatter) {
@@ -146,42 +173,68 @@ public class MarkdownExtractor extends AbstractExtractor {
     }
 
     /**
+     * Holder for the result of {@link #readMarkdown(InputStream)}.
+     */
+    protected static final class ReadResult {
+        /** The decoded Markdown source (possibly truncated). */
+        public final String content;
+        /** Whether the content was truncated at {@code maxTextLength}. */
+        public final boolean truncated;
+
+        ReadResult(final String content, final boolean truncated) {
+            this.content = content;
+            this.truncated = truncated;
+        }
+    }
+
+    /**
      * Reads the entire Markdown source from the supplied input stream, honoring
      * a leading BOM when present and bounding the result by {@link #maxTextLength}.
      *
+     * <p>Note: When {@code maxTextLength} truncates the input before the closing
+     * YAML front-matter delimiter ({@code ---}), front-matter metadata extraction
+     * will silently fail. Set {@code maxTextLength} large enough to contain the
+     * front matter.
+     *
      * @param in the input stream
-     * @return the decoded Markdown source
-     * @throws java.io.IOException if reading fails
+     * @return a {@link ReadResult} containing the decoded Markdown source and whether truncation occurred
+     * @throws IOException if reading fails
      */
-    protected String readMarkdown(final InputStream in) throws java.io.IOException {
-        final BOMInputStream bomIn = BOMInputStream.builder()
+    protected ReadResult readMarkdown(final InputStream in) throws IOException {
+        try (BOMInputStream bomIn = BOMInputStream.builder()
                 .setInputStream(in)
                 .setInclude(false)
                 .setByteOrderMarks(ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE,
                         ByteOrderMark.UTF_32BE)
-                .get();
-        final String detected = bomIn.getBOMCharsetName();
-        final String charset = detected != null ? detected : getEncoding();
-        try (Reader reader = new InputStreamReader(bomIn, charset); BufferedReader br = new BufferedReader(reader)) {
-            final StringBuilder sb = new StringBuilder();
-            final char[] buf = new char[READ_BUFFER_SIZE];
-            long total = 0;
-            int n;
-            while ((n = br.read(buf)) >= 0) {
-                if (maxTextLength > 0 && total + n > maxTextLength) {
-                    final int remaining = (int) (maxTextLength - total);
-                    if (remaining > 0) {
-                        sb.append(buf, 0, remaining);
+                .get()) {
+            final String detected = bomIn.getBOMCharsetName();
+            final String charset = detected != null ? detected : getEncoding();
+            try (Reader reader = new InputStreamReader(bomIn, charset); BufferedReader br = new BufferedReader(reader)) {
+                final StringBuilder sb = new StringBuilder();
+                final char[] buf = new char[READ_BUFFER_SIZE];
+                long total = 0;
+                boolean truncated = false;
+                int n;
+                while ((n = br.read(buf)) >= 0) {
+                    if (maxTextLength > 0 && total + n > maxTextLength) {
+                        final int remaining = (int) (maxTextLength - total);
+                        if (remaining > 0) {
+                            sb.append(buf, 0, remaining);
+                        }
+                        // Avoid leaving an unpaired high surrogate at the end.
+                        if (sb.length() > 0 && Character.isHighSurrogate(sb.charAt(sb.length() - 1))) {
+                            sb.setLength(sb.length() - 1);
+                        }
+                        logger.warn("Extracted content truncated: extractor={} maxTextLength={} totalChars={}", getClass().getSimpleName(),
+                                maxTextLength, total + n);
+                        truncated = true;
+                        break;
                     }
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Truncating Markdown content at maxTextLength={} characters", maxTextLength);
-                    }
-                    break;
+                    sb.append(buf, 0, n);
+                    total += n;
                 }
-                sb.append(buf, 0, n);
-                total += n;
+                return new ReadResult(sb.toString(), truncated);
             }
-            return sb.toString();
         }
     }
 
@@ -317,9 +370,13 @@ public class MarkdownExtractor extends AbstractExtractor {
     }
 
     /**
-     * Sets the maximum number of characters that will be extracted. Values
-     * less than or equal to zero, or {@link Long#MAX_VALUE}, are interpreted
-     * as unlimited.
+     * Sets the maximum number of characters that will be extracted. The default
+     * is {@link Long#MAX_VALUE}, which is effectively unlimited. Values less
+     * than or equal to zero explicitly disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
      *
      * @param maxTextLength the maximum text length
      */

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TextExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TextExtractor.java
@@ -32,7 +32,7 @@ import org.codelibs.fess.crawler.exception.ExtractException;
  * <p>The extractor honors a Byte Order Mark (BOM) at the start of the stream when
  * present (UTF-8, UTF-16 LE/BE, UTF-32 LE/BE) and decodes the stream accordingly.
  * If no BOM is detected, the configured {@link #encoding} is used.
- * The text is streamed via a {@link BufferedReader} so that very large inputs do
+ * The text is streamed via a {@code BufferedReader} so that very large inputs do
  * not require buffering the entire file as a byte array. The total number of
  * characters appended to the result can be capped by {@link #maxTextLength}.
  */

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TextExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TextExtractor.java
@@ -15,23 +15,51 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
+import java.io.BufferedReader;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.Map;
 
-import org.codelibs.core.io.InputStreamUtil;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.ExtractException;
 
 /**
  * Extracts text content from an input stream as plain text.
+ *
+ * <p>The extractor honors a Byte Order Mark (BOM) at the start of the stream when
+ * present (UTF-8, UTF-16 LE/BE, UTF-32 LE/BE) and decodes the stream accordingly.
+ * If no BOM is detected, the configured {@link #encoding} is used.
+ * The text is streamed via a {@link BufferedReader} so that very large inputs do
+ * not require buffering the entire file as a byte array. The total number of
+ * characters appended to the result can be capped by {@link #maxTextLength}.
  */
 public class TextExtractor extends AbstractExtractor {
+
+    private static final Logger logger = LogManager.getLogger(TextExtractor.class);
+
+    /**
+     * Default read buffer size in characters.
+     */
+    private static final int READ_BUFFER_SIZE = 8192;
 
     /**
      * The encoding for text.
      */
     protected String encoding = Constants.UTF_8;
+
+    /**
+     * Maximum number of characters to read from the input. Defaults to
+     * {@link Long#MAX_VALUE} which effectively imposes no limit. Set to a
+     * positive value to cap the resulting text length and avoid excessive heap
+     * usage on very large inputs.
+     */
+    protected long maxTextLength = Long.MAX_VALUE;
 
     /**
      * Creates a new TextExtractor instance.
@@ -44,8 +72,35 @@ public class TextExtractor extends AbstractExtractor {
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
         validateInputStream(in);
         try {
-            final String content = new String(InputStreamUtil.getBytes(in), getEncoding());
-            return new ExtractData(content);
+            final BOMInputStream bomIn = BOMInputStream.builder()
+                    .setInputStream(in)
+                    .setInclude(false)
+                    .setByteOrderMarks(ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE,
+                            ByteOrderMark.UTF_32BE)
+                    .get();
+            final String detected = bomIn.getBOMCharsetName();
+            final String charset = detected != null ? detected : getEncoding();
+            try (Reader reader = new InputStreamReader(bomIn, charset); BufferedReader br = new BufferedReader(reader)) {
+                final StringBuilder sb = new StringBuilder();
+                final char[] buf = new char[READ_BUFFER_SIZE];
+                long total = 0;
+                int n;
+                while ((n = br.read(buf)) >= 0) {
+                    if (maxTextLength > 0 && total + n > maxTextLength) {
+                        final int remaining = (int) (maxTextLength - total);
+                        if (remaining > 0) {
+                            sb.append(buf, 0, remaining);
+                        }
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Truncating text content at maxTextLength={} characters", maxTextLength);
+                        }
+                        break;
+                    }
+                    sb.append(buf, 0, n);
+                    total += n;
+                }
+                return new ExtractData(sb.toString());
+            }
         } catch (final Exception e) {
             throw new ExtractException("Failed to extract text content using encoding: " + getEncoding(), e);
         }
@@ -65,5 +120,26 @@ public class TextExtractor extends AbstractExtractor {
      */
     public void setEncoding(final String encoding) {
         this.encoding = encoding;
+    }
+
+    /**
+     * Returns the maximum number of characters that will be extracted.
+     * @return the maximum text length
+     */
+    public long getMaxTextLength() {
+        return maxTextLength;
+    }
+
+    /**
+     * Sets the maximum number of characters that will be extracted. The
+     * default is {@link Long#MAX_VALUE} which effectively means unlimited.
+     * Setting a positive value caps the resulting text and stops reading once
+     * the limit is reached. Values less than or equal to zero are interpreted
+     * as unlimited.
+     *
+     * @param maxTextLength the maximum text length in characters
+     */
+    public void setMaxTextLength(final long maxTextLength) {
+        this.maxTextLength = maxTextLength;
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TextExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TextExtractor.java
@@ -15,7 +15,6 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -23,8 +22,6 @@ import java.util.Map;
 
 import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.input.BOMInputStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.ExtractException;
@@ -40,13 +37,6 @@ import org.codelibs.fess.crawler.exception.ExtractException;
  * characters appended to the result can be capped by {@link #maxTextLength}.
  */
 public class TextExtractor extends AbstractExtractor {
-
-    private static final Logger logger = LogManager.getLogger(TextExtractor.class);
-
-    /**
-     * Default read buffer size in characters.
-     */
-    private static final int READ_BUFFER_SIZE = 8192;
 
     /**
      * The encoding for text.
@@ -100,32 +90,10 @@ public class TextExtractor extends AbstractExtractor {
                     .get()) {
                 final String detected = bomIn.getBOMCharsetName();
                 final String charset = detected != null ? detected : getEncoding();
-                try (Reader reader = new InputStreamReader(bomIn, charset); BufferedReader br = new BufferedReader(reader)) {
-                    final StringBuilder sb = new StringBuilder();
-                    final char[] buf = new char[READ_BUFFER_SIZE];
-                    long total = 0;
-                    boolean truncated = false;
-                    int n;
-                    while ((n = br.read(buf)) >= 0) {
-                        if (maxTextLength > 0 && total + n > maxTextLength) {
-                            final int remaining = (int) (maxTextLength - total);
-                            if (remaining > 0) {
-                                sb.append(buf, 0, remaining);
-                            }
-                            // Avoid leaving an unpaired high surrogate at the end.
-                            if (sb.length() > 0 && Character.isHighSurrogate(sb.charAt(sb.length() - 1))) {
-                                sb.setLength(sb.length() - 1);
-                            }
-                            logger.warn("Extracted content truncated: extractor={} maxTextLength={} totalChars={}",
-                                    getClass().getSimpleName(), maxTextLength, total + n);
-                            truncated = true;
-                            break;
-                        }
-                        sb.append(buf, 0, n);
-                        total += n;
-                    }
-                    final ExtractData extractData = new ExtractData(sb.toString());
-                    if (truncated) {
+                try (Reader reader = new InputStreamReader(bomIn, charset)) {
+                    final TextReadResult result = readWithLimit(reader, maxTextLength);
+                    final ExtractData extractData = new ExtractData(result.content);
+                    if (result.truncated) {
                         extractData.putValue("truncated", "true");
                         extractData.putValue("maxTextLength", Long.toString(maxTextLength));
                     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TextExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TextExtractor.java
@@ -54,10 +54,13 @@ public class TextExtractor extends AbstractExtractor {
     protected String encoding = Constants.UTF_8;
 
     /**
-     * Maximum number of characters to read from the input. Defaults to
-     * {@link Long#MAX_VALUE} which effectively imposes no limit. Set to a
-     * positive value to cap the resulting text length and avoid excessive heap
-     * usage on very large inputs.
+     * Maximum number of characters to read from the input. The default is
+     * {@link Long#MAX_VALUE}, which is effectively unlimited. Values less than
+     * or equal to zero explicitly disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
      */
     protected long maxTextLength = Long.MAX_VALUE;
 
@@ -68,38 +71,66 @@ public class TextExtractor extends AbstractExtractor {
         super();
     }
 
+    /**
+     * Extracts text from the supplied input stream.
+     *
+     * <p>The stream is decoded using the configured {@link #encoding}, overridden
+     * when a BOM (UTF-8, UTF-16 LE/BE, UTF-32 LE/BE) is detected at the start.
+     * The total character count is bounded by {@link #maxTextLength}. When
+     * truncation occurs, a WARN-level log message is emitted and the returned
+     * {@link ExtractData} carries {@code truncated=true} and
+     * {@code maxTextLength=<value>} metadata entries. The supplied {@code in} is
+     * closed by this method.
+     *
+     * @param in the text input stream; must not be {@code null}
+     * @param params optional extraction parameters (may be {@code null})
+     * @return the extracted text and optional truncation metadata
+     * @throws org.codelibs.fess.crawler.exception.CrawlerSystemException if {@code in} is {@code null}
+     * @throws ExtractException if reading or decoding fails
+     */
     @Override
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
         validateInputStream(in);
         try {
-            final BOMInputStream bomIn = BOMInputStream.builder()
+            try (BOMInputStream bomIn = BOMInputStream.builder()
                     .setInputStream(in)
                     .setInclude(false)
                     .setByteOrderMarks(ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE,
                             ByteOrderMark.UTF_32BE)
-                    .get();
-            final String detected = bomIn.getBOMCharsetName();
-            final String charset = detected != null ? detected : getEncoding();
-            try (Reader reader = new InputStreamReader(bomIn, charset); BufferedReader br = new BufferedReader(reader)) {
-                final StringBuilder sb = new StringBuilder();
-                final char[] buf = new char[READ_BUFFER_SIZE];
-                long total = 0;
-                int n;
-                while ((n = br.read(buf)) >= 0) {
-                    if (maxTextLength > 0 && total + n > maxTextLength) {
-                        final int remaining = (int) (maxTextLength - total);
-                        if (remaining > 0) {
-                            sb.append(buf, 0, remaining);
+                    .get()) {
+                final String detected = bomIn.getBOMCharsetName();
+                final String charset = detected != null ? detected : getEncoding();
+                try (Reader reader = new InputStreamReader(bomIn, charset); BufferedReader br = new BufferedReader(reader)) {
+                    final StringBuilder sb = new StringBuilder();
+                    final char[] buf = new char[READ_BUFFER_SIZE];
+                    long total = 0;
+                    boolean truncated = false;
+                    int n;
+                    while ((n = br.read(buf)) >= 0) {
+                        if (maxTextLength > 0 && total + n > maxTextLength) {
+                            final int remaining = (int) (maxTextLength - total);
+                            if (remaining > 0) {
+                                sb.append(buf, 0, remaining);
+                            }
+                            // Avoid leaving an unpaired high surrogate at the end.
+                            if (sb.length() > 0 && Character.isHighSurrogate(sb.charAt(sb.length() - 1))) {
+                                sb.setLength(sb.length() - 1);
+                            }
+                            logger.warn("Extracted content truncated: extractor={} maxTextLength={} totalChars={}",
+                                    getClass().getSimpleName(), maxTextLength, total + n);
+                            truncated = true;
+                            break;
                         }
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Truncating text content at maxTextLength={} characters", maxTextLength);
-                        }
-                        break;
+                        sb.append(buf, 0, n);
+                        total += n;
                     }
-                    sb.append(buf, 0, n);
-                    total += n;
+                    final ExtractData extractData = new ExtractData(sb.toString());
+                    if (truncated) {
+                        extractData.putValue("truncated", "true");
+                        extractData.putValue("maxTextLength", Long.toString(maxTextLength));
+                    }
+                    return extractData;
                 }
-                return new ExtractData(sb.toString());
             }
         } catch (final Exception e) {
             throw new ExtractException("Failed to extract text content using encoding: " + getEncoding(), e);
@@ -131,11 +162,13 @@ public class TextExtractor extends AbstractExtractor {
     }
 
     /**
-     * Sets the maximum number of characters that will be extracted. The
-     * default is {@link Long#MAX_VALUE} which effectively means unlimited.
-     * Setting a positive value caps the resulting text and stops reading once
-     * the limit is reached. Values less than or equal to zero are interpreted
-     * as unlimited.
+     * Sets the maximum number of characters that will be extracted. The default
+     * is {@link Long#MAX_VALUE}, which is effectively unlimited. Values less
+     * than or equal to zero explicitly disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
      *
      * @param maxTextLength the maximum text length in characters
      */

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/MarkdownExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/MarkdownExtractorTest.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.crawler.extractor.impl;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
@@ -28,7 +29,6 @@ import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.dbflute.utflute.core.PlainTestCase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -267,5 +267,89 @@ public class MarkdownExtractorTest extends PlainTestCase {
         final String content = extractData.getContent();
         // The rendered content cannot exceed the truncated source length.
         assertTrue(content.length() <= 20);
+    }
+
+    @Test
+    public void test_extractsUtf16LeWithBom_markdown() {
+        markdownExtractor.setEncoding("UTF-8");
+        final String md = "# Hello UTF-16 LE\n\nBody text.";
+        final byte[] bom = { (byte) 0xFF, (byte) 0xFE };
+        final InputStream in =
+                new SequenceInputStream(new ByteArrayInputStream(bom), new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_16LE)));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String content = extractData.getContent();
+        assertTrue(content.contains("Hello UTF-16 LE"));
+        assertTrue(content.contains("Body text."));
+    }
+
+    @Test
+    public void test_extractsUtf16BeWithBom_markdown() {
+        markdownExtractor.setEncoding("UTF-8");
+        final String md = "# Hello UTF-16 BE\n\nBody text.";
+        final byte[] bom = { (byte) 0xFE, (byte) 0xFF };
+        final InputStream in =
+                new SequenceInputStream(new ByteArrayInputStream(bom), new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_16BE)));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String content = extractData.getContent();
+        assertTrue(content.contains("Hello UTF-16 BE"));
+        assertTrue(content.contains("Body text."));
+    }
+
+    @Test
+    public void test_extractsShiftJis_markdown_noBom() {
+        markdownExtractor.setEncoding("Shift_JIS");
+        final String md = "# シフトJIS\n\n本文テスト。";
+        final InputStream in = new ByteArrayInputStream(md.getBytes(Charset.forName("Shift_JIS")));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String content = extractData.getContent();
+        assertTrue(content.contains("シフトJIS"));
+        assertTrue(content.contains("本文テスト"));
+    }
+
+    @Test
+    public void test_maxTextLength_zero_isUnlimited() {
+        // maxTextLength=0 means unlimited (condition: maxTextLength > 0 is false).
+        markdownExtractor.setMaxTextLength(0);
+        final String md = "# Title\n\nHello world full content.";
+        final InputStream in = new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String content = extractData.getContent();
+        assertTrue(content.contains("Title"));
+        assertTrue(content.contains("Hello world full content."));
+        // No truncation metadata expected.
+        assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_maxTextLength_negative_isUnlimited() {
+        // Negative maxTextLength means unlimited.
+        markdownExtractor.setMaxTextLength(-1);
+        final String md = "# Title\n\nFull content survives.";
+        final InputStream in = new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String content = extractData.getContent();
+        assertTrue(content.contains("Full content survives."));
+        assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_truncatedMetadataFlag() {
+        // When truncation occurs the ExtractData must carry truncated=true and maxTextLength metadata.
+        markdownExtractor.setMaxTextLength(10);
+        final String md = "# Title\n\nThis is a much longer Markdown document that should be truncated.";
+        final InputStream in = new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String[] truncated = extractData.getValues("truncated");
+        assertNotNull(truncated);
+        assertEquals("true", truncated[0]);
+        final String[] maxLen = extractData.getValues("maxTextLength");
+        assertNotNull(maxLen);
+        assertEquals("10", maxLen[0]);
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/MarkdownExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/MarkdownExtractorTest.java
@@ -15,7 +15,10 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -177,5 +180,92 @@ public class MarkdownExtractorTest extends PlainTestCase {
 
         // Code blocks should be converted to plain text
         assertTrue(content.contains("public class Example") || content.contains("Example"));
+    }
+
+    @Test
+    public void test_extractsBody() {
+        final String md = "# Title\n\nHello world body.";
+        final InputStream in = new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String content = extractData.getContent();
+        assertTrue(content.contains("Title"));
+        assertTrue(content.contains("Hello world body."));
+    }
+
+    @Test
+    public void test_extractsYamlFrontMatter() {
+        final String md = "---\n" + "title: My Title\n" + "author: Alice\n" + "tags: [one, two]\n" + "---\n\n" + "# Heading\n\nBody.";
+        final InputStream in = new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+
+        final String[] titles = extractData.getValues("frontmatter.title");
+        assertNotNull(titles);
+        assertEquals("My Title", titles[0]);
+
+        final String[] authors = extractData.getValues("frontmatter.author");
+        assertNotNull(authors);
+        assertEquals("Alice", authors[0]);
+
+        final String content = extractData.getContent();
+        assertTrue(content.contains("Heading"));
+        assertTrue(content.contains("Body."));
+    }
+
+    @Test
+    public void test_handlesNoFrontMatter() {
+        final String md = "Just some plain markdown without front matter.\n\n## Section\n\nText.";
+        final InputStream in = new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+
+        // No front matter values should be present.
+        assertNull(extractData.getValues("frontmatter.title"));
+
+        final String content = extractData.getContent();
+        assertTrue(content.contains("plain markdown"));
+        assertTrue(content.contains("Section"));
+    }
+
+    @Test
+    public void test_extractsUtf8WithBom() {
+        final String md = "# Heading\n\nBody with BOM.";
+        final byte[] bom = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+        final InputStream in =
+                new SequenceInputStream(new ByteArrayInputStream(bom), new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_8)));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+
+        final String content = extractData.getContent();
+        // BOM-induced replacement character at the start of the heading would block parsing as a heading.
+        // After our fix, the heading should be recognized as plain text.
+        assertTrue(content.contains("Heading"));
+        assertTrue(content.contains("Body with BOM."));
+        // Heading metadata extraction should also see the heading correctly.
+        final String[] headings = extractData.getValues("headings");
+        assertNotNull(headings);
+        boolean foundHeading = false;
+        for (final String heading : headings) {
+            if ("Heading".equals(heading)) {
+                foundHeading = true;
+                break;
+            }
+        }
+        assertTrue(foundHeading);
+    }
+
+    @Test
+    public void test_truncatesAtMaxTextLength() {
+        markdownExtractor.setMaxTextLength(20);
+        // The Markdown source itself is truncated at 20 chars before parsing.
+        final String md = "# Title\n\nThis body is much longer than twenty characters.";
+        final InputStream in = new ByteArrayInputStream(md.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = markdownExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+
+        final String content = extractData.getContent();
+        // The rendered content cannot exceed the truncated source length.
+        assertTrue(content.length() <= 20);
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/TextExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/TextExtractorTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fess.crawler.extractor.impl;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.nio.charset.StandardCharsets;
@@ -25,9 +26,9 @@ import org.apache.logging.log4j.Logger;
 import org.codelibs.core.io.CloseableUtil;
 import org.codelibs.core.io.ResourceUtil;
 import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
+import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.dbflute.utflute.core.PlainTestCase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -151,5 +152,172 @@ public class TextExtractorTest extends PlainTestCase {
         // Avoid full equality string comparison (already covered by length); spot check first/last 32.
         assertEquals(expected.substring(0, 32), content.substring(0, 32));
         assertEquals(expected.substring(totalChars - 32), content.substring(totalChars - 32));
+    }
+
+    @Test
+    public void test_maxTextLength_zero_isUnlimited() {
+        // maxTextLength=0 means unlimited (condition: maxTextLength > 0 is false).
+        textExtractor.setMaxTextLength(0);
+        final String text = "Hello full content.";
+        final InputStream in = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = textExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertEquals(text, extractData.getContent());
+        assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_maxTextLength_negative_isUnlimited() {
+        // Negative maxTextLength means unlimited.
+        textExtractor.setMaxTextLength(-1);
+        final String text = "Full content survives.";
+        final InputStream in = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = textExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertEquals(text, extractData.getContent());
+        assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_maxTextLength_exactlyContentLength() {
+        // When cap == content length, no truncation should occur.
+        final String text = "ExactFit";
+        textExtractor.setMaxTextLength(text.length());
+        final InputStream in = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = textExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertEquals(text, extractData.getContent());
+        assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_maxTextLength_one() {
+        textExtractor.setMaxTextLength(1);
+        final String text = "ABCDEF";
+        final InputStream in = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = textExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertEquals("A", extractData.getContent());
+        final String[] truncated = extractData.getValues("truncated");
+        assertNotNull(truncated);
+        assertEquals("true", truncated[0]);
+    }
+
+    @Test
+    public void test_maxTextLength_acrossBufferBoundary() {
+        // READ_BUFFER_SIZE=8192; set cap=8200 with 16384-char content so the
+        // truncation is detected in the second buffer read.
+        final int cap = 8200;
+        textExtractor.setMaxTextLength(cap);
+        final char[] unit = "abcdefghij".toCharArray();
+        final int totalChars = 16384;
+        final StringBuilder builder = new StringBuilder(totalChars);
+        for (int i = 0; i < totalChars; i++) {
+            builder.append(unit[i % unit.length]);
+        }
+        final String text = builder.toString();
+        final InputStream in = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = textExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String content = extractData.getContent();
+        assertTrue(content.length() <= cap);
+        assertTrue(content.length() > 0);
+        final String[] truncated = extractData.getValues("truncated");
+        assertNotNull(truncated);
+        assertEquals("true", truncated[0]);
+    }
+
+    @Test
+    public void test_truncatedMetadataFlag() {
+        // When truncation occurs the ExtractData must carry truncated=true and maxTextLength metadata.
+        textExtractor.setMaxTextLength(5);
+        final String text = "0123456789";
+        final InputStream in = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = textExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertEquals("01234", extractData.getContent());
+        final String[] truncated = extractData.getValues("truncated");
+        assertNotNull(truncated);
+        assertEquals("true", truncated[0]);
+        final String[] maxLen = extractData.getValues("maxTextLength");
+        assertNotNull(maxLen);
+        assertEquals("5", maxLen[0]);
+    }
+
+    @Test
+    public void test_midStreamBomIsPreserved() {
+        // A BOM in the middle of the stream (not at position 0) is NOT a real BOM;
+        // it should be preserved as U+FEFF in the output.
+        // We write plain ASCII then a BOM byte sequence (as UTF-8: EF BB BF).
+        final String prefix = "abc";
+        final byte[] bomBytes = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+        final String suffix = "xyz";
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            baos.write(prefix.getBytes(StandardCharsets.UTF_8));
+            baos.write(bomBytes);
+            baos.write(suffix.getBytes(StandardCharsets.UTF_8));
+        } catch (final Exception e) {
+            throw new RuntimeException("Setup failed: " + e.getMessage(), e);
+        }
+        final InputStream in = new ByteArrayInputStream(baos.toByteArray());
+        final String content = textExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        // The mid-stream BOM bytes decode as U+FEFF in UTF-8.
+        assertTrue(content.startsWith("abc"));
+        assertTrue(content.endsWith("xyz"));
+        // U+FEFF (BOM) should appear in the middle.
+        assertTrue(content.contains("﻿"));
+    }
+
+    @Test
+    public void test_surrogatePairAtBoundary() {
+        // Build a string where the last char before the cap is a high surrogate.
+        // U+1F600 (GRINNING FACE) encodes as the surrogate pair 0xD83D 0xDE00.
+        // We place it so the cap falls right after the high surrogate (0xD83D).
+        // The extractor must drop the dangling high surrogate.
+        final String emoji = "😀"; // U+1F600, 2 Java chars
+        // Build: 8 ASCII chars + emoji = 10 Java chars. Set cap=9 so the boundary
+        // falls at the high surrogate (char index 8).
+        final String text = "12345678" + emoji + "trailing";
+        textExtractor.setMaxTextLength(9); // cuts after char 9 — high surrogate at index 8 must be dropped
+        final InputStream in = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = textExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String content = extractData.getContent();
+        // High surrogate was dropped — result should be exactly the 8 ASCII chars.
+        assertEquals("12345678", content);
+        // Verify no unpaired high surrogate.
+        for (int i = 0; i < content.length(); i++) {
+            final char c = content.charAt(i);
+            assertFalse(Character.isHighSurrogate(c));
+        }
+    }
+
+    @Test
+    public void test_extractsUtf32LeWithBom() throws Exception {
+        textExtractor.setEncoding("UTF-8");
+        final String text = "Hello UTF-32 LE";
+        // UTF-32 LE BOM: FF FE 00 00
+        final byte[] bom = { (byte) 0xFF, (byte) 0xFE, (byte) 0x00, (byte) 0x00 };
+        // Encode text as UTF-32LE
+        final byte[] textBytes = text.getBytes("UTF-32LE");
+        final InputStream in = new SequenceInputStream(new ByteArrayInputStream(bom), new ByteArrayInputStream(textBytes));
+        final String content = textExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertEquals(text, content);
+    }
+
+    @Test
+    public void test_extractsUtf32BeWithBom() throws Exception {
+        textExtractor.setEncoding("UTF-8");
+        final String text = "Hello UTF-32 BE";
+        // UTF-32 BE BOM: 00 00 FE FF
+        final byte[] bom = { (byte) 0x00, (byte) 0x00, (byte) 0xFE, (byte) 0xFF };
+        final byte[] textBytes = text.getBytes("UTF-32BE");
+        final InputStream in = new SequenceInputStream(new ByteArrayInputStream(bom), new ByteArrayInputStream(textBytes));
+        final String content = textExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertEquals(text, content);
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/TextExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/TextExtractorTest.java
@@ -15,7 +15,10 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -61,5 +64,92 @@ public class TextExtractorTest extends PlainTestCase {
         } catch (final CrawlerSystemException e) {
             // NOP
         }
+    }
+
+    @Test
+    public void test_extractsUtf8() {
+        final String text = "Hello, world! こんにちは";
+        final InputStream in = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        final String content = textExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertEquals(text, content);
+    }
+
+    @Test
+    public void test_extractsUtf8WithBom() {
+        final String text = "BOM stripped テスト";
+        final byte[] bom = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+        final InputStream in =
+                new SequenceInputStream(new ByteArrayInputStream(bom), new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)));
+        final String content = textExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertEquals(text, content);
+        assertFalse(content.startsWith("﻿"));
+    }
+
+    @Test
+    public void test_extractsUtf16LeWithBom() {
+        // Configure a non-UTF16 encoding to prove the BOM (not the configured encoding) wins.
+        textExtractor.setEncoding("UTF-8");
+        final String text = "Hello UTF-16 LE テスト";
+        final byte[] bom = { (byte) 0xFF, (byte) 0xFE };
+        final InputStream in =
+                new SequenceInputStream(new ByteArrayInputStream(bom), new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_16LE)));
+        final String content = textExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertEquals(text, content);
+    }
+
+    @Test
+    public void test_extractsUtf16BeWithBom() {
+        textExtractor.setEncoding("UTF-8");
+        final String text = "Hello UTF-16 BE テスト";
+        final byte[] bom = { (byte) 0xFE, (byte) 0xFF };
+        final InputStream in =
+                new SequenceInputStream(new ByteArrayInputStream(bom), new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_16BE)));
+        final String content = textExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertEquals(text, content);
+    }
+
+    @Test
+    public void test_extractsShiftJis() {
+        textExtractor.setEncoding("Shift_JIS");
+        final String text = "シフトジステスト hello";
+        final InputStream in = new ByteArrayInputStream(text.getBytes(java.nio.charset.Charset.forName("Shift_JIS")));
+        final String content = textExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertEquals(text, content);
+    }
+
+    @Test
+    public void test_truncatesAtMaxTextLength() {
+        textExtractor.setMaxTextLength(10);
+        final String text = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"; // 36 chars
+        final InputStream in = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        final String content = textExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertEquals(10, content.length());
+        assertEquals("0123456789", content);
+    }
+
+    @Test
+    public void test_largeFile_streamsCorrectly() {
+        // 10 MiB of repeating content; verify exact length and a sample.
+        final char[] unit = "abcdefghij".toCharArray();
+        final int unitLen = unit.length;
+        final int totalChars = 10 * 1024 * 1024;
+        final StringBuilder builder = new StringBuilder(totalChars);
+        for (int i = 0; i < totalChars; i++) {
+            builder.append(unit[i % unitLen]);
+        }
+        final String expected = builder.toString();
+        final InputStream in = new ByteArrayInputStream(expected.getBytes(StandardCharsets.UTF_8));
+        final String content = textExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertEquals(totalChars, content.length());
+        // Avoid full equality string comparison (already covered by length); spot check first/last 32.
+        assertEquals(expected.substring(0, 32), content.substring(0, 32));
+        assertEquals(expected.substring(totalChars - 32), content.substring(totalChars - 32));
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/XmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/XmlExtractorTest.java
@@ -177,4 +177,57 @@ public class XmlExtractorTest extends PlainTestCase {
             // NOP
         }
     }
+
+    @Test
+    public void test_extractsXmlWithUtf8Bom() {
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/xml/test_utf8bom.xml");
+        final String content = xmlExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        logger.info(content);
+        // The first character of the extracted text should not be a BOM (﻿) since
+        // the BOM bytes are now stripped before decoding.
+        assertFalse(content.startsWith("﻿"));
+        assertTrue(content.length() >= 0);
+    }
+
+    @Test
+    public void test_extractsXmlWithUtf16LeBom() {
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/xml/test_utf16lebom.xml");
+        final String content = xmlExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        logger.info(content);
+        assertFalse(content.startsWith("﻿"));
+        assertTrue(content.length() >= 0);
+    }
+
+    @Test
+    public void test_extractsXmlWithUtf16BeBom() {
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/xml/test_utf16bebom.xml");
+        final String content = xmlExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        logger.info(content);
+        assertFalse(content.startsWith("﻿"));
+        assertTrue(content.length() >= 0);
+    }
+
+    @Test
+    public void test_truncatesAtMaxTextLength() {
+        // Build a long XML string and verify the extractor honours maxTextLength.
+        final StringBuilder sb = new StringBuilder();
+        sb.append("<root>");
+        for (int i = 0; i < 1000; i++) {
+            sb.append("<item>x</item>");
+        }
+        sb.append("</root>");
+        final byte[] bytes = sb.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        xmlExtractor.setMaxTextLength(50);
+        final InputStream in = new ByteArrayInputStream(bytes);
+        // We can't directly observe the truncated raw input from the public API, but we
+        // can ensure that extraction completes successfully and produces a non-null result.
+        final String content = xmlExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertNotNull(content);
+        // Reset to unlimited so subsequent tests in the suite are unaffected.
+        xmlExtractor.setMaxTextLength(Long.MAX_VALUE);
+    }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/XmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/XmlExtractorTest.java
@@ -18,15 +18,16 @@ package org.codelibs.fess.crawler.extractor.impl;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.io.CloseableUtil;
 import org.codelibs.core.io.ResourceUtil;
 import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
+import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.dbflute.utflute.core.PlainTestCase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -188,6 +189,8 @@ public class XmlExtractorTest extends PlainTestCase {
         // the BOM bytes are now stripped before decoding.
         assertFalse(content.startsWith("﻿"));
         assertTrue(content.length() >= 0);
+        // The xmlns attribute value survives extractString's attribute extraction.
+        assertTrue(content.contains("http://www.example.com/hoge"));
     }
 
     @Test
@@ -198,6 +201,8 @@ public class XmlExtractorTest extends PlainTestCase {
         logger.info(content);
         assertFalse(content.startsWith("﻿"));
         assertTrue(content.length() >= 0);
+        // The xmlns attribute value survives extractString's attribute extraction.
+        assertTrue(content.contains("http://www.example.com/hoge"));
     }
 
     @Test
@@ -208,6 +213,8 @@ public class XmlExtractorTest extends PlainTestCase {
         logger.info(content);
         assertFalse(content.startsWith("﻿"));
         assertTrue(content.length() >= 0);
+        // The xmlns attribute value survives extractString's attribute extraction.
+        assertTrue(content.contains("http://www.example.com/hoge"));
     }
 
     @Test
@@ -219,15 +226,62 @@ public class XmlExtractorTest extends PlainTestCase {
             sb.append("<item>x</item>");
         }
         sb.append("</root>");
-        final byte[] bytes = sb.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        final byte[] bytes = sb.toString().getBytes(StandardCharsets.UTF_8);
         xmlExtractor.setMaxTextLength(50);
         final InputStream in = new ByteArrayInputStream(bytes);
-        // We can't directly observe the truncated raw input from the public API, but we
-        // can ensure that extraction completes successfully and produces a non-null result.
+        final ExtractData extractData = xmlExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String content = extractData.getContent();
+        assertNotNull(content);
+        assertTrue(content.length() <= 50);
+        assertTrue(content.contains("x"));
+    }
+
+    @Test
+    public void test_largeXml_streamsCorrectly() {
+        // 100,000 items — verify that streaming doesn't OOM and produces correct output.
+        final StringBuilder sb = new StringBuilder();
+        sb.append("<root>");
+        for (int i = 0; i < 100_000; i++) {
+            sb.append("<item>x</item>");
+        }
+        sb.append("</root>");
+        final byte[] bytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+        final InputStream in = new ByteArrayInputStream(bytes);
         final String content = xmlExtractor.getText(in, null).getContent();
         CloseableUtil.closeQuietly(in);
         assertNotNull(content);
-        // Reset to unlimited so subsequent tests in the suite are unaffected.
-        xmlExtractor.setMaxTextLength(Long.MAX_VALUE);
+        assertTrue(content.contains("x"));
+    }
+
+    @Test
+    public void test_maxTextLength_zero_isUnlimited() {
+        // maxTextLength=0 should be treated as unlimited (condition: maxTextLength > 0 is false).
+        xmlExtractor.setMaxTextLength(0);
+        final String xml = "<root><item>hello world</item></root>";
+        final InputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+        final String content = xmlExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        assertTrue(content.contains("hello world"));
+    }
+
+    @Test
+    public void test_truncatedMetadataFlag() {
+        // When truncation occurs the ExtractData must carry truncated=true and maxTextLength metadata.
+        xmlExtractor.setMaxTextLength(20);
+        final StringBuilder sb = new StringBuilder("<root>");
+        for (int i = 0; i < 100; i++) {
+            sb.append("<item>x</item>");
+        }
+        sb.append("</root>");
+        final InputStream in = new ByteArrayInputStream(sb.toString().getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = xmlExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        final String[] truncated = extractData.getValues("truncated");
+        assertNotNull(truncated);
+        assertEquals("true", truncated[0]);
+        final String[] maxLen = extractData.getValues("maxTextLength");
+        assertNotNull(maxLen);
+        assertEquals("20", maxLen[0]);
     }
 }


### PR DESCRIPTION
## Summary
- Detect UTF-8/UTF-16/UTF-32 BOMs via `BOMInputStream` and decode accordingly; fall back to configured encoding when absent.
- Replace whole-file `IOUtils.toString` / `new String(getBytes())` with `BufferedReader` streaming bounded by `maxTextLength` (default unlimited; configurable).
- `AbstractXmlExtractor` now strips BOM bytes from the actual content stream before decoding so the XML parser does not see a leading `﻿`.
- `MarkdownExtractor` reuses the same Reader/BOM pipeline before handing the source to commonmark; YAML front-matter extraction is unaffected.

## Why
Large text/markdown/XML files cause unnecessary heap pressure since the entire byte buffer was materialized as a String before processing. Non-UTF-8 BOMs were silently misdecoded with the configured encoding, and the leading BOM character sometimes leaked into the extracted content.

## Tests
- BOM variants for UTF-8 / UTF-16 LE / UTF-16 BE on `TextExtractor`, `MarkdownExtractor`, `XmlExtractor`.
- Shift_JIS without BOM (configured encoding wins).
- Truncation at `maxTextLength`.
- Large-file (10 MiB) streaming verifies exact length and head/tail bytes.
- Markdown body / YAML front matter / no-front-matter paths.
- XML extractor BOM tests using existing `extractor/xml/test_utf8bom.xml`, `test_utf16lebom.xml`, `test_utf16bebom.xml` fixtures.
- All existing extractor tests still pass.

## Test plan
- [ ] CI green
- [ ] Manual review of BOM + reader composition