### PR TITLE
refactor(crawler): tighten CrawlerThread hot path

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerThread.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerThread.java
@@ -402,7 +402,7 @@ public class CrawlerThread implements Runnable {
         }
 
         // add url and filter
-        final Set<String> urlSet = new HashSet<>(childUrlList.size());
+        final Set<String> urlSet = HashSet.newHashSet(childUrlList.size());
         final List<UrlQueue<?>> childList = new ArrayList<>(childUrlList.size());
         for (final RequestData d : childUrlList) {
             final String childUrl = d.getUrl();

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerThread.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerThread.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.codelibs.core.io.CloseableUtil;
 import org.codelibs.core.lang.StringUtil;
@@ -403,21 +402,23 @@ public class CrawlerThread implements Runnable {
         }
 
         // add url and filter
-        final Set<String> urlSet = new HashSet<>();
-        final List<UrlQueue<?>> childList = childUrlList.stream()
-                .filter(d -> StringUtil.isNotBlank(d.getUrl()) && urlSet.add(d.getUrl()) && crawlerContext.urlFilter.match(d.getUrl()))
-                .map(d -> {
-                    final UrlQueue<?> uq = crawlerContainer.getComponent("urlQueue");
-                    uq.setCreateTime(SystemUtil.currentTimeMillis());
-                    uq.setDepth(depth);
-                    uq.setMethod(Constants.GET_METHOD);
-                    uq.setParentUrl(url);
-                    uq.setSessionId(crawlerContext.sessionId);
-                    uq.setUrl(d.getUrl());
-                    uq.setWeight(d.getWeight());
-                    return uq;
-                })
-                .collect(Collectors.toList());
+        final Set<String> urlSet = new HashSet<>(childUrlList.size());
+        final List<UrlQueue<?>> childList = new ArrayList<>(childUrlList.size());
+        for (final RequestData d : childUrlList) {
+            final String childUrl = d.getUrl();
+            if (StringUtil.isBlank(childUrl) || !urlSet.add(childUrl) || !crawlerContext.urlFilter.match(childUrl)) {
+                continue;
+            }
+            final UrlQueue<?> uq = crawlerContainer.getComponent("urlQueue");
+            uq.setCreateTime(SystemUtil.currentTimeMillis());
+            uq.setDepth(depth);
+            uq.setMethod(Constants.GET_METHOD);
+            uq.setParentUrl(url);
+            uq.setSessionId(crawlerContext.sessionId);
+            uq.setUrl(childUrl);
+            uq.setWeight(d.getWeight());
+            childList.add(uq);
+        }
         urlQueueService.offerAll(crawlerContext.sessionId, childList);
     }
 

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/CrawlerClientCreator.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/CrawlerClientCreator.java
@@ -67,7 +67,9 @@ public class CrawlerClientCreator {
      * @param crawlerClientFactory The CrawlerClientFactory to register.
      */
     public synchronized void register(final CrawlerClientFactory crawlerClientFactory) {
-        clientMap.entrySet().stream().forEach(e -> load(crawlerClientFactory, e.getKey(), e.getValue()));
+        for (final Map.Entry<String, String> e : clientMap.entrySet()) {
+            load(crawlerClientFactory, e.getKey(), e.getValue());
+        }
         clientFactoryList.add(crawlerClientFactory);
         if (clientFactoryList.size() > maxClientFactorySize) {
             clientFactoryList.remove(0);
@@ -82,7 +84,9 @@ public class CrawlerClientCreator {
      */
     public synchronized void register(final String regex, final String componentName) {
         clientMap.put(regex, componentName);
-        clientFactoryList.forEach(f -> load(f, regex, componentName));
+        for (final CrawlerClientFactory f : clientFactoryList) {
+            load(f, regex, componentName);
+        }
     }
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/filter/impl/UrlFilterImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/filter/impl/UrlFilterImpl.java
@@ -15,12 +15,12 @@
  */
 package org.codelibs.fess.crawler.filter.impl;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -163,7 +163,7 @@ public class UrlFilterImpl implements UrlFilter {
         this.sessionId = sessionId;
         if (!cachedIncludeSet.isEmpty()) {
             try {
-                getUrlFilterService().addIncludeUrlFilter(sessionId, cachedIncludeSet.stream().collect(Collectors.toList()));
+                getUrlFilterService().addIncludeUrlFilter(sessionId, new ArrayList<>(cachedIncludeSet));
             } catch (final Exception e) {
                 logger.warn("Failed to add include_urls on " + sessionId, e);
             }
@@ -171,7 +171,7 @@ public class UrlFilterImpl implements UrlFilter {
         }
         if (!cachedExcludeSet.isEmpty()) {
             try {
-                getUrlFilterService().addExcludeUrlFilter(sessionId, cachedExcludeSet.stream().collect(Collectors.toList()));
+                getUrlFilterService().addExcludeUrlFilter(sessionId, new ArrayList<>(cachedExcludeSet));
             } catch (final Exception e) {
                 logger.warn("Failed to add exclude_urls on " + sessionId, e);
             }


### PR DESCRIPTION
## Summary

Reduce stream/lambda allocations on per-crawl hot paths and small init code, mirroring the same direction as fess#3134. No behavior changes.

## Changes

- **`CrawlerThread.storeChildUrls`**: Convert the `stream().filter(...).map(...).collect(Collectors.toList())` pipeline into a single `for` loop. Pre-size both the dedup `HashSet` and the resulting `ArrayList` from `childUrlList.size()`. Reuses the URL value via a local variable instead of three repeated `d.getUrl()` calls. This runs once per crawled page that yields children.
- **`CrawlerClientCreator.register(...)`**: Replace `clientMap.entrySet().stream().forEach(...)` and `clientFactoryList.forEach(...)` with enhanced `for` loops. Both methods are `synchronized` and run during client registration; the change just removes lambda/stream object allocations.
- **`UrlFilterImpl.init`**: Replace `cachedXxxSet.stream().collect(Collectors.toList())` with `new ArrayList<>(set)`. Drops the `java.util.stream.Collectors` import.

## What was intentionally NOT changed

- The set/list types (`LinkedHashSet`, `HashSet`, `ArrayList`) are kept the same; only the way they are populated changes.
- No public/protected method signatures change.
- The redirect/HEAD logic in `CrawlerThread` is untouched.

## Test plan

- [x] `mvn compile` — succeeds
- [x] `mvn test -Dtest=UrlFilterImplTest,CrawlerThreadTest` — 34/34 pass (no `CrawlerClientCreatorTest` exists in this repo)
- [x] `mvn formatter:format && mvn license:format` — applied, clean
- [ ] Manual crawl smoke test against a small site

🤖 Generated with [Claude Code](https://claude.com/claude-code)