### PR TITLE
docs(javadoc): resolve missing Javadoc warnings

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/config/CookieConfig.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/config/CookieConfig.java
@@ -37,6 +37,13 @@ import java.util.Date;
  */
 public class CookieConfig {
 
+    /**
+     * Creates a new CookieConfig instance.
+     */
+    public CookieConfig() {
+        // Default constructor
+    }
+
     private String name;
     private String value;
     private String domain;

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/config/CredentialsConfig.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/config/CredentialsConfig.java
@@ -38,6 +38,13 @@ package org.codelibs.fess.crawler.client.http.config;
 public class CredentialsConfig {
 
     /**
+     * Creates a new CredentialsConfig instance.
+     */
+    public CredentialsConfig() {
+        // Default constructor
+    }
+
+    /**
      * Type of credentials.
      */
     public enum CredentialsType {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/config/WebAuthenticationConfig.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/config/WebAuthenticationConfig.java
@@ -49,6 +49,13 @@ import java.util.Map;
 public class WebAuthenticationConfig {
 
     /**
+     * Creates a new WebAuthenticationConfig instance.
+     */
+    public WebAuthenticationConfig() {
+        // Default constructor
+    }
+
+    /**
      * Type of authentication scheme.
      */
     public enum AuthSchemeType {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PsExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PsExtractor.java
@@ -99,6 +99,11 @@ public class PsExtractor extends AbstractExtractor {
         this.encoding = encoding;
     }
 
+    /**
+     * Extracts readable text from the given PostScript content.
+     * @param psContent the PostScript content to extract text from
+     * @return the extracted text
+     */
     protected String extractText(final String psContent) {
         final List<String> collectedTexts = new ArrayList<>();
         final List<String> stack = new ArrayList<>();

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/SitemapsHelper.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/SitemapsHelper.java
@@ -212,6 +212,7 @@ public class SitemapsHelper {
     /**
      * Parses a text-based sitemap from the given input stream.
      * @param in the input stream to parse
+     * @param sitemapBaseUrl the base URL used to resolve relative sitemap URLs
      * @return the parsed sitemap set
      */
     protected SitemapSet parseTextSitemaps(final InputStream in, final String sitemapBaseUrl) {
@@ -265,6 +266,7 @@ public class SitemapsHelper {
     /**
      * Parses an XML sitemap from the given input stream.
      * @param in the input stream to parse
+     * @param sitemapBaseUrl the base URL used to resolve relative sitemap URLs
      * @return the parsed sitemap set
      */
     protected SitemapSet parseXmlSitemaps(final InputStream in, final String sitemapBaseUrl) {
@@ -699,6 +701,7 @@ public class SitemapsHelper {
     /**
      * Parses an XML sitemap index from the given input stream.
      * @param in the input stream to parse
+     * @param sitemapBaseUrl the base URL used to resolve relative sitemap URLs
      * @return the parsed sitemap set
      */
     protected SitemapSet parseXmlSitemapsIndex(final InputStream in, final String sitemapBaseUrl) {
@@ -1161,6 +1164,11 @@ public class SitemapsHelper {
 
         private long bytesRead;
 
+        /**
+         * Creates a new SizeLimitedInputStream wrapping the given input stream.
+         * @param in the input stream to wrap
+         * @param maxSize the maximum number of bytes allowed to be read
+         */
         protected SizeLimitedInputStream(final InputStream in, final long maxSize) {
             super(in);
             this.maxSize = maxSize;


### PR DESCRIPTION
## Summary

Resolves the Javadoc build warnings for undocumented constructors and methods.

## Changes

- **CookieConfig / CredentialsConfig / WebAuthenticationConfig**: add an explicit public no-arg constructor with a Javadoc comment (these classes previously relied on the undocumented default constructor).
- **PsExtractor.extractText**: add a Javadoc comment with `@param` and `@return`.
- **SitemapsHelper**: add the missing `@param sitemapBaseUrl` to `parseTextSitemaps`, `parseXmlSitemaps`, and `parseXmlSitemapsIndex`, and add a full Javadoc comment to the `SizeLimitedInputStream` constructor.

## Notes

Documentation-only change; no behavior is affected.