### PR TITLE
test(opensearch): pin OpenSearchRunner HTTP port to avoid flaky tests

### DIFF
--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.crawler;
 
+import static org.codelibs.fess.crawler.util.OpenSearchRunnerUtil.findFreePort;
 import static org.codelibs.opensearch.runner.OpenSearchRunner.newConfigs;
 
 import java.io.File;
@@ -77,16 +78,21 @@ public class CrawlerTest extends LastaDiTestCase {
         runner = new OpenSearchRunner();
         // create ES nodes
         final String clusterName = UUID.randomUUID().toString();
+        final int httpPort = findFreePort();
+        // OpenSearchRunner binds the first node to (baseHttpPort + 1) and selects the port via an
+        // unreliable connect-based scan. Pin it to the reserved free port and disable the scan to
+        // avoid intermittent "Address already in use" failures.
+        runner.setMaxHttpPort(-1);
         runner.onBuild((number, settingsBuilder) -> {
             settingsBuilder.put("http.cors.enabled", true);
             settingsBuilder.put("http.cors.allow-origin", "*");
             settingsBuilder.put("discovery.type", "single-node");
-        }).build(newConfigs().clusterName(clusterName).numOfNode(1));
+        }).build(newConfigs().clusterName(clusterName).numOfNode(1).baseHttpPort(httpPort - 1));
 
         // wait for yellow status
         runner.ensureYellow();
 
-        System.setProperty(FesenClient.HTTP_ADDRESS, "localhost:" + runner.node().settings().get("http.port", "9201"));
+        System.setProperty(FesenClient.HTTP_ADDRESS, "localhost:" + runner.node().settings().get("http.port", String.valueOf(httpPort)));
 
         super.setUp(testInfo);
 

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchDataServiceTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchDataServiceTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.crawler.service.impl;
 
+import static org.codelibs.fess.crawler.util.OpenSearchRunnerUtil.findFreePort;
 import static org.codelibs.opensearch.runner.OpenSearchRunner.newConfigs;
 
 import java.util.ArrayList;
@@ -61,15 +62,20 @@ public class OpenSearchDataServiceTest extends LastaDiTestCase {
         runner = new OpenSearchRunner();
         // create ES nodes
         final String clusterName = UUID.randomUUID().toString();
+        final int httpPort = findFreePort();
+        // OpenSearchRunner binds the first node to (baseHttpPort + 1) and selects the port via an
+        // unreliable connect-based scan. Pin it to the reserved free port and disable the scan to
+        // avoid intermittent "Address already in use" failures.
+        runner.setMaxHttpPort(-1);
         runner.onBuild((number, settingsBuilder) -> {
             settingsBuilder.put("http.cors.enabled", true);
             settingsBuilder.put("discovery.type", "single-node");
-        }).build(newConfigs().clusterName(clusterName).numOfNode(1));
+        }).build(newConfigs().clusterName(clusterName).numOfNode(1).baseHttpPort(httpPort - 1));
 
         // wait for yellow status
         runner.ensureYellow();
 
-        System.setProperty(FesenClient.HTTP_ADDRESS, "localhost:" + runner.node().settings().get("http.port", "9201"));
+        System.setProperty(FesenClient.HTTP_ADDRESS, "localhost:" + runner.node().settings().get("http.port", String.valueOf(httpPort)));
 
         super.setUp(testInfo);
     }

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlFilterServiceTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlFilterServiceTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.crawler.service.impl;
 
+import static org.codelibs.fess.crawler.util.OpenSearchRunnerUtil.findFreePort;
 import static org.codelibs.opensearch.runner.OpenSearchRunner.newConfigs;
 
 import java.util.ArrayList;
@@ -62,15 +63,20 @@ public class OpenSearchUrlFilterServiceTest extends LastaDiTestCase {
         runner = new OpenSearchRunner();
         // create ES nodes
         final String clusterName = UUID.randomUUID().toString();
+        final int httpPort = findFreePort();
+        // OpenSearchRunner binds the first node to (baseHttpPort + 1) and selects the port via an
+        // unreliable connect-based scan. Pin it to the reserved free port and disable the scan to
+        // avoid intermittent "Address already in use" failures.
+        runner.setMaxHttpPort(-1);
         runner.onBuild((number, settingsBuilder) -> {
             settingsBuilder.put("http.cors.enabled", true);
             settingsBuilder.put("discovery.type", "single-node");
-        }).build(newConfigs().clusterName(clusterName).numOfNode(1));
+        }).build(newConfigs().clusterName(clusterName).numOfNode(1).baseHttpPort(httpPort - 1));
 
         // wait for yellow status
         runner.ensureYellow();
 
-        System.setProperty(FesenClient.HTTP_ADDRESS, "localhost:" + runner.node().settings().get("http.port", "9201"));
+        System.setProperty(FesenClient.HTTP_ADDRESS, "localhost:" + runner.node().settings().get("http.port", String.valueOf(httpPort)));
 
         super.setUp(testInfo);
     }

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.crawler.service.impl;
 
+import static org.codelibs.fess.crawler.util.OpenSearchRunnerUtil.findFreePort;
 import static org.codelibs.opensearch.runner.OpenSearchRunner.newConfigs;
 
 import java.util.ArrayList;
@@ -62,15 +63,20 @@ public class OpenSearchUrlQueueServiceTest extends LastaDiTestCase {
         runner = new OpenSearchRunner();
         // create ES nodes
         final String clusterName = UUID.randomUUID().toString();
+        final int httpPort = findFreePort();
+        // OpenSearchRunner binds the first node to (baseHttpPort + 1) and selects the port via an
+        // unreliable connect-based scan. Pin it to the reserved free port and disable the scan to
+        // avoid intermittent "Address already in use" failures.
+        runner.setMaxHttpPort(-1);
         runner.onBuild((number, settingsBuilder) -> {
             settingsBuilder.put("http.cors.enabled", true);
             settingsBuilder.put("discovery.type", "single-node");
-        }).build(newConfigs().clusterName(clusterName).numOfNode(1));
+        }).build(newConfigs().clusterName(clusterName).numOfNode(1).baseHttpPort(httpPort - 1));
 
         // wait for yellow status
         runner.ensureYellow();
 
-        System.setProperty(FesenClient.HTTP_ADDRESS, "localhost:" + runner.node().settings().get("http.port", "9201"));
+        System.setProperty(FesenClient.HTTP_ADDRESS, "localhost:" + runner.node().settings().get("http.port", String.valueOf(httpPort)));
 
         super.setUp(testInfo);
     }

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/util/OpenSearchRunnerUtil.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/util/OpenSearchRunnerUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.util;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * Test helper for {@code OpenSearchRunner}.
+ *
+ * <p>
+ * {@code OpenSearchRunner} decides an HTTP port by probing {@code localhost}
+ * (IPv4) with a TCP connect. That probe can report a port as free even when it
+ * is already bound on {@code [::1]} (IPv6), which makes the node fail to start
+ * with "Address already in use". To avoid this, let the OS assign an ephemeral
+ * port and pass it to the runner directly.
+ * </p>
+ */
+public final class OpenSearchRunnerUtil {
+
+    private OpenSearchRunnerUtil() {
+        // nothing
+    }
+
+    /**
+     * Returns an ephemeral port assigned by the OS.
+     *
+     * @return a free TCP port
+     */
+    public static int findFreePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (final IOException e) {
+            throw new IllegalStateException("Failed to find a free port.", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The OpenSearch backend tests intermittently fail to start the embedded node with "Address already in use". `OpenSearchRunner` selects its HTTP port via a connect-based scan that can report a port as free even when it is already bound on the IPv6 loopback (`[::1]`), so the node occasionally tries to bind a port that is not actually available. This PR makes the test setup deterministic by reserving a free ephemeral port up front and pinning the runner to it.

## Changes Made
- Added `OpenSearchRunnerUtil` test helper with `findFreePort()`, which asks the OS for an ephemeral port via `new ServerSocket(0)`.
- Updated `CrawlerTest`, `OpenSearchDataServiceTest`, `OpenSearchUrlFilterServiceTest`, and `OpenSearchUrlQueueServiceTest` to:
  - Reserve a free port before building the runner.
  - Disable the unreliable port scan via `runner.setMaxHttpPort(-1)`.
  - Pass `baseHttpPort(httpPort - 1)` so the first node binds to the reserved port (the runner uses `baseHttpPort + 1` for the first node).
  - Use the reserved port as the fallback value for the `FesenClient.HTTP_ADDRESS` system property.

## Testing
- Test-only change. Run the OpenSearch module tests (`mvn test -pl fess-crawler-opensearch`) to confirm the embedded node starts reliably.

## Breaking Changes
- None. Changes are limited to test code.

## Additional Notes
- The same setup pattern is duplicated across the four test classes for consistency; the shared logic lives in `OpenSearchRunnerUtil`.