### PR TITLE
Update version to 15.8.0-SNAPSHOT

### DIFF
--- a/fess-crawler-lasta/pom.xml
+++ b/fess-crawler-lasta/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-crawler-parent</artifactId>
-		<version>15.7.1-SNAPSHOT</version>
+		<version>15.8.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<build>

--- a/fess-crawler-opensearch/pom.xml
+++ b/fess-crawler-opensearch/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-crawler-parent</artifactId>
-		<version>15.7.1-SNAPSHOT</version>
+		<version>15.8.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<build>

--- a/fess-crawler/pom.xml
+++ b/fess-crawler/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-crawler-parent</artifactId>
-		<version>15.7.1-SNAPSHOT</version>
+		<version>15.8.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.fess</groupId>
 	<artifactId>fess-crawler-parent</artifactId>
-	<version>15.7.1-SNAPSHOT</version>
+	<version>15.8.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Fess Crawler Project</name>
 	<description>Fess Crawler is Crawler Framework.</description>
@@ -42,7 +42,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.7.0</version>
+		<version>15.8.0-SNAPSHOT</version>
 	</parent>
 	<modules>
 		<module>fess-crawler</module>


### PR DESCRIPTION
## Summary

Bump version for the 15.8.0 development cycle.

Depends on upstream Fess artifacts (`fess-parent`, and where applicable `fess-suggest`, `fess-crawler`, `fess-crawler-playwright`, `fess`) at `15.8.0-SNAPSHOT`, which must already be deployed to the Maven snapshot repository before CI runs here.

## Test plan

- [ ] CI build passes against `15.8.0-SNAPSHOT` upstreams