### PR TITLE
test: add coverage for HTML XPath extraction

### DIFF
--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
@@ -106,4 +106,50 @@ public class HtmlExtractorTest extends PlainTestCase {
             // NOP
         }
     }
+
+    @Test
+    public void test_getHtml_stringMetadata() {
+        // A STRING-typed metadata XPath (string(...)) is extracted as a single trimmed value.
+        htmlExtractor.addMetadata("titleStr", "string(//TITLE)");
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test_utf8.html");
+        final ExtractData data = htmlExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertEquals(1, data.getValues("titleStr").length);
+        assertEquals("タイトル", data.getValues("titleStr")[0]);
+    }
+
+    @Test
+    public void test_getHtml_booleanMetadata() {
+        // A BOOLEAN-typed metadata XPath (boolean(...)) is rendered as "true"/"false".
+        htmlExtractor.addMetadata("hasBody", "boolean(//BODY)");
+        htmlExtractor.addMetadata("hasTable", "boolean(//TABLE)");
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test_utf8.html");
+        final ExtractData data = htmlExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertEquals("true", data.getValues("hasBody")[0]);
+        assertEquals("false", data.getValues("hasTable")[0]);
+    }
+
+    @Test
+    public void test_getHtml_numberMetadata() {
+        // A NUMBER-typed metadata XPath (count(...)) is rendered as the number's string form.
+        htmlExtractor.addMetadata("divCount", "count(//DIV)");
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test_utf8.html");
+        final ExtractData data = htmlExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertEquals("1.0", data.getValues("divCount")[0]);
+    }
+
+    @Test
+    public void test_getHtml_invalidMetadataXPath() {
+        // An invalid metadata XPath must not break content extraction; it yields no values.
+        htmlExtractor.addMetadata("bad", "//TITLE[1");
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test_utf8.html");
+        final ExtractData data = htmlExtractor.getText(in, null);
+        final String content = data.getContent();
+        CloseableUtil.closeQuietly(in);
+        assertTrue(content.contains("テスト"));
+        assertEquals("タイトル", data.getValues("title")[0]);
+        assertEquals(0, data.getValues("bad").length);
+    }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlXpathExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlXpathExtractorTest.java
@@ -25,6 +25,7 @@ import org.codelibs.core.io.CloseableUtil;
 import org.codelibs.core.io.ResourceUtil;
 import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
+import org.codelibs.fess.crawler.exception.ExtractException;
 import org.dbflute.utflute.core.PlainTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -114,6 +115,32 @@ public class HtmlXpathExtractorTest extends PlainTestCase {
             fail();
         } catch (final CrawlerSystemException e) {
             // NOP
+        }
+    }
+
+    @Test
+    public void test_getHtml_customTargetNodePath() {
+        // A custom targetNodePath narrows extraction to the selected nodes only.
+        htmlXpathExtractor.setTargetNodePath("//A");
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test_attr.html");
+        final String content = htmlXpathExtractor.getText(in, null).getContent();
+        CloseableUtil.closeQuietly(in);
+        logger.info(content);
+        assertEquals("リンク1", content);
+    }
+
+    @Test
+    public void test_getHtml_invalidTargetNodePath() {
+        // An invalid targetNodePath surfaces as an ExtractException.
+        htmlXpathExtractor.setTargetNodePath("//A[1");
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test_attr.html");
+        try {
+            htmlXpathExtractor.getText(in, null);
+            fail();
+        } catch (final ExtractException e) {
+            // NOP
+        } finally {
+            CloseableUtil.closeQuietly(in);
         }
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformerTest.java
@@ -15,6 +15,9 @@
  */
 package org.codelibs.fess.crawler.transformer.impl;
 
+import java.io.StringReader;
+import java.net.URL;
+import java.util.List;
 import java.util.Map;
 
 import org.codelibs.fess.crawler.Constants;
@@ -23,10 +26,13 @@ import org.codelibs.fess.crawler.entity.AccessResultDataImpl;
 import org.codelibs.fess.crawler.entity.ResponseData;
 import org.codelibs.fess.crawler.entity.ResultData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
+import org.codelibs.nekohtml.parsers.DOMParser;
 import org.dbflute.utflute.core.PlainTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
 
 /**
  * @author shinsuke
@@ -532,5 +538,81 @@ public class HtmlTransformerTest extends PlainTestCase {
         final ResultData resultData = htmlTransformer.transform(responseData);
         assertEquals(1, resultData.getChildUrlSet().size());
         assertEquals("http://hoge/page.html?q=test", resultData.getChildUrlSet().iterator().next().getUrl());
+    }
+
+    private Document parseHtml(final String html) throws Exception {
+        final DOMParser parser = htmlTransformer.getDomParser();
+        parser.parse(new InputSource(new StringReader(html)));
+        return parser.getDocument();
+    }
+
+    // -----------------------------------------------------
+    //                                           getBaseHref
+    //                                           -----------
+    @Test
+    public void test_getBaseHref() throws Exception {
+        final Document document = parseHtml("<html><head><base href=\"http://example.com/foo/\"></head><body></body></html>");
+        assertEquals("http://example.com/foo/", htmlTransformer.getBaseHref(document));
+    }
+
+    @Test
+    public void test_getBaseHref_www() throws Exception {
+        // A bare "www." base href is completed with the http:// scheme.
+        final Document document = parseHtml("<html><head><base href=\"www.example.com/\"></head><body></body></html>");
+        assertEquals("http://www.example.com/", htmlTransformer.getBaseHref(document));
+    }
+
+    @Test
+    public void test_getBaseHref_none() throws Exception {
+        final Document document = parseHtml("<html><head></head><body></body></html>");
+        assertNull(htmlTransformer.getBaseHref(document));
+    }
+
+    @Test
+    public void test_getBaseHref_noHrefAttribute() throws Exception {
+        // A <base> element without an href attribute yields null.
+        final Document document = parseHtml("<html><head><base target=\"_blank\"></head><body></body></html>");
+        assertNull(htmlTransformer.getBaseHref(document));
+    }
+
+    // -----------------------------------------------------
+    //                                 getUrlFromTagAttribute
+    //                                 ----------------------
+    @Test
+    public void test_getUrlFromTagAttribute() throws Exception {
+        final Document document = parseHtml("<html><body><a href=\"child.html\">link</a></body></html>");
+        final List<String> urlList =
+                htmlTransformer.getUrlFromTagAttribute(new URL("http://example.com/"), document, "//A", "href", "UTF-8");
+        assertEquals(1, urlList.size());
+        assertEquals("http://example.com/child.html", urlList.get(0));
+    }
+
+    @Test
+    public void test_getUrlFromTagAttribute_multipleNodesAndInvalidPath() throws Exception {
+        // Every matching node yields a URL, but isValidPath skips invalid schemes (javascript:).
+        final Document document = parseHtml("<html><body>"//
+                + "<a href=\"a.html\">a</a>"//
+                + "<a href=\"javascript:void(0)\">js</a>"//
+                + "<a href=\"b.html\">b</a>"//
+                + "</body></html>");
+        final List<String> urlList =
+                htmlTransformer.getUrlFromTagAttribute(new URL("http://example.com/"), document, "//A", "href", "UTF-8");
+        assertEquals(2, urlList.size());
+        assertEquals("http://example.com/a.html", urlList.get(0));
+        assertEquals("http://example.com/b.html", urlList.get(1));
+    }
+
+    @Test
+    public void test_getUrlFromTagAttribute_invalidXPath() throws Exception {
+        // An invalid child-URL XPath must be caught and yield an empty list rather than fail.
+        // The same document with a valid expression yields a URL, proving the empty result is
+        // caused by the malformed expression rather than an empty/link-less document.
+        final Document document = parseHtml("<html><body><a href=\"child.html\">link</a></body></html>");
+        final URL baseUrl = new URL("http://example.com/");
+        assertEquals(1, htmlTransformer.getUrlFromTagAttribute(baseUrl, document, "//A", "href", "UTF-8").size());
+
+        final List<String> urlList = htmlTransformer.getUrlFromTagAttribute(baseUrl, document, "//A[1", "href", "UTF-8");
+        assertNotNull(urlList);
+        assertTrue(urlList.isEmpty());
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/XpathTransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/XpathTransformerTest.java
@@ -249,6 +249,149 @@ public class XpathTransformerTest extends PlainTestCase {
         assertEquals(list, entity.getList());
     }
 
+    /**
+     * Builds a bare {@link XpathTransformer} configured with the given field rules,
+     * mirroring the namespace/feature setup used by {@link #setUp(TestInfo)}.
+     */
+    private XpathTransformer createXpathTransformer(final Map<String, String> fieldRuleMap) {
+        final XpathTransformer transformer = new XpathTransformer();
+        transformer.setName("xpathTransformer");
+        final Map<String, String> featureMap = newHashMap();
+        featureMap.put("http://xml.org/sax/features/namespaces", "false");
+        transformer.setFeatureMap(featureMap);
+        transformer.setPropertyMap(newHashMap());
+        transformer.setChildUrlRuleMap(newHashMap());
+        transformer.setFieldRuleMap(fieldRuleMap);
+        return transformer;
+    }
+
+    private ResponseData createResponseData(final String resourcePath) {
+        final ResponseData responseData = new ResponseData();
+        responseData.setResponseBody(ResourceUtil.getResourceAsFile(resourcePath), false);
+        responseData.setCharSet(Constants.UTF_8);
+        return responseData;
+    }
+
+    // -----------------------------------------------------
+    //                            storeData: normal patterns
+    //                            --------------------------
+    @Test
+    public void test_storeData_stringType() throws Exception {
+        // The STRING result type (e.g. string(...)) trims and collapses whitespace when enabled.
+        final Map<String, String> fieldRuleMap = newLinkedHashMap();
+        fieldRuleMap.put("title", "string(//TITLE)");
+        final XpathTransformer transformer = createXpathTransformer(fieldRuleMap);
+
+        final String expected = "<?xml version=\"1.0\"?>\n"//
+                + "<doc>\n"//
+                + "<field name=\"title\">Hello World</field>\n"//
+                + "</doc>";
+
+        final ResultData resultData = new ResultData();
+        transformer.storeData(createResponseData("html/test_xpath.html"), resultData);
+        assertEquals(expected, new String(resultData.getData(), Constants.UTF_8));
+    }
+
+    @Test
+    public void test_storeData_trimSpaceDisabled() throws Exception {
+        // With trimSpace disabled the internal whitespace is preserved verbatim
+        // ("Hello  World"), whereas test_storeData_stringType collapses it to "Hello World".
+        final Map<String, String> fieldRuleMap = newLinkedHashMap();
+        fieldRuleMap.put("title", "string(//TITLE)");
+        final XpathTransformer transformer = createXpathTransformer(fieldRuleMap);
+        transformer.setTrimSpace(false);
+
+        final String expected = "<?xml version=\"1.0\"?>\n"//
+                + "<doc>\n"//
+                + "<field name=\"title\">Hello  World</field>\n"//
+                + "</doc>";
+
+        final ResultData resultData = new ResultData();
+        transformer.storeData(createResponseData("html/test_xpath.html"), resultData);
+        assertEquals(expected, new String(resultData.getData(), Constants.UTF_8));
+    }
+
+    @Test
+    public void test_storeData_emptyNodeSet() throws Exception {
+        // A NODESET that matches nothing produces an empty <list/>.
+        final Map<String, String> fieldRuleMap = newLinkedHashMap();
+        fieldRuleMap.put("missing", "//NOSUCH");
+        final XpathTransformer transformer = createXpathTransformer(fieldRuleMap);
+
+        final String expected = "<?xml version=\"1.0\"?>\n"//
+                + "<doc>\n"//
+                + "<field name=\"missing\"><list></list></field>\n"//
+                + "</doc>";
+
+        final ResultData resultData = new ResultData();
+        transformer.storeData(createResponseData("html/test_xpath.html"), resultData);
+        assertEquals(expected, new String(resultData.getData(), Constants.UTF_8));
+    }
+
+    @Test
+    public void test_storeData_emptyFieldRuleMap() throws Exception {
+        // No field rules should still emit a well-formed (empty) document.
+        final XpathTransformer transformer = createXpathTransformer(newLinkedHashMap());
+
+        final String expected = "<?xml version=\"1.0\"?>\n"//
+                + "<doc>\n"//
+                + "</doc>";
+
+        final ResultData resultData = new ResultData();
+        transformer.storeData(createResponseData("html/test_xpath.html"), resultData);
+        assertEquals(expected, new String(resultData.getData(), Constants.UTF_8));
+    }
+
+    // -----------------------------------------------------
+    //                             storeData: error patterns
+    //                             -------------------------
+    @Test
+    public void test_storeData_invalidXPath() throws Exception {
+        // An invalid XPath expression must be skipped (logged) without aborting the
+        // remaining, valid field rules.
+        final Map<String, String> fieldRuleMap = newLinkedHashMap();
+        fieldRuleMap.put("bad", "//P[1");
+        fieldRuleMap.put("title", "//TITLE");
+        final XpathTransformer transformer = createXpathTransformer(fieldRuleMap);
+
+        final String expected = "<?xml version=\"1.0\"?>\n"//
+                + "<doc>\n"//
+                + "<field name=\"title\"><list><item>Hello World</item></list></field>\n"//
+                + "</doc>";
+
+        final ResultData resultData = new ResultData();
+        transformer.storeData(createResponseData("html/test_xpath.html"), resultData);
+        assertEquals(expected, new String(resultData.getData(), Constants.UTF_8));
+    }
+
+    @Test
+    public void test_storeData_invalidCharset() throws Exception {
+        // An unsupported output charset must fall back to UTF-8 instead of failing.
+        final Map<String, String> fieldRuleMap = newLinkedHashMap();
+        fieldRuleMap.put("title", "//TITLE");
+        final XpathTransformer transformer = createXpathTransformer(fieldRuleMap);
+        transformer.setCharsetName("INVALID-CHARSET");
+
+        final String expected = "<?xml version=\"1.0\"?>\n"//
+                + "<doc>\n"//
+                + "<field name=\"title\"><list><item>Hello World</item></list></field>\n"//
+                + "</doc>";
+
+        final ResultData resultData = new ResultData();
+        transformer.storeData(createResponseData("html/test_xpath.html"), resultData);
+        assertEquals(Constants.UTF_8, resultData.getEncoding());
+        assertEquals(expected, new String(resultData.getData(), Constants.UTF_8));
+    }
+
+    @Test
+    public void test_addFieldRule() {
+        final XpathTransformer transformer = new XpathTransformer();
+        transformer.addFieldRule("title", "//TITLE");
+        transformer.addFieldRule("body", "//BODY");
+        assertEquals("//TITLE", transformer.getFieldRuleMap().get("title"));
+        assertEquals("//BODY", transformer.getFieldRuleMap().get("body"));
+    }
+
     @Test
     public void test_getData_dataMap_entity_emptyList() throws Exception {
         final String value = "<?xml version=\"1.0\"?>\n"//

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/util/XPathAPITest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/util/XPathAPITest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.util;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathEvaluationResult;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathNodes;
+
+import org.codelibs.fess.crawler.exception.CrawlerSystemException;
+import org.dbflute.utflute.core.PlainTestCase;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+/**
+ * Unit tests for {@link XPathAPI}, the shared XPath evaluation engine used by the
+ * HTML/XML transformers and extractors. Covers both the happy paths (each result
+ * type, matching/non-matching selections) and the error paths (invalid expressions,
+ * factory configuration failures).
+ *
+ * @author CodeLibs
+ */
+public class XPathAPITest extends PlainTestCase {
+
+    private static final String XML = "<root><title>Hello</title><item>a</item><item>b</item></root>";
+
+    private static final String INVALID_EXPRESSION = "//a[1";
+
+    private Document toDocument(final String xml) throws Exception {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    // -----------------------------------------------------
+    //                                                  eval
+    //                                                  ----
+    @Test
+    public void test_eval_nodeset() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        final XPathEvaluationResult<?> result = xPathAPI.eval(document, "//item");
+        assertEquals(XPathEvaluationResult.XPathResultType.NODESET, result.type());
+        final XPathNodes nodes = (XPathNodes) result.value();
+        assertEquals(2, nodes.size());
+        assertEquals("a", nodes.get(0).getTextContent());
+        assertEquals("b", nodes.get(1).getTextContent());
+    }
+
+    @Test
+    public void test_eval_number() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        final XPathEvaluationResult<?> result = xPathAPI.eval(document, "count(//item)");
+        assertEquals(XPathEvaluationResult.XPathResultType.NUMBER, result.type());
+        assertEquals(2, ((Number) result.value()).intValue());
+    }
+
+    @Test
+    public void test_eval_boolean() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        final XPathEvaluationResult<?> resultTrue = xPathAPI.eval(document, "boolean(//title)");
+        assertEquals(XPathEvaluationResult.XPathResultType.BOOLEAN, resultTrue.type());
+        assertTrue((Boolean) resultTrue.value());
+
+        final XPathEvaluationResult<?> resultFalse = xPathAPI.eval(document, "boolean(//nosuch)");
+        assertEquals(XPathEvaluationResult.XPathResultType.BOOLEAN, resultFalse.type());
+        assertFalse((Boolean) resultFalse.value());
+    }
+
+    @Test
+    public void test_eval_string() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        final XPathEvaluationResult<?> result = xPathAPI.eval(document, "string(//title)");
+        assertEquals(XPathEvaluationResult.XPathResultType.STRING, result.type());
+        assertEquals("Hello", result.value());
+    }
+
+    @Test
+    public void test_eval_invalidExpression() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        try {
+            xPathAPI.eval(document, INVALID_EXPRESSION);
+            fail();
+        } catch (final XPathExpressionException e) {
+            // NOP
+        }
+    }
+
+    // -----------------------------------------------------
+    //                                        selectNodeList
+    //                                        --------------
+    @Test
+    public void test_selectNodeList_match() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        final XPathNodes nodes = xPathAPI.selectNodeList(document, "//item");
+        assertEquals(2, nodes.size());
+        assertEquals("a", nodes.get(0).getTextContent());
+        assertEquals("b", nodes.get(1).getTextContent());
+    }
+
+    @Test
+    public void test_selectNodeList_noMatch() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        final XPathNodes nodes = xPathAPI.selectNodeList(document, "//nosuch");
+        assertNotNull(nodes);
+        assertEquals(0, nodes.size());
+    }
+
+    @Test
+    public void test_selectNodeList_invalidExpression() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        try {
+            xPathAPI.selectNodeList(document, INVALID_EXPRESSION);
+            fail();
+        } catch (final XPathExpressionException e) {
+            // NOP
+        }
+    }
+
+    // -----------------------------------------------------
+    //                                      selectSingleNode
+    //                                      ----------------
+    @Test
+    public void test_selectSingleNode_match() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        final Node node = xPathAPI.selectSingleNode(document, "//title");
+        assertNotNull(node);
+        assertEquals("Hello", node.getTextContent());
+    }
+
+    @Test
+    public void test_selectSingleNode_noMatch() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        final Node node = xPathAPI.selectSingleNode(document, "//nosuch");
+        assertNull(node);
+    }
+
+    @Test
+    public void test_selectSingleNode_invalidExpression() throws Exception {
+        final Document document = toDocument(XML);
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        try {
+            xPathAPI.selectSingleNode(document, INVALID_EXPRESSION);
+            fail();
+        } catch (final XPathExpressionException e) {
+            // NOP
+        }
+    }
+
+    // -----------------------------------------------------
+    //                                           createXPath
+    //                                           -----------
+    @Test
+    public void test_createXPath_valid() throws Exception {
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        final XPath xPath = xPathAPI.createXPath(factory -> {});
+        assertNotNull(xPath);
+        // The created instance must be usable for evaluation.
+        final Document document = toDocument(XML);
+        assertEquals("Hello", xPath.evaluate("string(//title)", document));
+    }
+
+    @Test
+    public void test_createXPath_builderThrows() {
+        final XPathAPI xPathAPI = new XPathAPI();
+
+        try {
+            xPathAPI.createXPath(factory -> {
+                throw new RuntimeException("Failed to configure factory.");
+            });
+            fail();
+        } catch (final CrawlerSystemException e) {
+            // NOP
+        }
+    }
+}

--- a/fess-crawler/src/test/resources/html/test_xpath.html
+++ b/fess-crawler/src/test/resources/html/test_xpath.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+<title>  Hello  World  </title>
+</head>
+<body>
+<p>Alpha</p>
+<p>Beta</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds unit tests for the **HTML XPath element-extraction** feature. The extraction
logic spans a shared engine plus four call sites, and several branches — most
notably the core engine and the error paths — had no direct coverage. This PR
fills those gaps for both normal (正常系) and error (異常系) cases. **Test-only
change; no production code is modified.**

## Why

Coverage audit of the XPath extraction surface found:

- `util/XPathAPI` (the shared `eval` / `selectNodeList` / `selectSingleNode` /
  `createXPath` engine) had **no dedicated test** — only indirect coverage.
- The result-type `switch` in `XpathTransformer.storeData` and
  `HtmlExtractor.getStringsByXPath` was only exercised for a subset of types;
  the `STRING` type and the invalid-XPath handling were untested.
- Error paths (invalid XPath expression, unsupported output charset, invalid
  `targetNodePath`) were untested across all call sites.

## What's added

| Target | Added coverage |
| --- | --- |
| `XPathAPITest` (new) | `eval` for BOOLEAN/NUMBER/STRING/NODESET; `selectNodeList` match / no-match; `selectSingleNode` match / no-match (null); invalid-expression errors for all three; `createXPath` valid + builder-throws (`CrawlerSystemException`) |
| `XpathTransformer` | STRING result type; `trimSpace` disabled; empty node-set (`<list/>`); empty field-rule map; `addFieldRule`; invalid XPath is skipped so remaining rules still run; unsupported charset falls back to UTF-8 |
| `HtmlExtractor` | STRING / BOOLEAN / NUMBER metadata result types; invalid metadata XPath does not break content extraction |
| `HtmlXpathExtractor` | custom `targetNodePath`; invalid `targetNodePath` surfaces as `ExtractException` |
| `HtmlTransformer` | `getBaseHref` (`//BASE`, `www.` prefixing, missing base, missing `href` attribute); `getUrlFromTagAttribute` (multiple nodes, invalid-scheme skipping, invalid XPath yields empty list) |

New fixture `src/test/resources/html/test_xpath.html` provides deterministic
whitespace so the `trimSpace` on/off behavior can be asserted exactly.

## Notes

- The `case NODE:` and `default:` branches of the result-type switch are
  effectively unreachable through this engine: `XPath.evaluateExpression(expr,
  ctx)` (used by `XPathAPI.eval`) only ever returns BOOLEAN/NUMBER/STRING/NODESET
  result types — even a single-node selection comes back as NODESET. They are
  therefore intentionally not tested.
- `XmlTransformer` uses a separate XML (not HTML) XPath path and is covered by
  its own `XmlTransformerTest`; it is out of scope here.

## Verification

- `mvn -pl fess-crawler test` — full module suite green (1754 tests, 0 failures,
  0 errors).
- `mvn -pl fess-crawler formatter:format license:format` — no changes required.
