### PR TITLE
perf(crawler): precompile hot-path regexes and short-circuit URL filter

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractXmlExtractor.java
@@ -68,6 +68,18 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
      */
     protected static final ByteOrderMark BOM_UTF_7 = new ByteOrderMark("UTF-7", 0x2B, 0x2F, 0x76);
 
+    /** Precompiled pattern for collapsing CR/LF characters in {@link #extractString(String)}. */
+    private static final Pattern NEWLINE_PATTERN = Pattern.compile("[\\r\\n]");
+
+    /** Precompiled pattern for stripping HTML comment tags in {@link #extractString(String)} (used when {@code ignoreCommentTag} is true). */
+    private static final Pattern COMMENT_TAG_PATTERN = Pattern.compile("<!--[^>]+-->");
+
+    /** Precompiled pattern for matching a tag's attribute value in {@link #extractString(String)}. */
+    private static final Pattern ATTR_PATTERN = Pattern.compile("\\s[^ ]+=\"([^\"]*)\"");
+
+    /** Precompiled pattern for collapsing whitespace runs in {@link #extractString(String)}. */
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
+
     /**
      * HTML4 unescape translator.
      */
@@ -254,18 +266,17 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
      * @return The extracted text.
      */
     protected String extractString(final String content) {
-        String input = content.replaceAll("[\\r\\n]", " ");
+        String input = NEWLINE_PATTERN.matcher(content).replaceAll(" ");
         if (ignoreCommentTag) {
-            input = input.replaceAll("<!--[^>]+-->", "");
+            input = COMMENT_TAG_PATTERN.matcher(input).replaceAll("");
         } else {
             input = input.replace("<!--", "").replace("-->", "");
         }
         final Matcher matcher = getTagPattern().matcher(input);
-        final StringBuffer sb = new StringBuffer();
-        final Pattern attrPattern = Pattern.compile("\\s[^ ]+=\"([^\"]*)\"");
+        final StringBuilder sb = new StringBuilder();
         while (matcher.find()) {
             final String tagStr = matcher.group();
-            final Matcher attrMatcher = attrPattern.matcher(tagStr);
+            final Matcher attrMatcher = ATTR_PATTERN.matcher(tagStr);
             final StringBuilder buf = new StringBuilder(100);
             while (attrMatcher.find()) {
                 buf.append(attrMatcher.group(1)).append(' ');
@@ -273,7 +284,7 @@ public abstract class AbstractXmlExtractor extends AbstractExtractor {
             matcher.appendReplacement(sb, buf.toString().replace("\\", "\\\\").replace("$", "\\$"));
         }
         matcher.appendTail(sb);
-        return sb.toString().replaceAll("\\s+", " ").trim();
+        return WHITESPACE_PATTERN.matcher(sb.toString()).replaceAll(" ").trim();
     }
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TikaExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/TikaExtractor.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.output.DeferredFileOutputStream;
@@ -156,6 +157,18 @@ public class TikaExtractor extends PasswordBasedExtractor {
     public static final String STRIP_HTML_TAGS = "tika.stripHtmlTags";
 
     private static final String FILE_PASSWORD = "fess.file.password";
+
+    /** Precompiled pattern for stripping {@code <script>...</script>} blocks in {@link #stripHtmlTags(String)}. */
+    private static final Pattern SCRIPT_TAG_PATTERN = Pattern.compile("<script[^>]*>.*?</script>");
+
+    /** Precompiled pattern for stripping {@code <style>...</style>} blocks in {@link #stripHtmlTags(String)}. */
+    private static final Pattern STYLE_TAG_PATTERN = Pattern.compile("<style[^>]*>.*?</style>");
+
+    /** Precompiled pattern for stripping remaining HTML tags in {@link #stripHtmlTags(String)}. */
+    private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<[^>]+>");
+
+    /** Precompiled pattern for collapsing whitespace runs in {@link #stripHtmlTags(String)}. */
+    private static final Pattern HTML_WHITESPACE_PATTERN = Pattern.compile("\\s+");
 
     /**
      * Output encoding used when materializing extracted content into a byte
@@ -1047,9 +1060,9 @@ public class TikaExtractor extends PasswordBasedExtractor {
             // Use regex to strip HTML tags
             // First, handle common HTML entities
             String result = content;
-            result = result.replaceAll("<script[^>]*>.*?</script>", " ");
-            result = result.replaceAll("<style[^>]*>.*?</style>", " ");
-            result = result.replaceAll("<[^>]+>", " ");
+            result = SCRIPT_TAG_PATTERN.matcher(result).replaceAll(" ");
+            result = STYLE_TAG_PATTERN.matcher(result).replaceAll(" ");
+            result = HTML_TAG_PATTERN.matcher(result).replaceAll(" ");
             // Decode common HTML entities
             result = result.replace("&nbsp;", " ");
             result = result.replace("&amp;", "&");
@@ -1058,7 +1071,7 @@ public class TikaExtractor extends PasswordBasedExtractor {
             result = result.replace("&quot;", "\"");
             result = result.replace("&#39;", "'");
             // Normalize whitespace
-            result = result.replaceAll("\\s+", " ").trim();
+            result = HTML_WHITESPACE_PATTERN.matcher(result).replaceAll(" ").trim();
             return result;
         } catch (final Exception e) {
             if (logger.isDebugEnabled()) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/filter/impl/UrlFilterImpl.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/filter/impl/UrlFilterImpl.java
@@ -195,6 +195,7 @@ public class UrlFilterImpl implements UrlFilter {
                 final Matcher matcher = pattern.matcher(url);
                 if (matcher.matches()) {
                     match = true;
+                    break;
                 }
             }
             if (!match) {
@@ -208,6 +209,7 @@ public class UrlFilterImpl implements UrlFilter {
                 final Matcher matcher = pattern.matcher(url);
                 if (matcher.matches()) {
                     match = true;
+                    break;
                 }
             }
             if (match) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/FileTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/FileTransformer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -64,6 +65,12 @@ import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 public class FileTransformer extends HtmlTransformer {
     /** Logger instance for this class */
     private static final Logger logger = LogManager.getLogger(FileTransformer.class);
+
+    /** Precompiled pattern for collapsing repeated slashes in {@link #getFilePath(String)}. */
+    private static final Pattern SLASH_COLLAPSE_PATTERN = Pattern.compile("/+");
+
+    /** Precompiled pattern for matching a trailing slash in {@link #getFilePath(String)}. */
+    private static final Pattern TRAILING_SLASH_PATTERN = Pattern.compile("/$");
 
     /**
      * Constructs a new FileTransformer.
@@ -221,14 +228,10 @@ public class FileTransformer extends HtmlTransformer {
      * @return path File path
      */
     protected String getFilePath(final String url) {
-        return url.replaceAll("/+", "/")
-                .replace("./", "")
-                .replace("../", "")
-                .replaceAll("/$", "/index.html")
-                .replaceAll("\\?", questionStr)
-                .replaceAll(":", colonStr)
-                .replaceAll(";", semicolonStr)
-                .replaceAll("&", ampersandStr);
+        String path = SLASH_COLLAPSE_PATTERN.matcher(url).replaceAll("/");
+        path = path.replace("./", "").replace("../", "");
+        path = TRAILING_SLASH_PATTERN.matcher(path).replaceAll("/index.html");
+        return path.replace("?", questionStr).replace(":", colonStr).replace(";", semicolonStr).replace("&", ampersandStr);
     }
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformer.java
@@ -124,6 +124,18 @@ public class HtmlTransformer extends AbstractTransformer {
     /** Header name for location redirects. */
     protected static final String LOCATION_HEADER = "Location";
 
+    /** Precompiled pattern for stripping a trailing {@code ;jsessionid=...} segment in {@link #normalizeUrl(String)}. */
+    private static final Pattern JSESSIONID_PATTERN = Pattern.compile(";jsessionid=[a-zA-Z0-9\\.]*");
+
+    /** Precompiled pattern for collapsing a single {@code /segment/../} in {@link #normalizeUrl(String)}. */
+    private static final Pattern PARENT_PATH_PATTERN = Pattern.compile("/[^/]+/\\.\\./");
+
+    /** Precompiled pattern for collapsing repeated slashes (except after a scheme colon) in {@link #normalizeUrl(String)}. */
+    private static final Pattern MULTI_SLASH_PATTERN = Pattern.compile("([^:])/+");
+
+    /** Precompiled pattern for extracting a charset value from a content string in {@link #parseCharset(String)}. */
+    private static final Pattern CHARSET_PATTERN = Pattern.compile("; *charset *= *([a-zA-Z0-9\\-_]+)", Pattern.CASE_INSENSITIVE);
+
     /** The crawler container for dependency injection. */
     @Resource
     protected CrawlerContainer crawlerContainer;
@@ -437,8 +449,7 @@ public class HtmlTransformer extends AbstractTransformer {
      * @return the parsed charset name, or null if not found
      */
     protected String parseCharset(final String content) {
-        final Pattern pattern = Pattern.compile("; *charset *= *([a-zA-Z0-9\\-_]+)", Pattern.CASE_INSENSITIVE);
-        final Matcher matcher = pattern.matcher(content);
+        final Matcher matcher = CHARSET_PATTERN.matcher(content);
         if (matcher.find()) {
             return matcher.group(1);
         }
@@ -644,7 +655,7 @@ public class HtmlTransformer extends AbstractTransformer {
 
         idx = url.indexOf(";jsessionid");
         if (idx >= 0) {
-            url = url.replaceFirst(";jsessionid=[a-zA-Z0-9\\.]*", "");
+            url = JSESSIONID_PATTERN.matcher(url).replaceFirst("");
         }
 
         if (url.indexOf(' ') >= 0) {
@@ -654,10 +665,13 @@ public class HtmlTransformer extends AbstractTransformer {
         String oldUrl = null;
         while (url.indexOf("/../") >= 0 && !url.equals(oldUrl)) {
             oldUrl = url;
-            url = url.replaceFirst("/[^/]+/\\.\\./", "/");
+            final Matcher matcher = PARENT_PATH_PATTERN.matcher(url);
+            if (matcher.find()) {
+                url = matcher.replaceFirst("/");
+            }
         }
 
-        return url.replaceAll("([^:])/+", "$1/");
+        return MULTI_SLASH_PATTERN.matcher(url).replaceAll("$1/");
     }
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/TextTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/TextTransformer.java
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -57,6 +58,9 @@ import jakarta.annotation.Resource;
  */
 public class TextTransformer extends AbstractTransformer {
     private static final Logger logger = LogManager.getLogger(TextTransformer.class);
+
+    /** Precompiled pattern for stripping trailing slashes in {@link #getResourceName(ResponseData)}. */
+    private static final Pattern TRAILING_SLASHES_PATTERN = Pattern.compile("/+$");
 
     /**
      * The crawler container.
@@ -151,7 +155,7 @@ public class TextTransformer extends AbstractTransformer {
             return null;
         }
 
-        name = name.replaceAll("/+$", "");
+        name = TRAILING_SLASHES_PATTERN.matcher(name).replaceAll("");
         final int idx = name.lastIndexOf('/');
         if (idx >= 0) {
             name = name.substring(idx + 1);

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/XmlUtil.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/util/XmlUtil.java
@@ -110,14 +110,34 @@ public final class XmlUtil {
         if (value == null) {
             return StringUtil.EMPTY;
         }
-        return stripInvalidXMLCharacters(//
-                value//
-                        .replace("&", "&amp;") //
-                        .replace("<", "&lt;")//
-                        .replace(">", "&gt;")//
-                        .replace("\"", "&quot;")//
-                        .replace("\'", "&apos;")//
-        );
+        final int length = value.length();
+        final StringBuilder buf = new StringBuilder(length + 16);
+        for (int i = 0; i < length; i++) {
+            final char c = value.charAt(i);
+            switch (c) {
+            case '&':
+                buf.append("&amp;");
+                break;
+            case '<':
+                buf.append("&lt;");
+                break;
+            case '>':
+                buf.append("&gt;");
+                break;
+            case '"':
+                buf.append("&quot;");
+                break;
+            case '\'':
+                buf.append("&apos;");
+                break;
+            default:
+                if (isValidXMLCharacter(c)) {
+                    buf.append(c);
+                }
+                break;
+            }
+        }
+        return buf.toString().trim();
     }
 
     /**
@@ -141,16 +161,49 @@ public final class XmlUtil {
             return in;
         }
 
-        final StringBuilder buf = new StringBuilder(in.length());
+        final int length = in.length();
+        boolean hasInvalidChar = false;
+        for (int i = 0; i < length; i++) {
+            if (!isValidXMLCharacter(in.charAt(i))) {
+                hasInvalidChar = true;
+                break;
+            }
+        }
+        if (!hasInvalidChar) {
+            // Nothing to strip; still honor the trim() contract below.
+            return in.trim();
+        }
+
+        final StringBuilder buf = new StringBuilder(length);
         char c;
-        for (int i = 0; i < in.length(); i++) {
+        for (int i = 0; i < length; i++) {
             c = in.charAt(i);
-            if (c == 0x9 || c == 0xA || c == 0xD || (c >= 0x20 && c <= 0xD7FF) || (c >= 0xE000 && c <= 0xFFFD)
-                    || (c >= 0x10000 && c <= 0x10FFFF)) {
+            if (isValidXMLCharacter(c)) {
                 buf.append(c);
             }
         }
         return buf.toString().trim();
+    }
+
+    /**
+     * Checks whether the given character is a valid XML 1.0 character.
+     *
+     * Valid characters are:
+     * <ul>
+     *   <li>Tab (0x9)</li>
+     *   <li>Line feed (0xA)</li>
+     *   <li>Carriage return (0xD)</li>
+     *   <li>Any character between 0x20 and 0xD7FF</li>
+     *   <li>Any character between 0xE000 and 0xFFFD</li>
+     *   <li>Any character between 0x10000 and 0x10FFFF</li>
+     * </ul>
+     *
+     * @param c the character to check
+     * @return true if the character is valid per the XML 1.0 specification
+     */
+    private static boolean isValidXMLCharacter(final char c) {
+        return c == 0x9 || c == 0xA || c == 0xD || (c >= 0x20 && c <= 0xD7FF) || (c >= 0xE000 && c <= 0xFFFD)
+                || (c >= 0x10000 && c <= 0x10FFFF);
     }
 
     /**

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/filter/impl/UrlFilterImplTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/filter/impl/UrlFilterImplTest.java
@@ -187,6 +187,38 @@ public class UrlFilterImplTest extends PlainTestCase {
     }
 
     @Test
+    public void test_match_include_shortCircuit_matchOnLaterPattern() {
+        // Regression for the short-circuit (break) optimization: a match on a
+        // later pattern in the include list must still be honored even though
+        // earlier patterns in the list did not match.
+        urlFilter.addInclude("http://none-matching-1.com/.*");
+        urlFilter.addInclude("http://none-matching-2.com/.*");
+        urlFilter.addInclude("http://example.com/.*");
+
+        final String sessionId = "id1";
+        urlFilter.init(sessionId);
+
+        assertTrue(urlFilter.match("http://example.com/a"));
+        assertFalse(urlFilter.match("http://other.com/a"));
+    }
+
+    @Test
+    public void test_match_exclude_shortCircuit_precedenceOverInclude() {
+        // Regression for the short-circuit (break) optimization on the exclude
+        // loop: a match on a later exclude pattern must still take precedence
+        // over an otherwise-matching include list.
+        urlFilter.addInclude("http://example.com/.*");
+        urlFilter.addExclude("http://none-matching.com/.*");
+        urlFilter.addExclude("http://example.com/a.*");
+
+        final String sessionId = "id1";
+        urlFilter.init(sessionId);
+
+        assertTrue(urlFilter.match("http://example.com/"));
+        assertFalse(urlFilter.match("http://example.com/a"));
+    }
+
+    @Test
     public void test_processUrl() {
         assertEquals(0, urlFilter.cachedIncludeSet.size());
         assertEquals(0, urlFilter.cachedExcludeSet.size());

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/util/XmlUtilTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/util/XmlUtilTest.java
@@ -64,6 +64,42 @@ public class XmlUtilTest extends PlainTestCase {
     }
 
     @Test
+    public void test_escapeXml_ampersandNotDoubleEscaped() {
+        // Regression: '&' must be escaped exactly once and other specials must not
+        // be re-escaped through the '&' produced by the ampersand entity itself.
+        assertEquals("&amp;&lt;&gt;&quot;&apos;", XmlUtil.escapeXml("&<>\"\'"));
+        assertEquals("&amp;lt;", XmlUtil.escapeXml("&lt;"));
+    }
+
+    @Test
+    public void test_escapeXml_mixedTextAndEntities() {
+        String input = "Price: 10 < 20 & \"cheap\" isn't bad > free";
+        String expected = "Price: 10 &lt; 20 &amp; &quot;cheap&quot; isn&apos;t bad &gt; free";
+        assertEquals(expected, XmlUtil.escapeXml(input));
+    }
+
+    @Test
+    public void test_escapeXml_withInvalidControlChars() {
+        // Invalid XML control chars (0x1, 0x2) interleaved with entity-triggering
+        // chars must be stripped while the entities are still produced correctly.
+        String input = "A\u0001<B>\u0002";
+        assertEquals("A&lt;B&gt;", XmlUtil.escapeXml(input));
+    }
+
+    @Test
+    public void test_escapeXml_leadingTrailingWhitespaceTrimmed() {
+        String input = "  <b>bold</b>  ";
+        assertEquals("&lt;b&gt;bold&lt;/b&gt;", XmlUtil.escapeXml(input));
+    }
+
+    @Test
+    public void test_escapeXml_needsNoChanges() {
+        // No entities, no invalid chars, no leading/trailing whitespace: identity-like result.
+        String input = "PlainAsciiTextWithNumbers123";
+        assertEquals(input, XmlUtil.escapeXml(input));
+    }
+
+    @Test
     public void test_stripInvalidXMLCharacters_null() {
         // Test null input
         assertNull(XmlUtil.stripInvalidXMLCharacters(null));
@@ -102,6 +138,29 @@ public class XmlUtilTest extends PlainTestCase {
                 + String.valueOf((char) 0xD7FF) + String.valueOf((char) 0xE000) + String.valueOf((char) 0xFFFD);
         String result = XmlUtil.stripInvalidXMLCharacters(input);
         assertNotNull(result);
+    }
+
+    @Test
+    public void test_stripInvalidXMLCharacters_noInvalidCharsStillTrims() {
+        // Regression for the short-circuit fast path: even when there is nothing
+        // to strip, leading/trailing whitespace must still be trimmed.
+        String input = "  no invalid chars here  ";
+        assertEquals("no invalid chars here", XmlUtil.stripInvalidXMLCharacters(input));
+    }
+
+    @Test
+    public void test_stripInvalidXMLCharacters_invalidCharsWithWhitespaceTrimmed() {
+        // Regression: when invalid chars ARE present, leading/trailing whitespace
+        // must still be trimmed from the filtered result exactly as before.
+        String input = "  Test  ";
+        assertEquals("Test", XmlUtil.stripInvalidXMLCharacters(input));
+    }
+
+    @Test
+    public void test_stripInvalidXMLCharacters_needsNoChanges() {
+        // A string that needs no modification at all should round-trip unchanged.
+        String input = "PlainAsciiTextWithNumbers123";
+        assertEquals(input, XmlUtil.stripInvalidXMLCharacters(input));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Behavior-preserving performance quick-wins on the crawl processing / data-conversion hot paths. The common theme is eliminating per-document / per-URL work that was being redone on every invocation: `Pattern.compile` (via `String.replaceAll`/`replaceFirst`), redundant string passes, and non-short-circuiting loops.

All changes preserve existing observable behavior and output.

## Changes

- **HtmlTransformer**: hoist `normalizeUrl` (`;jsessionid`, `/../` collapse, multi-slash) and `parseCharset` regexes to `static final Pattern`; reuse a compiled `Matcher` in the `/../` loop instead of recompiling per iteration.
- **FileTransformer.getFilePath**: precompile the `/+` and `/$` regexes; convert the four single-character substitutions (`?`, `:`, `;`, `&`) to `String.replace`.
- **TextTransformer.getResourceName**: precompile the trailing-slash regex.
- **XmlUtil.escapeXml / stripInvalidXMLCharacters**: rewrite the 5-pass replace chain + strip pass as a single character pass sharing an `isValidXMLCharacter` predicate; add a no-op short-circuit that skips the copy when there is nothing to strip.
- **AbstractXmlExtractor.extractString**: hoist the newline / comment-tag / attribute / whitespace regexes to `static final Pattern`; switch the method-local `StringBuffer` to `StringBuilder`.
- **TikaExtractor.stripHtmlTags**: hoist the script/style/tag/whitespace regexes to `static final Pattern`.
- **UrlFilterImpl.match**: `break` on the first matching include/exclude pattern (the result is unchanged — "any pattern matched" — but the full list is no longer scanned after a decisive match, which matters because Fess grows these lists dynamically from robots.txt).

## Notes

- `getFilePath`'s configurable replacement fields (`questionStr`/`colonStr`/`semicolonStr`/`ampersandStr`) switch from `replaceAll` to `String.replace`. For the built-in defaults there is no difference. The only behavioral change is for a non-default replacement string containing `$` or `\`: the previous `replaceAll` treated these as replacement metacharacters (and could throw), whereas `String.replace` now emits them literally. This is considered an acceptable hardening.

## Testing

- Added regression tests locking the exact output of `XmlUtil.escapeXml` / `stripInvalidXMLCharacters` (entities, invalid control chars, trim contract, no-op inputs) and the `UrlFilterImpl.match` short-circuit precedence.
- Full `fess-crawler` module test suite passes (1988 tests, 0 failures). `mvn formatter:format` / `license:format` clean.

## Out of scope (follow-up)

Larger structural optimizations from the same audit are intentionally left out of this PR and will follow separately (e.g. reusing JAXP factories / caching compiled XPath in `XmlTransformer`, parsing the HTML DOM and reading the response body once in the Xpath transformer, enforcing max content length before fully downloading a response, and bounding memory in the PostScript/JSON/PDF extractors).
