### PR TITLE
refactor(transformer): add Document-accepting storeChildUrls overload

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformer.java
@@ -247,6 +247,10 @@ public class HtmlTransformer extends AbstractTransformer {
 
     /**
      * Stores child URLs found in the HTML content.
+     * <p>
+     * This parses the response body into a DOM {@link Document} and delegates the
+     * actual extraction to {@link #storeChildUrls(ResponseData, ResultData, Document)}.
+     * </p>
      *
      * @param responseData the response data containing the HTML content
      * @param resultData the result data to store child URLs in
@@ -257,39 +261,58 @@ public class HtmlTransformer extends AbstractTransformer {
             final DOMParser parser = getDomParser();
             parser.parse(new InputSource(is));
             final Document document = parser.getDocument();
-            // base href
-            final String baseHref = getBaseHref(document);
-            URL url;
-            try {
-                if (baseHref == null) {
-                    url = new URL(responseData.getUrl());
-                } else {
-                    url = new URL(new URL(responseData.getUrl()), baseHref);
-                }
-            } catch (final Exception e) {
-                url = new URL(responseData.getUrl());
-            }
-            final URL baseUrl = url;
-            getChildUrlRules(responseData, resultData).forEach(entry -> {
-                List<RequestData> requestDataList = new ArrayList<>();
-                for (final String childUrl : getUrlFromTagAttribute(baseUrl, document, entry.getFirst(), entry.getSecond(),
-                        responseData.getCharSet())) {
-                    requestDataList.add(RequestDataBuilder.newRequestData().get().url(childUrl).build());
-                }
-                requestDataList = convertChildUrlList(requestDataList);
-                resultData.addAllUrl(requestDataList);
-            });
-
-            resultData.addAllUrl(responseData.getChildUrlSet());
-
-            final RequestData requestData = responseData.getRequestData();
-            resultData.removeUrl(requestData);
-            resultData.removeUrl(getDuplicateUrl(requestData));
+            storeChildUrls(responseData, resultData, document);
         } catch (final CrawlerSystemException e) {
             throw e;
         } catch (final Exception e) {
             throw new CrawlerSystemException("Could not store data.", e);
         }
+    }
+
+    /**
+     * Stores child URLs found in the given, already-parsed DOM document.
+     * <p>
+     * This overload lets a caller that has already parsed the response body into a
+     * {@link Document} (for example, to also perform XPath-based content extraction)
+     * reuse that document instead of causing {@link #storeChildUrls(ResponseData, ResultData)}
+     * to parse the same content a second time.
+     * </p>
+     *
+     * @param responseData the response data containing the HTML content
+     * @param resultData the result data to store child URLs in
+     * @param document the pre-parsed DOM document to extract child URLs from
+     * @throws MalformedURLException if the response URL or the resolved base URL is malformed
+     */
+    protected void storeChildUrls(final ResponseData responseData, final ResultData resultData, final Document document)
+            throws MalformedURLException {
+        // base href
+        final String baseHref = getBaseHref(document);
+        URL url;
+        try {
+            if (baseHref == null) {
+                url = new URL(responseData.getUrl());
+            } else {
+                url = new URL(new URL(responseData.getUrl()), baseHref);
+            }
+        } catch (final Exception e) {
+            url = new URL(responseData.getUrl());
+        }
+        final URL baseUrl = url;
+        getChildUrlRules(responseData, resultData).forEach(entry -> {
+            List<RequestData> requestDataList = new ArrayList<>();
+            for (final String childUrl : getUrlFromTagAttribute(baseUrl, document, entry.getFirst(), entry.getSecond(),
+                    responseData.getCharSet())) {
+                requestDataList.add(RequestDataBuilder.newRequestData().get().url(childUrl).build());
+            }
+            requestDataList = convertChildUrlList(requestDataList);
+            resultData.addAllUrl(requestDataList);
+        });
+
+        resultData.addAllUrl(responseData.getChildUrlSet());
+
+        final RequestData requestData = responseData.getRequestData();
+        resultData.removeUrl(requestData);
+        resultData.removeUrl(getDuplicateUrl(requestData));
     }
 
     /**

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformerTest.java
@@ -19,10 +19,12 @@ import java.io.StringReader;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.crawler.builder.RequestDataBuilder;
 import org.codelibs.fess.crawler.entity.AccessResultDataImpl;
+import org.codelibs.fess.crawler.entity.RequestData;
 import org.codelibs.fess.crawler.entity.ResponseData;
 import org.codelibs.fess.crawler.entity.ResultData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
@@ -544,6 +546,58 @@ public class HtmlTransformerTest extends PlainTestCase {
         final DOMParser parser = htmlTransformer.getDomParser();
         parser.parse(new InputSource(new StringReader(html)));
         return parser.getDocument();
+    }
+
+    // -----------------------------------------------------
+    //                                        storeChildUrls
+    //                                        ---------------
+    @Test
+    public void test_storeChildUrls_withPreParsedDocument() throws Exception {
+        // The 3-arg overload, given a Document already parsed by the caller, must discover the
+        // same child URLs as the 2-arg overload that parses the response body itself.
+        final String content = "<html><body>"//
+                + "<a href=\"test2.html\">test</a>"//
+                + "<a href=\"http://fuga/other.html\">other</a>"//
+                + "<base href=\"http://hoge/base/\">"//
+                + "</body></html>";
+
+        final ResponseData responseData1 = new ResponseData();
+        responseData1.setUrl("http://hoge/test.html");
+        responseData1.setResponseBody(content.getBytes());
+        responseData1.setCharSet("UTF-8");
+        responseData1.setMimeType("text/html");
+        final ResultData expected = new ResultData();
+        htmlTransformer.storeChildUrls(responseData1, expected);
+
+        final ResponseData responseData2 = new ResponseData();
+        responseData2.setUrl("http://hoge/test.html");
+        responseData2.setResponseBody(content.getBytes());
+        responseData2.setCharSet("UTF-8");
+        responseData2.setMimeType("text/html");
+        final Document document = parseHtml(content);
+        final ResultData actual = new ResultData();
+        htmlTransformer.storeChildUrls(responseData2, actual, document);
+
+        final List<String> expectedUrls = expected.getChildUrlSet().stream().map(RequestData::getUrl).sorted().collect(Collectors.toList());
+        final List<String> actualUrls = actual.getChildUrlSet().stream().map(RequestData::getUrl).sorted().collect(Collectors.toList());
+        assertEquals(2, expectedUrls.size());
+        assertEquals(expectedUrls, actualUrls);
+    }
+
+    @Test
+    public void test_storeChildUrls_twoArgDelegatesToThreeArg() throws Exception {
+        // The 2-arg overload must still work end-to-end (parse + extract) for existing callers.
+        final String content = "<a href=\"child.html\">link</a>";
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://hoge/test.html");
+        responseData.setResponseBody(content.getBytes());
+        responseData.setCharSet("UTF-8");
+        responseData.setMimeType("text/html");
+        final ResultData resultData = new ResultData();
+        htmlTransformer.storeChildUrls(responseData, resultData);
+
+        assertEquals(1, resultData.getChildUrlSet().size());
+        assertEquals("http://hoge/child.html", resultData.getChildUrlSet().iterator().next().getUrl());
     }
 
     // -----------------------------------------------------


### PR DESCRIPTION
## Summary

Refactor `HtmlTransformer.storeChildUrls` to expose a `Document`-accepting overload, so a caller that has already parsed the response body into a DOM (e.g. an XPath-based content extractor) can reuse that `Document` for child-URL extraction instead of parsing the same page a second time.

## Changes

- Add `protected void storeChildUrls(ResponseData, ResultData, Document)` containing the existing child-URL extraction logic (base-href resolution, child-URL rules, `getChildUrlSet()` merge, self-URL removal).
- The existing `storeChildUrls(ResponseData, ResultData)` keeps identical behavior: it parses the body exactly as before and delegates to the new overload.

Behavior for all current callers (`HtmlTransformer`, `FileTransformer`, `XpathTransformer`) is unchanged:
- The 2-arg method still parses (no BOM handling / `setEncoding` change) and its try/catch is preserved.
- The new overload declares `MalformedURLException`, which the 2-arg method's existing `catch (Exception)` wraps into `CrawlerSystemException("Could not store data.", e)` exactly as before.
- The overridable helpers (`getChildUrlRules`, `getUrlFromTagAttribute`, `getBaseHref`, `convertChildUrlList`, `addChildUrlFromTagAttribute`) are still invoked via dynamic dispatch, so subclass customizations continue to apply.

## Testing

- New test asserting the 3-arg overload produces the same child URLs as the 2-arg method for the same page, plus a sanity check that the 2-arg method still works end-to-end.
- Full `fess-crawler` module test suite passes (1980 tests, 0 failures); `mvn formatter:format` / `license:format` / `javadoc:jar` all clean.

## Motivation

This enables a follow-up change in Fess (`FessXpathTransformer`) to parse each crawled page's DOM once instead of twice per page.
