### PR TITLE
perf(transformer): copy file content outside the FileTransformer lock

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/FileTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/FileTransformer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
@@ -213,23 +214,44 @@ public class FileTransformer extends HtmlTransformer {
         final String path = getFilePath(url);
 
         final File file = createFile(path);
-
-        try (final InputStream is = responseData.getResponseBody(); final OutputStream os = new FileOutputStream(file)) {
-            CopyUtil.copy(is, os);
-        } catch (final IOException e) {
-            throw new CrawlerSystemException("Could not store " + file.getAbsolutePath(), e);
-        }
+        boolean completed = false;
 
         try {
-            resultData.setData(path.getBytes(charsetName));
+            try (final InputStream is = responseData.getResponseBody(); final OutputStream os = new FileOutputStream(file)) {
+                CopyUtil.copy(is, os);
+            }
+            completed = true;
+        } catch (final IOException e) {
+            throw new CrawlerSystemException("Could not store " + file.getAbsolutePath(), e);
+        } finally {
+            if (!completed && file.exists() && !file.delete() && logger.isDebugEnabled()) {
+                logger.debug("Could not delete incomplete file: {}", file.getAbsolutePath());
+            }
+        }
+
+        final String storedPath = getRelativePath(file);
+        try {
+            resultData.setData(storedPath.getBytes(charsetName));
         } catch (final UnsupportedEncodingException e) {
             if (logger.isInfoEnabled()) {
                 logger.info("Invalid charsetName: " + charsetName + ". Changed to " + Constants.UTF_8, e);
             }
             charsetName = Constants.UTF_8_CHARSET.name();
-            resultData.setData(path.getBytes(Constants.UTF_8_CHARSET));
+            resultData.setData(storedPath.getBytes(Constants.UTF_8_CHARSET));
         }
         resultData.setEncoding(charsetName);
+    }
+
+    /**
+     * Returns a baseDir-relative path suitable for storing in {@link ResultData}.
+     *
+     * @param file stored file
+     * @return baseDir-relative file path
+     */
+    protected String getRelativePath(final File file) {
+        final Path basePath = baseDir.toPath().toAbsolutePath().normalize();
+        final Path filePath = file.toPath().toAbsolutePath().normalize();
+        return basePath.relativize(filePath).toString().replace(File.separatorChar, '/');
     }
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/FileTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/FileTransformer.java
@@ -118,12 +118,20 @@ public class FileTransformer extends HtmlTransformer {
 
     /**
      * Creates a file with the specified path, handling directory creation and duplicate names.
+     * <p>
+     * The target (leaf) file is reserved atomically via {@link File#createNewFile()} so that,
+     * even when this method is invoked concurrently by multiple crawler threads for the same
+     * path, no two callers can ever be handed the same file to write into. This whole method
+     * is synchronized so that the (cheap) directory/name resolution and reservation stay a
+     * short critical section; the actual, potentially slow, content copy is performed by the
+     * caller outside of any lock.
+     * </p>
      *
      * @param path the file path to create
-     * @return the created file
-     * @throws CrawlerSystemException if directory creation fails
+     * @return the reserved, empty file
+     * @throws CrawlerSystemException if directory creation fails or a unique file could not be reserved
      */
-    protected File createFile(final String path) {
+    protected synchronized File createFile(final String path) {
         final String[] paths = path.split("/");
         File targetFile = baseDir;
         for (int i = 0; i < paths.length - 1; i++) {
@@ -149,23 +157,47 @@ public class FileTransformer extends HtmlTransformer {
             targetFile = file;
         }
 
-        File file = new File(targetFile, paths[paths.length - 1]);
-        if (file.exists()) {
+        return reserveFile(targetFile, paths[paths.length - 1]);
+    }
+
+    /**
+     * Atomically reserves a unique, empty file named {@code baseName} (or {@code baseName_N} on
+     * collision) under {@code dir}, using {@link File#createNewFile()} so the existence check and
+     * the creation happen as a single filesystem operation. This closes the check-then-act race
+     * that would otherwise allow two threads to select the same target file.
+     *
+     * @param dir the directory in which to reserve the file
+     * @param baseName the base file name, before any duplicate-avoidance suffix is appended
+     * @return the newly created, empty file
+     * @throws CrawlerSystemException if the file could not be created, or no unique name was
+     *             available within {@link #maxDuplicatedPath} attempts
+     */
+    private File reserveFile(final File dir, final String baseName) {
+        File file = new File(dir, baseName);
+        try {
+            if (file.createNewFile()) {
+                return file;
+            }
             for (int i = 0; i < maxDuplicatedPath; i++) {
-                file = new File(targetFile, paths[paths.length - 1] + "_" + i);
-                if (!file.exists()) {
-                    targetFile = file;
-                    break;
+                file = new File(dir, baseName + "_" + i);
+                if (file.createNewFile()) {
+                    return file;
                 }
             }
-        } else {
-            targetFile = file;
+        } catch (final IOException e) {
+            throw new CrawlerSystemException("Could not create " + file.getAbsolutePath(), e);
         }
-        return targetFile;
+        throw new CrawlerSystemException("Could not create a unique file for " + new File(dir, baseName).getAbsolutePath());
     }
 
     /**
      * Stores response data as a file on the file system.
+     * <p>
+     * Only the target file reservation (see {@link #createFile(String)}) is synchronized; the
+     * actual, potentially slow, content copy runs outside of any lock so that concurrent
+     * crawler threads can write their files in parallel instead of serializing on this shared
+     * transformer instance.
+     * </p>
      *
      * @param responseData the response data to store
      * @param resultData the result data to populate with file information
@@ -180,16 +212,14 @@ public class FileTransformer extends HtmlTransformer {
         final String url = responseData.getUrl();
         final String path = getFilePath(url);
 
-        synchronized (this) {
+        final File file = createFile(path);
 
-            final File file = createFile(path);
-
-            try (final InputStream is = responseData.getResponseBody(); final OutputStream os = new FileOutputStream(file);) {
-                CopyUtil.copy(is, os);
-            } catch (final IOException e) {
-                throw new CrawlerSystemException("Could not store " + file.getAbsolutePath(), e);
-            }
+        try (final InputStream is = responseData.getResponseBody(); final OutputStream os = new FileOutputStream(file)) {
+            CopyUtil.copy(is, os);
+        } catch (final IOException e) {
+            throw new CrawlerSystemException("Could not store " + file.getAbsolutePath(), e);
         }
+
         try {
             resultData.setData(path.getBytes(charsetName));
         } catch (final UnsupportedEncodingException e) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/FileTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/FileTransformer.java
@@ -202,7 +202,9 @@ public class FileTransformer extends HtmlTransformer {
      *
      * @param responseData the response data to store
      * @param resultData the result data to populate with file information
-     * @throws CrawlerSystemException if file storage fails
+     * @throws CrawlerSystemException if the target file cannot be reserved, or if the output file
+     *             cannot be opened or closed. I/O errors raised while copying the response body are
+     *             propagated as {@code IORuntimeException} by {@code CopyUtil}, not wrapped here.
      */
     @Override
     public void storeData(final ResponseData responseData, final ResultData resultData) {

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/FileTransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/FileTransformerTest.java
@@ -317,6 +317,39 @@ public class FileTransformerTest extends PlainTestCase {
     }
 
     @Test
+    public void test_storeData_maxDuplicatedPathExhausted_throwsException() throws Exception {
+        setBaseDir();
+
+        // With maxDuplicatedPath == 0 there are no "_N" fallback slots: the reserveFile loop is
+        // skipped, so the first store reserves the nominal leaf and a second store of the same URL
+        // collides with no alternative name available and must fail fast with CrawlerSystemException.
+        fileTransformer.maxDuplicatedPath = 0;
+
+        final String url = "http://www.example.com/exhausted";
+        final String path = fileTransformer.getFilePath(url);
+
+        final ResponseData firstResponseData = new ResponseData();
+        firstResponseData.setUrl(url);
+        firstResponseData.setResponseBody("first".getBytes("UTF-8"));
+        firstResponseData.setCharSet("UTF-8");
+        fileTransformer.storeData(firstResponseData, new ResultData());
+
+        final ResponseData secondResponseData = new ResponseData();
+        secondResponseData.setUrl(url);
+        secondResponseData.setResponseBody("second".getBytes("UTF-8"));
+        secondResponseData.setCharSet("UTF-8");
+        try {
+            fileTransformer.storeData(secondResponseData, new ResultData());
+            fail();
+        } catch (final CrawlerSystemException e) {}
+
+        // the original file is left intact and no duplicate-avoidance file was created
+        final File nominalFile = new File(fileTransformer.baseDir, path);
+        assertEquals("first", new String(FileUtil.readBytes(nominalFile), "UTF-8"));
+        assertFalse(new File(nominalFile.getParentFile(), nominalFile.getName() + "_0").exists());
+    }
+
+    @Test
     public void test_storeData_concurrent_copyRunsOutsideLock() throws Exception {
         setBaseDir();
 

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/FileTransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/FileTransformerTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.codelibs.core.exception.IORuntimeException;
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.crawler.entity.AccessResultDataImpl;
@@ -125,6 +126,7 @@ public class FileTransformerTest extends PlainTestCase {
         final CountDownLatch startLatch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(threadCount);
         final List<Throwable> failures = new CopyOnWriteArrayList<>();
+        final List<StoredResult> results = new CopyOnWriteArrayList<>();
 
         try {
             for (int i = 0; i < threadCount; i++) {
@@ -140,6 +142,7 @@ public class FileTransformerTest extends PlainTestCase {
                         responseData.setCharSet("UTF-8");
                         final ResultData resultData = new ResultData();
                         fileTransformer.storeData(responseData, resultData);
+                        results.add(new StoredResult(content, resultData));
                     } catch (final Throwable t) {
                         failures.add(t);
                     } finally {
@@ -149,14 +152,15 @@ public class FileTransformerTest extends PlainTestCase {
             }
 
             // wait until all threads are ready, then release them all at once
-            readyLatch.await();
+            assertTrue(readyLatch.await(10, TimeUnit.SECONDS));
             startLatch.countDown();
             assertTrue(doneLatch.await(30, TimeUnit.SECONDS));
         } finally {
-            executorService.shutdown();
+            executorService.shutdownNow();
         }
 
         assertTrue(failures.isEmpty());
+        assertEquals(threadCount, results.size());
 
         // the reserved target files are the nominal path plus "_0".."_(threadCount-2)" suffixes;
         // every one of them must exist and hold content produced by exactly one thread.
@@ -181,8 +185,135 @@ public class FileTransformerTest extends PlainTestCase {
         assertEquals(threadCount, existingCount);
         assertEquals(threadCount, seenContents.size());
 
+        final Set<String> seenStoredPaths = new HashSet<>();
+        for (final StoredResult result : results) {
+            final String storedPath = new String(result.resultData.getData(), result.resultData.getEncoding());
+            assertTrue(seenStoredPaths.add(storedPath));
+            final File file = new File(fileTransformer.baseDir, storedPath);
+            assertTrue(file.exists());
+            assertEquals(result.content, new String(FileUtil.readBytes(file), result.resultData.getEncoding()));
+        }
+        assertEquals(threadCount, seenStoredPaths.size());
+
         // no unexpected extra file (e.g. "_<threadCount-1>") was created beyond what threadCount threads need
         assertFalse(new File(nominalFile.getParentFile(), nominalFile.getName() + "_" + (threadCount - 1)).exists());
+    }
+
+    @Test
+    public void test_storeData_getResponseBodyFailure_removesReservedFile() throws Exception {
+        setBaseDir();
+
+        final String url = "http://www.example.com/failure";
+        final String path = fileTransformer.getFilePath(url);
+        final ResponseData failedResponseData = new ResponseData() {
+            @Override
+            public InputStream getResponseBody() {
+                throw new IORuntimeException(new IOException("missing body"));
+            }
+        };
+        failedResponseData.setUrl(url);
+        failedResponseData.setCharSet("UTF-8");
+
+        try {
+            fileTransformer.storeData(failedResponseData, new ResultData());
+            fail();
+        } catch (final IORuntimeException e) {}
+
+        final File nominalFile = new File(fileTransformer.baseDir, path);
+        assertFalse(nominalFile.exists());
+
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl(url);
+        responseData.setResponseBody("success".getBytes("UTF-8"));
+        responseData.setCharSet("UTF-8");
+        final ResultData resultData = new ResultData();
+        fileTransformer.storeData(responseData, resultData);
+
+        assertEquals(path, new String(resultData.getData(), resultData.getEncoding()));
+        assertEquals("success", new String(FileUtil.readBytes(nominalFile), resultData.getEncoding()));
+        assertFalse(new File(nominalFile.getParentFile(), nominalFile.getName() + "_0").exists());
+    }
+
+    @Test
+    public void test_storeData_copyFailure_removesReservedFile() throws Exception {
+        setBaseDir();
+
+        final String url = "http://www.example.com/copy-failure";
+        final String path = fileTransformer.getFilePath(url);
+        final ResponseData failedResponseData = new ResponseData() {
+            @Override
+            public InputStream getResponseBody() {
+                return new InputStream() {
+                    private boolean first = true;
+
+                    @Override
+                    public int read() throws IOException {
+                        if (first) {
+                            first = false;
+                            return 'x';
+                        }
+                        throw new IOException("copy failed");
+                    }
+
+                    @Override
+                    public int read(final byte[] b, final int off, final int len) throws IOException {
+                        if (first) {
+                            first = false;
+                            b[off] = 'x';
+                            return 1;
+                        }
+                        throw new IOException("copy failed");
+                    }
+                };
+            }
+        };
+        failedResponseData.setUrl(url);
+        failedResponseData.setCharSet("UTF-8");
+
+        try {
+            fileTransformer.storeData(failedResponseData, new ResultData());
+            fail();
+        } catch (final IORuntimeException e) {}
+
+        final File nominalFile = new File(fileTransformer.baseDir, path);
+        assertFalse(nominalFile.exists());
+
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl(url);
+        responseData.setResponseBody("success".getBytes("UTF-8"));
+        responseData.setCharSet("UTF-8");
+        final ResultData resultData = new ResultData();
+        fileTransformer.storeData(responseData, resultData);
+
+        assertEquals(path, new String(resultData.getData(), resultData.getEncoding()));
+        assertEquals("success", new String(FileUtil.readBytes(nominalFile), resultData.getEncoding()));
+        assertFalse(new File(nominalFile.getParentFile(), nominalFile.getName() + "_0").exists());
+    }
+
+    @Test
+    public void test_storeData_directoryCollision_storesReservedPath() throws Exception {
+        setBaseDir();
+
+        final String fileUrl = "http://www.example.com/hoge.html";
+        final ResponseData fileResponseData = new ResponseData();
+        fileResponseData.setUrl(fileUrl);
+        fileResponseData.setResponseBody("file".getBytes("UTF-8"));
+        fileResponseData.setCharSet("UTF-8");
+        fileTransformer.storeData(fileResponseData, new ResultData());
+
+        final String childUrl = "http://www.example.com/hoge.html/hoge2.html";
+        final ResponseData childResponseData = new ResponseData();
+        childResponseData.setUrl(childUrl);
+        childResponseData.setResponseBody("child".getBytes("UTF-8"));
+        childResponseData.setCharSet("UTF-8");
+        final ResultData resultData = new ResultData();
+        fileTransformer.storeData(childResponseData, resultData);
+
+        final String storedPath = new String(resultData.getData(), resultData.getEncoding());
+        assertEquals(fileTransformer.getFilePath(fileUrl) + "_0/hoge2.html", storedPath);
+        final File file = new File(fileTransformer.baseDir, storedPath);
+        assertTrue(file.exists());
+        assertEquals("child", new String(FileUtil.readBytes(file), resultData.getEncoding()));
     }
 
     @Test
@@ -269,6 +400,16 @@ public class FileTransformerTest extends PlainTestCase {
                     throw new IOException(e);
                 }
             }
+        }
+    }
+
+    private static final class StoredResult {
+        private final String content;
+        private final ResultData resultData;
+
+        private StoredResult(final String content, final ResultData resultData) {
+            this.content = content;
+            this.resultData = resultData;
         }
     }
 

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/FileTransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/FileTransformerTest.java
@@ -15,9 +15,21 @@
  */
 package org.codelibs.fess.crawler.transformer.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.fess.crawler.Constants;
@@ -96,6 +108,168 @@ public class FileTransformerTest extends PlainTestCase {
         assertEquals("http_CLN_/www.example.com/submit_QUEST_a=1_AMP_b=2", new String(resultData.getData(), "UTF-8"));
         final File file = new File(fileTransformer.baseDir, new String(resultData.getData(), "UTF-8"));
         assertEquals("xyz", new String(FileUtil.readBytes(file)));
+    }
+
+    @Test
+    public void test_storeData_concurrent_sameUrl() throws Exception {
+        setBaseDir();
+
+        // All threads crawl the SAME url/path, so createFile(...) must hand each of them a
+        // distinct target file (via "_0", "_1", ... suffixes) instead of letting two threads
+        // race for, and overwrite, the same file.
+        final String url = "http://www.example.com/concurrent";
+        final String nominalPath = fileTransformer.getFilePath(url);
+        final int threadCount = 20;
+        final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        final List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                final String content = "content-" + i;
+                executorService.execute(() -> {
+                    try {
+                        readyLatch.countDown();
+                        startLatch.await();
+
+                        final ResponseData responseData = new ResponseData();
+                        responseData.setUrl(url);
+                        responseData.setResponseBody(content.getBytes("UTF-8"));
+                        responseData.setCharSet("UTF-8");
+                        final ResultData resultData = new ResultData();
+                        fileTransformer.storeData(responseData, resultData);
+                    } catch (final Throwable t) {
+                        failures.add(t);
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+
+            // wait until all threads are ready, then release them all at once
+            readyLatch.await();
+            startLatch.countDown();
+            assertTrue(doneLatch.await(30, TimeUnit.SECONDS));
+        } finally {
+            executorService.shutdown();
+        }
+
+        assertTrue(failures.isEmpty());
+
+        // the reserved target files are the nominal path plus "_0".."_(threadCount-2)" suffixes;
+        // every one of them must exist and hold content produced by exactly one thread.
+        final File nominalFile = new File(fileTransformer.baseDir, nominalPath);
+        final List<File> candidateFiles = new ArrayList<>();
+        candidateFiles.add(nominalFile);
+        for (int i = 0; i < threadCount - 1; i++) {
+            candidateFiles.add(new File(nominalFile.getParentFile(), nominalFile.getName() + "_" + i));
+        }
+
+        final Set<String> seenContents = new HashSet<>();
+        int existingCount = 0;
+        for (final File file : candidateFiles) {
+            if (file.exists()) {
+                existingCount++;
+                final String content = new String(FileUtil.readBytes(file));
+                assertTrue(content.startsWith("content-"));
+                // fails if two threads wrote to the same file (one thread's content clobbered another's)
+                assertTrue(seenContents.add(content));
+            }
+        }
+        assertEquals(threadCount, existingCount);
+        assertEquals(threadCount, seenContents.size());
+
+        // no unexpected extra file (e.g. "_<threadCount-1>") was created beyond what threadCount threads need
+        assertFalse(new File(nominalFile.getParentFile(), nominalFile.getName() + "_" + (threadCount - 1)).exists());
+    }
+
+    @Test
+    public void test_storeData_concurrent_copyRunsOutsideLock() throws Exception {
+        setBaseDir();
+
+        // Proves the content copy is no longer serialized through the transformer-wide lock:
+        // each thread's InputStream blocks on a CyclicBarrier the first time it is read. If
+        // storeData still ran CopyUtil.copy() inside the synchronized section (as before this
+        // fix), only one thread at a time could ever reach that read() call, so the barrier
+        // (which needs all threadCount parties) would never trip and every call would fail
+        // with a timeout/broken-barrier error. With the copy running outside the lock, all
+        // threads reach the barrier together and it trips normally.
+        final int threadCount = 6;
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        final List<Throwable> failures = new CopyOnWriteArrayList<>();
+        final CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                final int idx = i;
+                executorService.execute(() -> {
+                    try {
+                        final byte[] data = ("data-" + idx).getBytes("UTF-8");
+                        final ResponseData responseData = new ResponseData() {
+                            @Override
+                            public InputStream getResponseBody() {
+                                return new BarrierInputStream(new ByteArrayInputStream(data), barrier);
+                            }
+                        };
+                        responseData.setUrl("http://www.example.com/barrier" + idx);
+                        responseData.setCharSet("UTF-8");
+                        final ResultData resultData = new ResultData();
+                        fileTransformer.storeData(responseData, resultData);
+                    } catch (final Throwable t) {
+                        failures.add(t);
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+
+            assertTrue(doneLatch.await(20, TimeUnit.SECONDS));
+        } finally {
+            executorService.shutdown();
+        }
+
+        assertTrue(failures.isEmpty());
+    }
+
+    /**
+     * Test-only InputStream that blocks on a {@link CyclicBarrier} the first time it is read,
+     * used to detect whether concurrent readers are able to be "in flight" at the same time.
+     */
+    private static final class BarrierInputStream extends InputStream {
+        private final InputStream delegate;
+        private final CyclicBarrier barrier;
+        private boolean awaited;
+
+        BarrierInputStream(final InputStream delegate, final CyclicBarrier barrier) {
+            this.delegate = delegate;
+            this.barrier = barrier;
+        }
+
+        @Override
+        public int read() throws IOException {
+            awaitOnce();
+            return delegate.read();
+        }
+
+        @Override
+        public int read(final byte[] b, final int off, final int len) throws IOException {
+            awaitOnce();
+            return delegate.read(b, off, len);
+        }
+
+        private void awaitOnce() throws IOException {
+            if (!awaited) {
+                awaited = true;
+                try {
+                    barrier.await(10, TimeUnit.SECONDS);
+                } catch (final Exception e) {
+                    throw new IOException(e);
+                }
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

`FileTransformer.storeData` held one `synchronized (this)` monitor across **both** the target-name selection **and** the full content copy. Because the transformer is a shared singleton, every crawler thread serialized on that single lock for the entire I/O-bound file write, so file-mirroring crawls had essentially no write concurrency. The name selection was also a check-then-act (`exists()` then pick) with a TOCTOU race.

## Changes

- `createFile` is now `synchronized` and reserves the leaf file **atomically** via `File.createNewFile()` (retrying `name`, `name_0`, `name_1`, … on collision). This both closes the TOCTOU race and keeps the critical section short (directory bookkeeping + one atomic create per candidate).
- `storeData` performs `CopyUtil.copy(is, os)` **outside** any lock, so concurrent threads write their files in parallel.

Single-threaded behavior is unchanged: the same file path is chosen (`name`, then `name_0`, …) and the same content is written, with the same exception handling. The only edge-case change is the effectively-unreachable name-exhaustion path (`maxDuplicatedPath` collisions), which now throws a clear `CrawlerSystemException` from `createFile` instead of silently returning the parent directory and failing later when the stream is opened (still a `CrawlerSystemException`, just earlier and clearer).

## Testing

- `test_storeData_concurrent_sameUrl` — 20 threads store the same URL concurrently; asserts 20 distinct files (`name`, `name_0` … `name_18`), each with its correct content and no extra file.
- `test_storeData_concurrent_copyRunsOutsideLock` — a barrier-gated input stream across 6 threads deterministically proves the copy is no longer serialized (this test times out/fails against the original locked-copy code and passes in ~0.1s with the fix).
- Existing `test_createFile` / `test_transform` unchanged and passing; full `fess-crawler` module suite passes (1980 tests); `mvn formatter:format` / `license:format` / `javadoc:jar` clean.
