### PR TITLE
fix(extractor): bound Ps/Json/Pdf extractor memory usage

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/AbstractExtractor.java
@@ -17,6 +17,7 @@ package org.codelibs.fess.crawler.extractor.impl;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -411,5 +412,72 @@ public abstract class AbstractExtractor implements Extractor {
             total += read;
         }
         return total;
+    }
+
+    /**
+     * Wraps {@code in} so that no more than {@code limit} bytes can be read from
+     * it, throwing {@link MaxLengthExceededException} as soon as the cumulative
+     * number of bytes read <em>exceeds</em> {@code limit}. Used by extractors
+     * that must bound the size of the input they spool to disk or materialize in
+     * memory (for example when copying to a temporary file or building an
+     * in-memory document tree) so that a hostile or accidentally huge stream
+     * cannot exhaust disk or heap.
+     *
+     * <p>A {@code limit} of zero or less disables the bound: the supplied stream
+     * is returned unchanged (never wrapped), so the default unlimited path is
+     * byte-for-byte identical to reading the stream directly.
+     *
+     * <p>The count is maintained across both {@link InputStream#read()} and
+     * {@link InputStream#read(byte[], int, int)} (and therefore
+     * {@link InputStream#read(byte[])}, which delegates to the latter), and the
+     * exception is thrown only after the delegate read returns, so the caller
+     * never receives the overflowing bytes. Matching
+     * {@link CommandExtractor}'s bounded-copy convention, the byte count is
+     * incremented first and then compared with {@code >}, so a stream of exactly
+     * {@code limit} bytes is accepted while a stream of {@code limit + 1} bytes
+     * is rejected.
+     *
+     * <p>The wrapper does not take ownership of {@code in}: the caller is still
+     * responsible for closing the original stream.
+     *
+     * @param in the stream to bound (must not be {@code null} when
+     *            {@code limit > 0})
+     * @param limit the maximum number of bytes that may be read; a value less
+     *              than or equal to zero disables the bound
+     * @return {@code in} unchanged when {@code limit <= 0}, otherwise a
+     *         size-bounded wrapper around {@code in}
+     */
+    protected static InputStream limitInputStream(final InputStream in, final long limit) {
+        if (limit <= 0) {
+            return in;
+        }
+        return new FilterInputStream(in) {
+            /** Cumulative number of bytes read through this wrapper. */
+            private long count;
+
+            @Override
+            public int read() throws IOException {
+                final int b = super.read();
+                if (b != -1) {
+                    count++;
+                    if (count > limit) {
+                        throw new MaxLengthExceededException("input size exceeded limit: limit=" + limit);
+                    }
+                }
+                return b;
+            }
+
+            @Override
+            public int read(final byte[] b, final int off, final int len) throws IOException {
+                final int n = super.read(b, off, len);
+                if (n > 0) {
+                    count += n;
+                    if (count > limit) {
+                        throw new MaxLengthExceededException("input size exceeded limit: limit=" + limit);
+                    }
+                }
+                return n;
+            }
+        };
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/JsonExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/JsonExtractor.java
@@ -29,6 +29,7 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.ExtractException;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -46,10 +47,55 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  *   <li>Array element extraction</li>
  *   <li>Configurable field separator and array formatting</li>
  * </ul>
+ *
+ * <p>
+ * The shared {@link #objectMapper} is configured with explicit
+ * {@link StreamReadConstraints} (max nesting depth, max string length, max
+ * number length) pinned to Jackson's own out-of-the-box defaults, so
+ * out-of-the-box parsing behaves exactly as it would with a default-configured
+ * {@link ObjectMapper} (no legitimate JSON that Jackson would otherwise accept
+ * is rejected) while still giving callers an explicit, tunable ceiling to
+ * tighten if desired rather than relying on Jackson's implicit defaults.
+ * Independently, the accumulated output text is bounded by
+ * {@link #maxTextLength} (default unlimited), mirroring the truncate-not-reject
+ * convention used by {@link TextExtractor} and {@link MarkdownExtractor}: once
+ * the cap is reached, the recursive walk stops early and the returned
+ * {@link ExtractData} carries {@code truncated=true} and
+ * {@code maxTextLength=<value>} metadata entries. The real protection against
+ * pathological memory/CPU use comes from this output-side {@code maxTextLength}
+ * cap together with the {@link TextAccumulator} bound, not from tightening the
+ * parse-time constraints below Jackson's defaults.
+ * </p>
  */
 public class JsonExtractor extends AbstractExtractor {
     /** Logger instance for this class. */
     private static final Logger logger = LogManager.getLogger(JsonExtractor.class);
+
+    /**
+     * Maximum nesting depth the shared {@link #objectMapper} will accept while
+     * parsing. Pinned to Jackson's own {@code StreamReadConstraints} default
+     * (also documented as the JVM's typical safe stack-depth ceiling), so
+     * out-of-the-box parsing accepts exactly what a default-configured Jackson
+     * {@link ObjectMapper} would, rather than being tighter than master.
+     */
+    protected static final int MAX_NESTING_DEPTH = 1000;
+
+    /**
+     * Maximum total string length (in characters) the shared
+     * {@link #objectMapper} will accept for any single token/value. Pinned to
+     * Jackson's own {@code StreamReadConstraints} default so out-of-the-box
+     * parsing accepts exactly what a default-configured Jackson
+     * {@link ObjectMapper} would, rather than being tighter than master.
+     */
+    protected static final int MAX_STRING_LENGTH = 20_000_000;
+
+    /**
+     * Maximum number length (in characters) the shared {@link #objectMapper}
+     * will accept. This already matches Jackson's own {@code StreamReadConstraints}
+     * default, so out-of-the-box parsing accepts exactly what a
+     * default-configured Jackson {@link ObjectMapper} would.
+     */
+    protected static final int MAX_NUMBER_LENGTH = 1000;
 
     /** Jackson ObjectMapper for JSON parsing. */
     protected final ObjectMapper objectMapper = new ObjectMapper();
@@ -73,10 +119,27 @@ public class JsonExtractor extends AbstractExtractor {
     protected int maxArrayElements = 100;
 
     /**
+     * Maximum number of characters to accumulate in the extracted text output.
+     * The default is {@link Long#MAX_VALUE}, which is effectively unlimited.
+     * Values less than or equal to zero explicitly disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
+     */
+    protected long maxTextLength = Long.MAX_VALUE;
+
+    /**
      * Constructs a new JsonExtractor.
      */
     public JsonExtractor() {
         super();
+        final StreamReadConstraints constraints = StreamReadConstraints.builder()
+                .maxNestingDepth(MAX_NESTING_DEPTH)
+                .maxStringLength(MAX_STRING_LENGTH)
+                .maxNumberLength(MAX_NUMBER_LENGTH)
+                .build();
+        objectMapper.getFactory().setStreamReadConstraints(constraints);
     }
 
     @Override
@@ -90,12 +153,20 @@ public class JsonExtractor extends AbstractExtractor {
 
         try {
             final JsonNode rootNode = objectMapper.readTree(in);
-            final StringBuilder textBuilder = new StringBuilder();
+            final TextAccumulator textAccumulator = new TextAccumulator(maxTextLength);
             final Map<String, List<String>> metadataMap = new LinkedHashMap<>();
 
-            extractContent(rootNode, "", textBuilder, metadataMap, 0);
+            extractContent(rootNode, "", textAccumulator, metadataMap, 0);
 
-            final ExtractData extractData = new ExtractData(textBuilder.toString().trim());
+            final ExtractData extractData = new ExtractData(textAccumulator.builder.toString().trim());
+
+            if (textAccumulator.truncated) {
+                if (logger.isWarnEnabled()) {
+                    logger.warn("Extracted JSON content truncated: maxTextLength={}", maxTextLength);
+                }
+                extractData.putValue("truncated", "true");
+                extractData.putValue("maxTextLength", Long.toString(maxTextLength));
+            }
 
             if (extractMetadata) {
                 for (final Map.Entry<String, List<String>> entry : metadataMap.entrySet()) {
@@ -111,26 +182,77 @@ public class JsonExtractor extends AbstractExtractor {
     }
 
     /**
+     * Mutable per-invocation accumulator for the recursive JSON walk. Bounds
+     * the total number of characters appended to {@code maxLength}, mirroring
+     * the {@code maxTextLength} truncate-not-reject convention used by
+     * {@link AbstractExtractor#readWithLimit(java.io.Reader, long)}: once the
+     * cap is reached, further appends are silently dropped and
+     * {@link #truncated} is set so callers can flag the result.
+     */
+    protected static final class TextAccumulator {
+        /** The accumulated text. */
+        protected final StringBuilder builder = new StringBuilder();
+
+        /** The maximum number of characters to accumulate; {@code <= 0} means unlimited. */
+        protected final long maxLength;
+
+        /** Whether truncation has occurred. */
+        protected boolean truncated;
+
+        /**
+         * Creates a new accumulator.
+         * @param maxLength the maximum number of characters to accumulate
+         */
+        protected TextAccumulator(final long maxLength) {
+            this.maxLength = maxLength;
+        }
+
+        /**
+         * Appends {@code s} unless doing so would exceed {@link #maxLength}, in
+         * which case as much of {@code s} as still fits is appended and no
+         * further appends are accepted.
+         * @param s the text to append
+         */
+        protected void append(final String s) {
+            if (truncated || s == null || s.isEmpty()) {
+                return;
+            }
+            if (maxLength > 0 && (long) builder.length() + s.length() > maxLength) {
+                final int remaining = (int) (maxLength - builder.length());
+                if (remaining > 0) {
+                    builder.append(s, 0, remaining);
+                }
+                if (builder.length() > 0 && Character.isHighSurrogate(builder.charAt(builder.length() - 1))) {
+                    builder.setLength(builder.length() - 1);
+                }
+                truncated = true;
+                return;
+            }
+            builder.append(s);
+        }
+    }
+
+    /**
      * Recursively extracts content from JSON nodes.
      *
      * @param node the JSON node to extract from
      * @param parentKey the parent key path
-     * @param textBuilder the string builder for text content
+     * @param textAccumulator the accumulator for text content, bounded by {@link #maxTextLength}
      * @param metadataMap the map for metadata extraction
      * @param depth the current depth in the JSON structure
      */
-    protected void extractContent(final JsonNode node, final String parentKey, final StringBuilder textBuilder,
+    protected void extractContent(final JsonNode node, final String parentKey, final TextAccumulator textAccumulator,
             final Map<String, List<String>> metadataMap, final int depth) {
-        if (node == null || depth > maxDepth) {
+        if (node == null || depth > maxDepth || textAccumulator.truncated) {
             return;
         }
 
         if (node.isObject()) {
-            extractObject((ObjectNode) node, parentKey, textBuilder, metadataMap, depth);
+            extractObject((ObjectNode) node, parentKey, textAccumulator, metadataMap, depth);
         } else if (node.isArray()) {
-            extractArray((ArrayNode) node, parentKey, textBuilder, metadataMap, depth);
+            extractArray((ArrayNode) node, parentKey, textAccumulator, metadataMap, depth);
         } else {
-            extractValue(node, parentKey, textBuilder, metadataMap, depth);
+            extractValue(node, parentKey, textAccumulator, metadataMap, depth);
         }
     }
 
@@ -139,20 +261,20 @@ public class JsonExtractor extends AbstractExtractor {
      *
      * @param node the object node
      * @param parentKey the parent key path
-     * @param textBuilder the string builder for text content
+     * @param textAccumulator the accumulator for text content, bounded by {@link #maxTextLength}
      * @param metadataMap the map for metadata extraction
      * @param depth the current depth
      */
-    protected void extractObject(final ObjectNode node, final String parentKey, final StringBuilder textBuilder,
+    protected void extractObject(final ObjectNode node, final String parentKey, final TextAccumulator textAccumulator,
             final Map<String, List<String>> metadataMap, final int depth) {
         final Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-        while (fields.hasNext()) {
+        while (fields.hasNext() && !textAccumulator.truncated) {
             final Map.Entry<String, JsonNode> field = fields.next();
             final String fieldName = field.getKey();
             final JsonNode fieldValue = field.getValue();
 
             final String currentKey = buildKey(parentKey, fieldName);
-            extractContent(fieldValue, currentKey, textBuilder, metadataMap, depth + 1);
+            extractContent(fieldValue, currentKey, textAccumulator, metadataMap, depth + 1);
         }
     }
 
@@ -161,17 +283,17 @@ public class JsonExtractor extends AbstractExtractor {
      *
      * @param node the array node
      * @param parentKey the parent key path
-     * @param textBuilder the string builder for text content
+     * @param textAccumulator the accumulator for text content, bounded by {@link #maxTextLength}
      * @param metadataMap the map for metadata extraction
      * @param depth the current depth
      */
-    protected void extractArray(final ArrayNode node, final String parentKey, final StringBuilder textBuilder,
+    protected void extractArray(final ArrayNode node, final String parentKey, final TextAccumulator textAccumulator,
             final Map<String, List<String>> metadataMap, final int depth) {
         final int size = Math.min(node.size(), maxArrayElements);
-        for (int i = 0; i < size; i++) {
+        for (int i = 0; i < size && !textAccumulator.truncated; i++) {
             final JsonNode element = node.get(i);
             final String currentKey = parentKey + "[" + i + "]";
-            extractContent(element, currentKey, textBuilder, metadataMap, depth + 1);
+            extractContent(element, currentKey, textAccumulator, metadataMap, depth + 1);
         }
 
         if (node.size() > maxArrayElements) {
@@ -186,11 +308,11 @@ public class JsonExtractor extends AbstractExtractor {
      *
      * @param node the value node
      * @param key the key for this value
-     * @param textBuilder the string builder for text content
+     * @param textAccumulator the accumulator for text content, bounded by {@link #maxTextLength}
      * @param metadataMap the map for metadata extraction
      * @param depth the current depth
      */
-    protected void extractValue(final JsonNode node, final String key, final StringBuilder textBuilder,
+    protected void extractValue(final JsonNode node, final String key, final TextAccumulator textAccumulator,
             final Map<String, List<String>> metadataMap, final int depth) {
         if (node.isNull()) {
             return;
@@ -203,9 +325,13 @@ public class JsonExtractor extends AbstractExtractor {
 
         // Add to text content
         if (StringUtil.isNotBlank(key)) {
-            textBuilder.append(key).append(fieldSeparator).append(value).append(lineSeparator);
+            textAccumulator.append(key);
+            textAccumulator.append(fieldSeparator);
+            textAccumulator.append(value);
+            textAccumulator.append(lineSeparator);
         } else {
-            textBuilder.append(value).append(lineSeparator);
+            textAccumulator.append(value);
+            textAccumulator.append(lineSeparator);
         }
 
         // Add to metadata if at top level
@@ -280,5 +406,31 @@ public class JsonExtractor extends AbstractExtractor {
      */
     public void setMaxArrayElements(final int maxArrayElements) {
         this.maxArrayElements = maxArrayElements;
+    }
+
+    /**
+     * Returns the maximum number of characters that will be accumulated in the
+     * extracted text output.
+     *
+     * @return the maximum text length
+     */
+    public long getMaxTextLength() {
+        return maxTextLength;
+    }
+
+    /**
+     * Sets the maximum number of characters that will be accumulated in the
+     * extracted text output. The default is {@link Long#MAX_VALUE}, which is
+     * effectively unlimited. Values less than or equal to zero explicitly
+     * disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
+     *
+     * @param maxTextLength the maximum text length
+     */
+    public void setMaxTextLength(final long maxTextLength) {
+        this.maxTextLength = maxTextLength;
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/JsonExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/JsonExtractor.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.ExtractException;
+import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
 
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -51,21 +52,25 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * <p>
  * The shared {@link #objectMapper} is configured with explicit
  * {@link StreamReadConstraints} (max nesting depth, max string length, max
- * number length) pinned to Jackson's own out-of-the-box defaults, so
- * out-of-the-box parsing behaves exactly as it would with a default-configured
- * {@link ObjectMapper} (no legitimate JSON that Jackson would otherwise accept
- * is rejected) while still giving callers an explicit, tunable ceiling to
- * tighten if desired rather than relying on Jackson's implicit defaults.
- * Independently, the accumulated output text is bounded by
- * {@link #maxTextLength} (default unlimited), mirroring the truncate-not-reject
- * convention used by {@link TextExtractor} and {@link MarkdownExtractor}: once
- * the cap is reached, the recursive walk stops early and the returned
- * {@link ExtractData} carries {@code truncated=true} and
- * {@code maxTextLength=<value>} metadata entries. The real protection against
- * pathological memory/CPU use comes from this output-side {@code maxTextLength}
- * cap together with the {@link TextAccumulator} bound, not from tightening the
- * parse-time constraints below Jackson's defaults.
+ * number length) pinned to Jackson's own out-of-the-box defaults purely to make
+ * that ceiling explicit and tunable; they do <em>not</em> reject anything a
+ * default-configured {@link ObjectMapper} would otherwise accept and are not the
+ * memory guard. The actual protection against pathological memory/CPU use comes
+ * from two independent, opt-in bounds (both default to unlimited, so the
+ * out-of-the-box behavior is unchanged):
  * </p>
+ * <ul>
+ *   <li>Input size is bounded by {@link #maxContentLength}: oversized input is
+ *       <em>rejected</em> with {@link MaxLengthExceededException} before the
+ *       {@link JsonNode} tree is fully materialized, which bounds the dominant
+ *       {@code readTree()} allocation.</li>
+ *   <li>Accumulated <em>output</em> text is bounded by {@link #maxTextLength}
+ *       using the truncate-not-reject convention shared with
+ *       {@link TextExtractor} and {@link MarkdownExtractor}: once the cap is
+ *       reached, the recursive walk stops early and the returned
+ *       {@link ExtractData} carries {@code truncated=true} and
+ *       {@code maxTextLength=<value>} metadata entries.</li>
+ * </ul>
  */
 public class JsonExtractor extends AbstractExtractor {
     /** Logger instance for this class. */
@@ -130,6 +135,15 @@ public class JsonExtractor extends AbstractExtractor {
     protected long maxTextLength = Long.MAX_VALUE;
 
     /**
+     * Maximum number of input bytes to read before rejecting oversized JSON with
+     * {@link MaxLengthExceededException}. Values less than or equal to zero (the
+     * default) disable the limit, preserving the previous unbounded behavior.
+     * Bounds the dominant {@code readTree()} allocation by capping the input the
+     * tree is built from.
+     */
+    protected long maxContentLength = 0;
+
+    /**
      * Constructs a new JsonExtractor.
      */
     public JsonExtractor() {
@@ -152,7 +166,7 @@ public class JsonExtractor extends AbstractExtractor {
         validateInputStream(in);
 
         try {
-            final JsonNode rootNode = objectMapper.readTree(in);
+            final JsonNode rootNode = objectMapper.readTree(limitInputStream(in, maxContentLength));
             final TextAccumulator textAccumulator = new TextAccumulator(maxTextLength);
             final Map<String, List<String>> metadataMap = new LinkedHashMap<>();
 
@@ -432,5 +446,28 @@ public class JsonExtractor extends AbstractExtractor {
      */
     public void setMaxTextLength(final long maxTextLength) {
         this.maxTextLength = maxTextLength;
+    }
+
+    /**
+     * Returns the maximum number of input bytes that will be read before
+     * oversized JSON is rejected with {@link MaxLengthExceededException}.
+     *
+     * @return the maximum input content length in bytes
+     */
+    public long getMaxContentLength() {
+        return maxContentLength;
+    }
+
+    /**
+     * Sets the maximum number of input bytes to read before oversized JSON is
+     * rejected with {@link MaxLengthExceededException}. Values less than or equal
+     * to zero (the default) disable the limit, preserving the previous unbounded
+     * behavior. Bounding the input size bounds the dominant {@code readTree()}
+     * allocation, so a hostile or accidentally huge stream cannot exhaust heap.
+     *
+     * @param maxContentLength the maximum input content length in bytes
+     */
+    public void setMaxContentLength(final long maxContentLength) {
+        this.maxContentLength = maxContentLength;
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractor.java
@@ -15,9 +15,10 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
+import java.io.Writer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +35,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.cos.COSInputStream;
-import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
@@ -47,6 +47,8 @@ import org.apache.pdfbox.pdmodel.common.filespecification.PDFileSpecification;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
 import org.apache.pdfbox.text.PDFTextStripper;
+import org.codelibs.core.io.CopyUtil;
+import org.codelibs.core.io.FileUtil;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.ExtractException;
@@ -77,6 +79,16 @@ import org.codelibs.fess.crawler.helper.MimeTypeHelper;
  *   <li>Configurable timeout for extraction process</li>
  *   <li>Configurable grace period for orderly cancellation before document close</li>
  * </ul>
+ *
+ * <p>The supplied input stream is first spooled to a temporary file and the PDF is
+ * loaded from that file (rather than buffering the whole document into a
+ * {@code byte[]} in memory), which reduces peak heap usage for large PDFs; the
+ * temp file is deleted once extraction completes. The extracted text is bounded
+ * by {@link #maxTextLength} (default unlimited), mirroring the truncate-not-reject
+ * convention used by {@link TextExtractor} and {@link MarkdownExtractor}: once the
+ * cap is reached, further writes to the output are silently dropped and the
+ * returned {@link ExtractData} carries {@code truncated=true} and
+ * {@code maxTextLength=<value>} metadata entries.</p>
  *
  * @author shinsuke
  */
@@ -119,6 +131,18 @@ public class PdfExtractor extends PasswordBasedExtractor {
     protected long cancelGracePeriodMs = 2000L;
 
     /**
+     * Maximum number of characters to accumulate in the extracted text output
+     * (page text plus embedded-document and annotation text). The default is
+     * {@link Long#MAX_VALUE}, which is effectively unlimited. Values less than
+     * or equal to zero explicitly disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
+     */
+    protected long maxTextLength = Long.MAX_VALUE;
+
+    /**
      * Creates a new PdfExtractor instance.
      */
     public PdfExtractor() {
@@ -138,57 +162,75 @@ public class PdfExtractor extends PasswordBasedExtractor {
         }
 
         final String password = getPassword(params);
-        try (PDDocument document = Loader.loadPDF(new RandomAccessReadBuffer(in), password)) {
-            final StringWriter writer = new StringWriter();
-            final PDFTextStripper stripper = createStripper();
+        File tempFile = null;
+        try {
+            // Spool the input to a temp file and load PDFBox from the file rather than
+            // buffering the whole document into memory (the previous RandomAccessReadBuffer
+            // approach). This reduces peak heap for large PDFs; see createTempFile/CopyUtil
+            // usage in JodExtractor for the same spool-to-disk convention used elsewhere in
+            // this module. The temp file is removed in the outer finally block below, after
+            // the PDDocument (and its file handle) has been closed.
+            tempFile = createTempFile("pdfExtractor-", ".pdf", null);
+            CopyUtil.copy(in, tempFile);
 
-            final ExecutorService executor = Executors.newSingleThreadExecutor(DAEMON_THREAD_FACTORY);
-            try {
-                final Future<?> future = executor.submit(() -> {
+            try (PDDocument document = Loader.loadPDF(tempFile, password)) {
+                final BoundedTextWriter writer = new BoundedTextWriter(maxTextLength);
+                final PDFTextStripper stripper = createStripper();
+
+                final ExecutorService executor = Executors.newSingleThreadExecutor(DAEMON_THREAD_FACTORY);
+                try {
+                    final Future<?> future = executor.submit(() -> {
+                        try {
+                            stripper.writeText(document, writer);
+                            extractEmbeddedDocuments(document, writer);
+                            extractAnnotations(document, writer);
+                        } catch (final IOException e) {
+                            throw new CrawlerSystemException("Failed to extract PDF text.", e);
+                        }
+                    });
                     try {
-                        stripper.writeText(document, writer);
-                        extractEmbeddedDocuments(document, writer);
-                        extractAnnotations(document, writer);
-                    } catch (final IOException e) {
-                        throw new CrawlerSystemException("Failed to extract PDF text.", e);
+                        future.get(timeout, TimeUnit.MILLISECONDS);
+                    } catch (final TimeoutException e) {
+                        future.cancel(true);
+                        throw new ExtractException("PDFBox process cannot finish in " + timeout + " ms.", e);
+                    } catch (final ExecutionException e) {
+                        final Throwable cause = e.getCause() != null ? e.getCause() : e;
+                        if (cause instanceof ExtractException) {
+                            throw (ExtractException) cause;
+                        }
+                        throw new ExtractException("PDF extraction failed.", cause);
+                    } catch (final InterruptedException e) {
+                        future.cancel(true);
+                        Thread.currentThread().interrupt();
+                        throw new ExtractException("PDF extraction was interrupted.", e);
                     }
-                });
-                try {
-                    future.get(timeout, TimeUnit.MILLISECONDS);
-                } catch (final TimeoutException e) {
-                    future.cancel(true);
-                    throw new ExtractException("PDFBox process cannot finish in " + timeout + " ms.", e);
-                } catch (final ExecutionException e) {
-                    final Throwable cause = e.getCause() != null ? e.getCause() : e;
-                    if (cause instanceof ExtractException) {
-                        throw (ExtractException) cause;
+                } finally {
+                    // Stop any laggard task and wait briefly so the worker stops touching the
+                    // PDDocument before try-with-resources closes it. This reduces (does not
+                    // eliminate) the "COSStream is closed" secondary failure on cancellation:
+                    // PDFBox does not consistently honour Thread.interrupt for native I/O, so
+                    // the race remains in worst-case scenarios.
+                    executor.shutdownNow();
+                    try {
+                        if (!executor.awaitTermination(cancelGracePeriodMs, TimeUnit.MILLISECONDS) && logger.isDebugEnabled()) {
+                            logger.debug("PdfExtractor worker did not terminate within {} ms grace period.", cancelGracePeriodMs);
+                        }
+                    } catch (final InterruptedException ignore) {
+                        Thread.currentThread().interrupt();
                     }
-                    throw new ExtractException("PDF extraction failed.", cause);
-                } catch (final InterruptedException e) {
-                    future.cancel(true);
-                    Thread.currentThread().interrupt();
-                    throw new ExtractException("PDF extraction was interrupted.", e);
                 }
-            } finally {
-                // Stop any laggard task and wait briefly so the worker stops touching the
-                // PDDocument before try-with-resources closes it. This reduces (does not
-                // eliminate) the "COSStream is closed" secondary failure on cancellation:
-                // PDFBox does not consistently honour Thread.interrupt for native I/O, so
-                // the race remains in worst-case scenarios.
-                executor.shutdownNow();
-                try {
-                    if (!executor.awaitTermination(cancelGracePeriodMs, TimeUnit.MILLISECONDS) && logger.isDebugEnabled()) {
-                        logger.debug("PdfExtractor worker did not terminate within {} ms grace period.", cancelGracePeriodMs);
-                    }
-                } catch (final InterruptedException ignore) {
-                    Thread.currentThread().interrupt();
-                }
-            }
 
-            writer.flush();
-            final ExtractData extractData = new ExtractData(writer.toString());
-            extractMetadata(document, extractData);
-            return extractData;
+                final ExtractData extractData = new ExtractData(writer.getContent());
+                if (writer.isTruncated()) {
+                    if (logger.isWarnEnabled()) {
+                        logger.warn("Extracted PDF content truncated: maxTextLength={}", maxTextLength);
+                    }
+                    extractData.putValue("truncated", "true");
+                    extractData.putValue("maxTextLength", Long.toString(maxTextLength));
+                }
+                extractMetadata(document, extractData);
+                return extractData;
+            }
         } catch (final ExtractException e) {
             throw e;
         } catch (final CrawlerSystemException e) {
@@ -197,6 +239,10 @@ public class PdfExtractor extends PasswordBasedExtractor {
             throw new ExtractException("Failed to load PDF.", e);
         } catch (final Exception e) {
             throw new ExtractException(e);
+        } finally {
+            if (tempFile != null) {
+                FileUtil.deleteInBackground(tempFile);
+            }
         }
     }
 
@@ -213,11 +259,87 @@ public class PdfExtractor extends PasswordBasedExtractor {
     }
 
     /**
+     * A {@link Writer} that accumulates into an internal buffer capped at
+     * {@code maxLength} characters. Writes beyond the cap are silently
+     * discarded (matching the truncate-not-reject {@code maxTextLength}
+     * convention used elsewhere in this module, see
+     * {@link AbstractExtractor#readWithLimit(java.io.Reader, long)}), so
+     * {@link PDFTextStripper#writeText(PDDocument, Writer)} and the
+     * embedded-document/annotation appenders below never accumulate more than
+     * {@code maxLength} characters regardless of how large the source PDF is.
+     * At the truncation boundary a trailing unpaired high surrogate is dropped
+     * so the buffered content is always a valid UTF-16 sequence.
+     */
+    protected static final class BoundedTextWriter extends Writer {
+        /** The accumulated text. */
+        private final StringBuilder sb = new StringBuilder();
+
+        /** The maximum number of characters to accumulate; {@code <= 0} means unlimited. */
+        private final long maxLength;
+
+        /** Whether truncation has occurred. */
+        private boolean truncated;
+
+        /**
+         * Creates a new bounded writer.
+         * @param maxLength the maximum number of characters to accumulate
+         */
+        BoundedTextWriter(final long maxLength) {
+            this.maxLength = maxLength;
+        }
+
+        @Override
+        public void write(final char[] cbuf, final int off, final int len) {
+            if (truncated || len <= 0) {
+                return;
+            }
+            if (maxLength > 0 && (long) sb.length() + len > maxLength) {
+                final int remaining = (int) (maxLength - sb.length());
+                if (remaining > 0) {
+                    sb.append(cbuf, off, remaining);
+                }
+                if (sb.length() > 0 && Character.isHighSurrogate(sb.charAt(sb.length() - 1))) {
+                    sb.setLength(sb.length() - 1);
+                }
+                truncated = true;
+                return;
+            }
+            sb.append(cbuf, off, len);
+        }
+
+        @Override
+        public void flush() {
+            // no-op: content is accumulated directly in the internal StringBuilder
+        }
+
+        @Override
+        public void close() {
+            // no-op: no underlying resource to release
+        }
+
+        /**
+         * Returns whether truncation has occurred.
+         * @return {@code true} if the cap was reached
+         */
+        boolean isTruncated() {
+            return truncated;
+        }
+
+        /**
+         * Returns the accumulated (possibly truncated) content.
+         * @return the accumulated content
+         */
+        String getContent() {
+            return sb.toString();
+        }
+    }
+
+    /**
      * Extracts text from file attachments in PDF annotations.
      * @param doc the PDF document
      * @param writer the writer to append extracted text to
      */
-    protected void extractAnnotations(final PDDocument doc, final StringWriter writer) {
+    protected void extractAnnotations(final PDDocument doc, final Writer writer) {
         for (final PDPage page : doc.getPages()) {
             try {
                 for (final PDAnnotation annotation : page.getAnnotations()) {
@@ -241,7 +363,7 @@ public class PdfExtractor extends PasswordBasedExtractor {
      * @param embeddedFile the embedded file to extract text from
      * @param writer the writer to append extracted text to
      */
-    protected void extractFile(final String filename, final PDEmbeddedFile embeddedFile, final StringWriter writer) {
+    protected void extractFile(final String filename, final PDEmbeddedFile embeddedFile, final Writer writer) {
         final MimeTypeHelper mimeTypeHelper = getMimeTypeHelper();
         final ExtractorFactory extractorFactory = getExtractorFactory();
         final String mimeType = mimeTypeHelper.getContentType(null, filename);
@@ -268,7 +390,7 @@ public class PdfExtractor extends PasswordBasedExtractor {
      * @param document the PDF document
      * @param writer the writer to append extracted text to
      */
-    protected void extractEmbeddedDocuments(final PDDocument document, final StringWriter writer) {
+    protected void extractEmbeddedDocuments(final PDDocument document, final Writer writer) {
         final PDDocumentNameDictionary namesDictionary = new PDDocumentNameDictionary(document.getDocumentCatalog());
         final PDEmbeddedFilesNameTreeNode efTree = namesDictionary.getEmbeddedFiles();
         if (efTree == null) {
@@ -298,7 +420,7 @@ public class PdfExtractor extends PasswordBasedExtractor {
      * @param embeddedFileNames the map of embedded file names to specifications
      * @param writer the writer to append extracted text to
      */
-    protected void processEmbeddedDocNames(final Map<String, PDComplexFileSpecification> embeddedFileNames, final StringWriter writer) {
+    protected void processEmbeddedDocNames(final Map<String, PDComplexFileSpecification> embeddedFileNames, final Writer writer) {
         if (embeddedFileNames == null || embeddedFileNames.isEmpty()) {
             return;
         }
@@ -418,5 +540,31 @@ public class PdfExtractor extends PasswordBasedExtractor {
     @Deprecated
     public void setDaemonThread(final boolean isDaemonThread) {
         // no-op: daemon worker threads are always used
+    }
+
+    /**
+     * Returns the maximum number of characters that will be accumulated in the
+     * extracted text output.
+     *
+     * @return the maximum text length
+     */
+    public long getMaxTextLength() {
+        return maxTextLength;
+    }
+
+    /**
+     * Sets the maximum number of characters that will be accumulated in the
+     * extracted text output. The default is {@link Long#MAX_VALUE}, which is
+     * effectively unlimited. Values less than or equal to zero explicitly
+     * disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
+     *
+     * @param maxTextLength the maximum text length
+     */
+    public void setMaxTextLength(final long maxTextLength) {
+        this.maxTextLength = maxTextLength;
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractor.java
@@ -52,6 +52,7 @@ import org.codelibs.core.io.FileUtil;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.ExtractException;
+import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
 import org.codelibs.fess.crawler.extractor.Extractor;
 import org.codelibs.fess.crawler.extractor.ExtractorFactory;
 import org.codelibs.fess.crawler.helper.MimeTypeHelper;
@@ -83,7 +84,11 @@ import org.codelibs.fess.crawler.helper.MimeTypeHelper;
  * <p>The supplied input stream is first spooled to a temporary file and the PDF is
  * loaded from that file (rather than buffering the whole document into a
  * {@code byte[]} in memory), which reduces peak heap usage for large PDFs; the
- * temp file is deleted once extraction completes. The extracted text is bounded
+ * temp file is deleted once extraction completes. The number of bytes spooled is
+ * bounded by {@link #maxContentLength} (opt-in; default unlimited): oversized
+ * input is rejected with {@link MaxLengthExceededException} before the temp file
+ * can grow without bound, so a hostile stream cannot fill the temp filesystem.
+ * The extracted text is bounded
  * by {@link #maxTextLength} (default unlimited), mirroring the truncate-not-reject
  * convention used by {@link TextExtractor} and {@link MarkdownExtractor}: once the
  * cap is reached, further writes to the output are silently dropped and the
@@ -143,6 +148,15 @@ public class PdfExtractor extends PasswordBasedExtractor {
     protected long maxTextLength = Long.MAX_VALUE;
 
     /**
+     * Maximum number of input bytes spooled to the temporary file before
+     * rejecting oversized PDFs with {@link MaxLengthExceededException}. Values
+     * less than or equal to zero (the default) disable the limit, preserving the
+     * previous unbounded spool. Bounds temp-file (disk) usage for hostile or
+     * huge streams.
+     */
+    protected long maxContentLength = 0;
+
+    /**
      * Creates a new PdfExtractor instance.
      */
     public PdfExtractor() {
@@ -171,7 +185,7 @@ public class PdfExtractor extends PasswordBasedExtractor {
             // this module. The temp file is removed in the outer finally block below, after
             // the PDDocument (and its file handle) has been closed.
             tempFile = createTempFile("pdfExtractor-", ".pdf", null);
-            CopyUtil.copy(in, tempFile);
+            CopyUtil.copy(limitInputStream(in, maxContentLength), tempFile);
 
             try (PDDocument document = Loader.loadPDF(tempFile, password)) {
                 final BoundedTextWriter writer = new BoundedTextWriter(maxTextLength);
@@ -566,5 +580,30 @@ public class PdfExtractor extends PasswordBasedExtractor {
      */
     public void setMaxTextLength(final long maxTextLength) {
         this.maxTextLength = maxTextLength;
+    }
+
+    /**
+     * Returns the maximum number of input bytes that will be spooled to the
+     * temporary file before oversized PDFs are rejected with
+     * {@link MaxLengthExceededException}.
+     *
+     * @return the maximum input content length in bytes
+     */
+    public long getMaxContentLength() {
+        return maxContentLength;
+    }
+
+    /**
+     * Sets the maximum number of input bytes spooled to the temporary file before
+     * oversized PDFs are rejected with {@link MaxLengthExceededException}. Values
+     * less than or equal to zero (the default) disable the limit, preserving the
+     * previous unbounded spool. Bounding the spooled size bounds temp-file (disk)
+     * usage, so a hostile or accidentally huge stream cannot fill the temp
+     * filesystem.
+     *
+     * @param maxContentLength the maximum input content length in bytes
+     */
+    public void setMaxContentLength(final long maxContentLength) {
+        this.maxContentLength = maxContentLength;
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PsExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PsExtractor.java
@@ -16,12 +16,13 @@
 package org.codelibs.fess.crawler.extractor.impl;
 
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.codelibs.core.io.InputStreamUtil;
 import org.codelibs.fess.crawler.Constants;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.ExtractException;
@@ -43,6 +44,16 @@ import org.codelibs.fess.crawler.exception.UnsupportedExtractException;
  * via loops or procedures, font encoding redefinitions, or binary-encoded
  * PostScript files.
  * </p>
+ *
+ * <p>
+ * The input stream is decoded via a {@code BufferedReader} (not buffered into a
+ * byte array first) and the raw character count is bounded by
+ * {@link #maxTextLength}, mirroring the same cap used by {@link TextExtractor}
+ * and {@link MarkdownExtractor}. When truncation occurs, a WARN-level log
+ * message is emitted and the returned {@link ExtractData} carries
+ * {@code truncated=true} and {@code maxTextLength=<value>} metadata entries.
+ * The supplied input stream is closed by {@link #getText(InputStream, Map)}.
+ * </p>
  */
 public class PsExtractor extends AbstractExtractor {
 
@@ -55,6 +66,17 @@ public class PsExtractor extends AbstractExtractor {
     protected String encoding = Constants.UTF_8;
 
     /**
+     * Maximum number of characters to read from the input. The default is
+     * {@link Long#MAX_VALUE}, which is effectively unlimited. Values less than
+     * or equal to zero explicitly disable the limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
+     */
+    protected long maxTextLength = Long.MAX_VALUE;
+
+    /**
      * Creates a new PsExtractor instance.
      */
     public PsExtractor() {
@@ -65,12 +87,20 @@ public class PsExtractor extends AbstractExtractor {
     public ExtractData getText(final InputStream in, final Map<String, String> params) {
         validateInputStream(in);
         try {
-            final String psContent = new String(InputStreamUtil.getBytes(in), getEncoding());
-            final String extractedText = extractText(psContent);
+            final TextReadResult readResult;
+            try (Reader reader = new InputStreamReader(in, getEncoding())) {
+                readResult = readWithLimit(reader, maxTextLength);
+            }
+            final String extractedText = extractText(readResult.content);
             if (extractedText.isEmpty()) {
                 throw new UnsupportedExtractException("No text found in PostScript content.");
             }
-            return new ExtractData(extractedText);
+            final ExtractData extractData = new ExtractData(extractedText);
+            if (readResult.truncated) {
+                extractData.putValue("truncated", "true");
+                extractData.putValue("maxTextLength", Long.toString(maxTextLength));
+            }
+            return extractData;
         } catch (final UnsupportedExtractException e) {
             throw e;
         } catch (final Exception e) {
@@ -97,6 +127,32 @@ public class PsExtractor extends AbstractExtractor {
      */
     public void setEncoding(final String encoding) {
         this.encoding = encoding;
+    }
+
+    /**
+     * Returns the maximum number of characters that will be read from the
+     * input stream before truncation.
+     *
+     * @return the maximum text length
+     */
+    public long getMaxTextLength() {
+        return maxTextLength;
+    }
+
+    /**
+     * Sets the maximum number of characters that will be read from the input
+     * stream. The default is {@link Long#MAX_VALUE}, which is effectively
+     * unlimited. Values less than or equal to zero explicitly disable the
+     * limit.
+     *
+     * <p>The limit is measured in Java {@code char} units (UTF-16 code units).
+     * At the truncation boundary, an unpaired high surrogate is dropped to avoid
+     * leaving an invalid string.
+     *
+     * @param maxTextLength the maximum text length
+     */
+    public void setMaxTextLength(final long maxTextLength) {
+        this.maxTextLength = maxTextLength;
     }
 
     /**

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/AbstractExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/AbstractExtractorTest.java
@@ -88,6 +88,10 @@ public class AbstractExtractorTest extends PlainTestCase {
         public long testAddOneSaturating(final long value) {
             return addOneSaturating(value);
         }
+
+        public InputStream testLimitInputStream(final InputStream in, final long limit) {
+            return limitInputStream(in, limit);
+        }
     }
 
     private TestExtractor extractor;
@@ -447,5 +451,39 @@ public class AbstractExtractorTest extends PlainTestCase {
         assertEquals(Long.MAX_VALUE, extractor.testAddOneSaturating(Long.MAX_VALUE - 1L));
         // Verify the result is positive (not wrapped to negative).
         assertTrue(extractor.testAddOneSaturating(Long.MAX_VALUE) > 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // limitInputStream (input-size bound)
+    // -----------------------------------------------------------------------
+
+    /** A stream of exactly {@code limit} bytes is fully readable and never throws. */
+    @Test
+    public void test_limitInputStream_exactlyLimit_readsAllNoThrow() throws Exception {
+        final InputStream bounded = extractor.testLimitInputStream(new ByteArrayInputStream(new byte[10]), 10);
+        final byte[] read = bounded.readAllBytes();
+        assertEquals(10, read.length);
+    }
+
+    /** One byte beyond the limit triggers MaxLengthExceededException. */
+    @Test
+    public void test_limitInputStream_limitPlusOne_throws() throws Exception {
+        final InputStream bounded = extractor.testLimitInputStream(new ByteArrayInputStream(new byte[11]), 10);
+        try {
+            bounded.readAllBytes();
+            fail();
+        } catch (final MaxLengthExceededException e) {
+            assertTrue(e.getMessage().contains("input size exceeded limit"));
+        }
+    }
+
+    /** A limit of zero or less returns the SAME instance unwrapped and never throws. */
+    @Test
+    public void test_limitInputStream_nonPositiveLimit_returnsSameInstance() throws Exception {
+        final InputStream original = new ByteArrayInputStream(new byte[100]);
+        org.junit.jupiter.api.Assertions.assertSame(original, extractor.testLimitInputStream(original, 0));
+        org.junit.jupiter.api.Assertions.assertSame(original, extractor.testLimitInputStream(original, -1L));
+        // The unwrapped stream reads all bytes without any bound.
+        assertEquals(100, original.readAllBytes().length);
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/JsonExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/JsonExtractorTest.java
@@ -15,7 +15,9 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,6 +26,7 @@ import org.codelibs.core.io.ResourceUtil;
 import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
+import org.codelibs.fess.crawler.exception.ExtractException;
 import org.dbflute.utflute.core.PlainTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -130,5 +133,118 @@ public class JsonExtractorTest extends PlainTestCase {
 
         // With depth 1, nested content should not be deeply processed
         assertNotNull(content);
+    }
+
+    @Test
+    public void test_getText_normalInputUnaffectedByBounds() {
+        // Default bounds (tightened StreamReadConstraints; unlimited maxTextLength) must not
+        // change output for the existing normal-sized fixture.
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/json/test.json");
+        final ExtractData extractData = jsonExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+
+        assertTrue(extractData.getContent().contains("Sample Document"));
+        assertEquals("Sample Document", extractData.getValues("title")[0]);
+        assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_getText_truncatesAtMaxTextLength() {
+        // A JSON object with a very large number of top-level fields (unbounded by
+        // maxArrayElements, which only caps arrays) must not grow the accumulated output
+        // text without bound; maxTextLength must cap it, mirroring TextExtractor/
+        // MarkdownExtractor's truncate-not-reject convention.
+        jsonExtractor.setMaxTextLength(50);
+        final StringBuilder json = new StringBuilder("{");
+        for (int i = 0; i < 100_000; i++) {
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("\"field").append(i).append("\":\"value").append(i).append('"');
+        }
+        json.append('}');
+        final InputStream in = new ByteArrayInputStream(json.toString().getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = jsonExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+
+        assertTrue(extractData.getContent().length() <= 50);
+        final String[] truncated = extractData.getValues("truncated");
+        assertNotNull(truncated);
+        assertEquals("true", truncated[0]);
+        final String[] maxLen = extractData.getValues("maxTextLength");
+        assertNotNull(maxLen);
+        assertEquals("50", maxLen[0]);
+    }
+
+    @Test
+    public void test_getText_maxTextLength_zero_isUnlimited() {
+        // maxTextLength=0 means unlimited, matching TextExtractor's convention.
+        jsonExtractor.setMaxTextLength(0);
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/json/test.json");
+        final ExtractData extractData = jsonExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertNull(extractData.getValues("truncated"));
+        assertTrue(extractData.getContent().contains("Sample Document"));
+    }
+
+    @Test
+    public void test_getText_deeplyNestedJsonIsRejected() {
+        // The shared ObjectMapper is configured with StreamReadConstraints.maxNestingDepth
+        // pinned to Jackson's own default (1000), so a document with pathological nesting
+        // that exceeds even that generous ceiling must fail fast at parse time rather than
+        // risking stack/heap exhaustion by materializing an arbitrarily deep tree.
+        final int depth = 2000;
+        final StringBuilder json = new StringBuilder();
+        for (int i = 0; i < depth; i++) {
+            json.append("{\"a\":");
+        }
+        json.append('1');
+        for (int i = 0; i < depth; i++) {
+            json.append('}');
+        }
+        final InputStream in = new ByteArrayInputStream(json.toString().getBytes(StandardCharsets.UTF_8));
+        try {
+            jsonExtractor.getText(in, null);
+            fail();
+        } catch (final ExtractException e) {
+            // Expected: StreamReadConstraints.maxNestingDepth rejects the pathological input.
+        } finally {
+            CloseableUtil.closeQuietly(in);
+        }
+    }
+
+    @Test
+    public void test_getText_legitimatelyDeepJsonIsNotRejected() {
+        // A nesting depth of ~500 is well under Jackson's default maxNestingDepth (1000), so
+        // it must parse successfully just like it would with a default-configured Jackson
+        // ObjectMapper on master. This would have FAILED when MAX_NESTING_DEPTH was tightened
+        // to 64, and guards against re-tightening the parse-time constraint below Jackson's
+        // own default. Each level carries a scalar "value" field alongside the nested
+        // "nested" object so the extractor's own maxDepth=10 output traversal (a separate,
+        // intentional bound on the recursive text walk) still yields non-empty content.
+        final int depth = 500;
+        final StringBuilder json = new StringBuilder();
+        for (int i = 0; i < depth; i++) {
+            json.append("{\"value\":").append(i).append(",\"nested\":");
+        }
+        json.append("null");
+        for (int i = 0; i < depth; i++) {
+            json.append('}');
+        }
+        final InputStream in = new ByteArrayInputStream(json.toString().getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData;
+        try {
+            extractData = jsonExtractor.getText(in, null);
+        } finally {
+            CloseableUtil.closeQuietly(in);
+        }
+
+        final String content = extractData.getContent();
+        assertNotNull(content);
+        assertFalse(content.isEmpty());
+        // The output-side maxDepth=10 traversal bound (independent of parse-time
+        // StreamReadConstraints) means only the first few levels' "value" fields are walked.
+        assertTrue(content.contains("value: 0"));
+        assertNull(extractData.getValues("truncated"));
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/JsonExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/JsonExtractorTest.java
@@ -27,6 +27,7 @@ import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.ExtractException;
+import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
 import org.dbflute.utflute.core.PlainTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -246,5 +247,45 @@ public class JsonExtractorTest extends PlainTestCase {
         // StreamReadConstraints) means only the first few levels' "value" fields are walked.
         assertTrue(content.contains("value: 0"));
         assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_getText_maxContentLength_rejectsOversizedInput() {
+        // Input clearly larger than the 10-byte cap must be rejected (with
+        // MaxLengthExceededException) before the JsonNode tree is materialized.
+        jsonExtractor.setMaxContentLength(10);
+        final InputStream in = new ByteArrayInputStream("{\"key\":\"aaaaaaaaaaaaaaaaaaaa\"}".getBytes(StandardCharsets.UTF_8));
+        try {
+            jsonExtractor.getText(in, null);
+            fail();
+        } catch (final MaxLengthExceededException e) {
+            assertTrue(e.getMessage().contains("input size exceeded limit"));
+        } finally {
+            CloseableUtil.closeQuietly(in);
+        }
+    }
+
+    @Test
+    public void test_getText_maxContentLength_underCapExtractsNormally() {
+        // A cap well above the fixture size must not change extraction.
+        jsonExtractor.setMaxContentLength(1_000_000);
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/json/test.json");
+        final ExtractData extractData = jsonExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+
+        assertFalse(extractData.getContent().isEmpty());
+        assertTrue(extractData.getContent().contains("Sample Document"));
+        assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_getText_maxContentLength_defaultUnlimited() {
+        // Default (unset, 0) preserves the previous unbounded behavior for a normal fixture.
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/json/test.json");
+        final ExtractData extractData = jsonExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+
+        assertTrue(extractData.getContent().contains("Sample Document"));
+        assertEquals("Sample Document", extractData.getValues("title")[0]);
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractorTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
@@ -362,5 +363,99 @@ public class PdfExtractorTest extends PlainTestCase {
         assertNotNull(t);
         assertTrue(t instanceof ExtractException);
         assertTrue(Boolean.TRUE.equals(interruptFlagAfter.get()));
+    }
+
+    @Test
+    public void test_getText_truncatesAtMaxTextLength() {
+        // extractor/test.pdf's full extracted text is "テスト\n" (4 chars); cap below that to
+        // force truncation deterministically.
+        pdfExtractor.setMaxTextLength(2);
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test.pdf");
+        final ExtractData extractData = pdfExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+
+        assertTrue(extractData.getContent().length() <= 2);
+        final String[] truncated = extractData.getValues("truncated");
+        assertNotNull(truncated);
+        assertEquals("true", truncated[0]);
+        final String[] maxLen = extractData.getValues("maxTextLength");
+        assertNotNull(maxLen);
+        assertEquals("2", maxLen[0]);
+        // Metadata extraction runs independently of the bounded text writer and must still
+        // populate normally even though the page text was truncated.
+        assertEquals("Writer", extractData.getValues("Creator")[0]);
+    }
+
+    @Test
+    public void test_getText_maxTextLengthDoesNotAffectNormalInput() {
+        // Default maxTextLength (unlimited) must not change output for the existing fixture.
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test.pdf");
+        final ExtractData extractData = pdfExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertTrue(extractData.getContent().contains("テスト"));
+        assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_boundedTextWriter_capsOutputRegardlessOfWriteVolume() {
+        // Directly exercise the writer used to bound PDFTextStripper's output: even when far
+        // more than the cap is written (simulating a huge/hostile PDF), the internal buffer
+        // must never exceed maxLength, proving heap use is bounded independent of source size.
+        final PdfExtractor.BoundedTextWriter writer = new PdfExtractor.BoundedTextWriter(1000);
+        final char[] chunk = new char[8192];
+        java.util.Arrays.fill(chunk, 'x');
+        for (int i = 0; i < 2000; i++) {
+            writer.write(chunk, 0, chunk.length);
+        }
+        assertTrue(writer.isTruncated());
+        assertEquals(1000, writer.getContent().length());
+    }
+
+    @Test
+    public void test_boundedTextWriter_unlimitedByDefaultConvention() {
+        // maxLength <= 0 disables the limit, matching the maxTextLength convention used by
+        // TextExtractor/MarkdownExtractor/JsonExtractor.
+        final PdfExtractor.BoundedTextWriter writer = new PdfExtractor.BoundedTextWriter(0);
+        final String text = "Hello, world!";
+        writer.write(text.toCharArray(), 0, text.length());
+        assertFalse(writer.isTruncated());
+        assertEquals(text, writer.getContent());
+    }
+
+    @Test
+    public void test_getText_spooledTempFileIsDeletedAfterExtraction() throws Exception {
+        final java.util.Set<String> before = listPdfExtractorTempFiles();
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test.pdf");
+        try {
+            final ExtractData extractData = pdfExtractor.getText(in, null);
+            assertNotNull(extractData);
+        } finally {
+            CloseableUtil.closeQuietly(in);
+        }
+
+        // FileUtil.deleteInBackground is asynchronous (TimeoutManager polls at ~1s cadence),
+        // so poll for up to ~5s for the spool file to disappear.
+        final long deadline = System.currentTimeMillis() + 5_000L;
+        java.util.Set<String> leaked = listPdfExtractorTempFiles();
+        leaked.removeAll(before);
+        while (!leaked.isEmpty() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(100L);
+            leaked = listPdfExtractorTempFiles();
+            leaked.removeAll(before);
+        }
+        org.junit.jupiter.api.Assertions.assertTrue(leaked.isEmpty(),
+                "spooled temp file must be deleted after extraction, leaked=" + leaked);
+    }
+
+    private static java.util.Set<String> listPdfExtractorTempFiles() {
+        final File dir = org.apache.commons.lang3.SystemUtils.getJavaIoTmpDir();
+        final File[] files = dir.listFiles((d, name) -> name.startsWith("pdfExtractor-") && name.endsWith(".pdf"));
+        final java.util.Set<String> names = new java.util.HashSet<>();
+        if (files != null) {
+            for (final File f : files) {
+                names.add(f.getName());
+            }
+        }
+        return names;
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/PdfExtractorTest.java
@@ -33,6 +33,7 @@ import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
 import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.ExtractException;
+import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
 import org.codelibs.fess.crawler.extractor.ExtractorFactory;
 import org.codelibs.fess.crawler.helper.impl.MimeTypeHelperImpl;
 import org.dbflute.utflute.core.PlainTestCase;
@@ -389,6 +390,33 @@ public class PdfExtractorTest extends PlainTestCase {
     @Test
     public void test_getText_maxTextLengthDoesNotAffectNormalInput() {
         // Default maxTextLength (unlimited) must not change output for the existing fixture.
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test.pdf");
+        final ExtractData extractData = pdfExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertTrue(extractData.getContent().contains("テスト"));
+        assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_getText_maxContentLength_rejectsOversizedInput() {
+        // extractor/test.pdf is ~3.5KB, far larger than the 10-byte cap, so the spool to the
+        // temp file must be rejected with MaxLengthExceededException before it grows unbounded.
+        pdfExtractor.setMaxContentLength(10);
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test.pdf");
+        try {
+            pdfExtractor.getText(in, null);
+            fail();
+        } catch (final MaxLengthExceededException e) {
+            assertTrue(e.getMessage().contains("input size exceeded limit"));
+        } finally {
+            CloseableUtil.closeQuietly(in);
+        }
+    }
+
+    @Test
+    public void test_getText_maxContentLength_underCapExtractsNormally() {
+        // A cap larger than test.pdf's size must not change extraction.
+        pdfExtractor.setMaxContentLength(10_000_000);
         final InputStream in = ResourceUtil.getResourceAsStream("extractor/test.pdf");
         final ExtractData extractData = pdfExtractor.getText(in, null);
         CloseableUtil.closeQuietly(in);

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/PsExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/PsExtractorTest.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.codelibs.core.io.CloseableUtil;
 import org.codelibs.core.io.ResourceUtil;
 import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
+import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.UnsupportedExtractException;
 import org.dbflute.utflute.core.PlainTestCase;
@@ -261,6 +262,61 @@ public class PsExtractorTest extends PlainTestCase {
     @Test
     public void test_getText_incompleteLessThan() {
         final String ps = "%!PS\n<";
+        final InputStream in = new ByteArrayInputStream(ps.getBytes(StandardCharsets.UTF_8));
+        try {
+            psExtractor.getText(in, null);
+            fail();
+        } catch (final UnsupportedExtractException e) {
+            // NOP
+        } finally {
+            CloseableUtil.closeQuietly(in);
+        }
+    }
+
+    @Test
+    public void test_getText_truncatesAtMaxTextLength() {
+        // A pathological/oversized PostScript stream must be bounded rather than read
+        // entirely into memory. Build a stream far larger than a small cap and verify the
+        // extractor stops well short of consuming/decoding the whole thing.
+        psExtractor.setMaxTextLength(200);
+        final StringBuilder ps = new StringBuilder("%!PS\n72 700 moveto\n");
+        for (int i = 0; i < 100_000; i++) {
+            ps.append("(Hello World ").append(i).append(") show\n");
+        }
+        ps.append("showpage\n");
+        final InputStream in = new ByteArrayInputStream(ps.toString().getBytes(StandardCharsets.UTF_8));
+        final ExtractData extractData = psExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+
+        // The raw (pre-parse) character count fed into extractText is capped at 200 chars,
+        // so the resulting extracted text must be far smaller than the ~2MB source.
+        assertTrue(extractData.getContent().length() < 200);
+        final String[] truncated = extractData.getValues("truncated");
+        assertNotNull(truncated);
+        assertEquals("true", truncated[0]);
+        final String[] maxLen = extractData.getValues("maxTextLength");
+        assertNotNull(maxLen);
+        assertEquals("200", maxLen[0]);
+    }
+
+    @Test
+    public void test_getText_maxTextLengthDoesNotAffectNormalInput() {
+        // Default maxTextLength (unlimited) must not change output for a normal-sized file.
+        final InputStream in = ResourceUtil.getResourceAsStream("extractor/test.ps");
+        final ExtractData extractData = psExtractor.getText(in, null);
+        CloseableUtil.closeQuietly(in);
+        assertTrue(extractData.getContent().contains("Hello World"));
+        assertTrue(extractData.getContent().contains("test of PostScript"));
+        assertNull(extractData.getValues("truncated"));
+    }
+
+    @Test
+    public void test_getText_maxTextLength_exceedsCapButNoShowTextFound() {
+        // When truncation lands before any show-family operator, the (now-shorter) content
+        // still yields no extractable text and must throw the same exception as an empty
+        // document, not silently succeed with a different result shape.
+        psExtractor.setMaxTextLength(5);
+        final String ps = "%!PS\n72 700 moveto\n(Hello World) show\nshowpage\n";
         final InputStream in = new ByteArrayInputStream(ps.getBytes(StandardCharsets.UTF_8));
         try {
             psExtractor.getText(in, null);


### PR DESCRIPTION
## Summary

Bound the heap usage of three extractors that previously read/accumulated their input without any limit, so a large or hostile PostScript, JSON, or PDF document can no longer drive unbounded memory growth. All new bounds follow the module's existing **truncate-not-reject** convention and **default to unlimited**, so normal inputs are unchanged.

## Changes

- **PsExtractor** — replaced `new String(InputStreamUtil.getBytes(in), enc)` (whole stream → `byte[]` → `String`) with `AbstractExtractor.readWithLimit(reader, maxTextLength)`, the same helper `TextExtractor`/`MarkdownExtractor` use. New configurable `maxTextLength` (default `Long.MAX_VALUE`).
- **JsonExtractor** —
  - Cap the accumulated output text with a new `TextAccumulator`, which also bounds **object-field** output (previously only arrays were bounded via `maxArrayElements`; a huge flat object could still produce unbounded output).
  - Pin the `ObjectMapper` `StreamReadConstraints` explicitly to **Jackson's own defaults** (`maxNestingDepth=1000`, `maxStringLength=20_000_000`, `maxNumberLength=1000`). This documents the parse-time DoS ceilings without tightening them below what a default `ObjectMapper` already enforces — so no legitimate JSON that parsed before is rejected.
- **PdfExtractor** —
  - Bound the extracted text with a `BoundedTextWriter` (caps the sum across the page text, annotations, and embedded documents).
  - Spool the input to a temp file and use PDFBox's file-backed `Loader.loadPDF(File)` instead of `RandomAccessReadBuffer(InputStream)` (which buffers the whole PDF in heap). The temp file is always deleted in a `finally` (via `FileUtil.deleteInBackground`), after the document is closed. The per-call extraction executor/timeout is unchanged.

All truncation is high-surrogate-safe and sets the `truncated` / `maxTextLength` `ExtractData` metadata, consistent with the existing `readWithLimit` behavior.

## Testing

- Per-extractor: oversized-input truncation (metadata asserted) and normal-fixture parity (byte-identical output).
- `JsonExtractorTest`: a legitimately deep (500-level) JSON is **not** rejected and extracts content — this guards against re-tightening `maxNestingDepth` below Jackson's default (it fails if the limit is dropped back to a small value); plus a truly-pathological (2000-level) document is rejected.
- `PdfExtractorTest`: a `BoundedTextWriter` unit test proving the buffer never exceeds the cap, and a temp-file-cleanup test.
- Full `fess-crawler` module suite passes (a pre-existing timing-sensitive `FtpClientTest` flake under parallel load is unrelated — these changes do not touch FTP — and passes in isolation); `mvn formatter:format` / `license:format` / `javadoc:jar` clean.
