### PR TITLE
perf(http): enforce max content length before fully downloading the body

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerContext.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerContext.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.crawler;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -85,8 +86,16 @@ public class CrawlerContext {
 
     /**
      * Set of robots.txt URLs that have been processed.
+     * <p>
+     * Wrapped with {@link Collections#synchronizedSet(Set)} because {@link LruHashSet} (backed by a
+     * plain, non-thread-safe {@code LruHashMap}) is shared across all crawler threads. HTTP clients
+     * collapse their check-then-add into a single {@code add(url)} call, which under this wrapper is
+     * synchronized as one atomic operation -- avoiding both backing-map corruption from concurrent
+     * structural modification and duplicate robots.txt fetches. The 10000-entry LRU bound and
+     * eviction behavior are unchanged.
+     * </p>
      */
-    protected Set<String> robotsTxtUrlSet = new LruHashSet<>(10000);
+    protected Set<String> robotsTxtUrlSet = Collections.synchronizedSet(new LruHashSet<>(10000));
 
     /**
      * Thread-local storage for sitemaps.

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/Hc4HttpClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/Hc4HttpClient.java
@@ -40,6 +40,7 @@ import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLContext;
 
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.io.output.DeferredFileOutputStream;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.http.Header;
@@ -582,8 +583,11 @@ public class Hc4HttpClient extends HcHttpClient {
         }
         final String robotTxtUrl = hostUrl + "/robots.txt";
 
-        // check url
-        if (crawlerContext.getRobotsTxtUrlSet().contains(robotTxtUrl)) {
+        // Atomically check-and-add: LruHashSet#add() (via the synchronized set wrapping it in
+        // CrawlerContext) returns false when robotTxtUrl was already present, so a single add()
+        // call replaces the previous contains()-then-add() pair. That avoided a race where two
+        // threads could both observe "not present" and both fetch robots.txt for the same host.
+        if (!crawlerContext.getRobotsTxtUrlSet().add(robotTxtUrl)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("{} is already visited.", robotTxtUrl);
             }
@@ -593,8 +597,6 @@ public class Hc4HttpClient extends HcHttpClient {
         if (logger.isInfoEnabled()) {
             logger.info("Checking URL: {}", robotTxtUrl);
         }
-        // add url to a set
-        crawlerContext.getRobotsTxtUrlSet().add(robotTxtUrl);
 
         final HttpGet httpGet = new HttpGet(robotTxtUrl);
 
@@ -835,13 +837,65 @@ public class Hc4HttpClient extends HcHttpClient {
                     contentType = defaultMimeType;
                 }
             } else {
-                final InputStream responseBodyStream = httpEntity.getContent();
-                try (final DeferredFileOutputStream dfos = DeferredFileOutputStream.builder()
-                        .setThreshold((int) maxCachedContentSize)
-                        .setPrefix("crawler-Hc4HttpClient-")
-                        .setSuffix(".out")
-                        .setDirectory(SystemUtils.getJavaIoTmpDir())
-                        .get()) {
+                // Determine the effective max content length before downloading the body so an
+                // oversized response can be rejected without fully buffering it in memory or on
+                // disk. ContentLengthHelper#getMaxLength() never signals "no limit" via <= 0 --
+                // addMaxLength()/setDefaultMaxLength() both reject negative values -- so, by the
+                // convention used elsewhere in this codebase (see AbstractXmlExtractor#maxTextLength,
+                // ApiExtractor#maxResponseSize), Long.MAX_VALUE is the "effectively unlimited" value.
+                // contentLengthHelper itself may also be null (not injected, e.g. in some unit
+                // tests), which likewise means no length bound applies here. When contentType is
+                // still unknown at this point (no Content-Type header), the actual MIME type can
+                // only be determined by sniffing the body after it has been downloaded, so the
+                // per-type limit that will ultimately apply is not knowable yet either. Using just
+                // the default max here would risk bounding -- and thus truncating -- the stream
+                // below a larger per-type limit before the post-copy check ever runs; that check
+                // only compares the length already read against the limit, it cannot recover bytes
+                // the bound has already discarded. To stay safe, the overall upper bound across the
+                // default and all per-type limits (ContentLengthHelper#getMaxLength()) is used
+                // instead in that case. The post-copy check below still re-evaluates against the
+                // (possibly sniffed) final contentType for the authoritative, exact comparison.
+                final long maxLength;
+                if (contentLengthHelper == null) {
+                    maxLength = Long.MAX_VALUE;
+                } else if (contentType == null) {
+                    maxLength = contentLengthHelper.getMaxLength();
+                } else {
+                    maxLength = contentLengthHelper.getMaxLength(contentType);
+                }
+                final boolean lengthLimited = maxLength < Long.MAX_VALUE;
+
+                // Content-Length precheck: reject an oversized response before downloading
+                // anything, mirroring the robots.txt Content-Length check above. A malformed or
+                // unparseable declared length (e.g. "Content-Length: abc") must not fail the URL --
+                // it is treated as unknown so this precheck is skipped for that response, relying on
+                // the BoundedInputStream cap and the authoritative post-copy check below instead.
+                if (lengthLimited) {
+                    final Header declaredContentLengthHeader = response.getFirstHeader("Content-Length");
+                    if (declaredContentLengthHeader != null) {
+                        final long declaredContentLength = parseDeclaredContentLength(declaredContentLengthHeader.getValue());
+                        if (declaredContentLength >= 0 && declaredContentLength > maxLength) {
+                            throw new MaxLengthExceededException("The content length (" + declaredContentLength + " byte) is over "
+                                    + maxLength + " byte. The url is " + url);
+                        }
+                    }
+                }
+
+                final InputStream entityStream = httpEntity.getContent();
+                // Bound the stream so a chunked/unknown-length body that turns out to be oversized
+                // is capped mid-copy instead of being fully buffered before the size check below
+                // runs. The +1 (via incrementWithoutOverflow) lets one extra byte through so the
+                // post-copy check can still detect and report the excess; when unlimited, the
+                // stream is used as-is so no cap is ever applied.
+                try (final InputStream responseBodyStream = lengthLimited
+                        ? BoundedInputStream.builder().setInputStream(entityStream).setMaxCount(incrementWithoutOverflow(maxLength)).get()
+                        : entityStream;
+                        final DeferredFileOutputStream dfos = DeferredFileOutputStream.builder()
+                                .setThreshold((int) maxCachedContentSize)
+                                .setPrefix("crawler-Hc4HttpClient-")
+                                .setSuffix(".out")
+                                .setDirectory(SystemUtils.getJavaIoTmpDir())
+                                .get()) {
                     CopyUtil.copy(responseBodyStream, dfos);
                     dfos.flush();
 

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/Hc5HttpClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/Hc5HttpClient.java
@@ -46,6 +46,7 @@ import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLContext;
 
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.io.output.DeferredFileOutputStream;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.hc.client5.http.DnsResolver;
@@ -805,8 +806,11 @@ public class Hc5HttpClient extends HcHttpClient {
         }
         final String robotTxtUrl = hostUrl + "/robots.txt";
 
-        // check url
-        if (crawlerContext.getRobotsTxtUrlSet().contains(robotTxtUrl)) {
+        // Atomically check-and-add: LruHashSet#add() (via the synchronized set wrapping it in
+        // CrawlerContext) returns false when robotTxtUrl was already present, so a single add()
+        // call replaces the previous contains()-then-add() pair. That avoided a race where two
+        // threads could both observe "not present" and both fetch robots.txt for the same host.
+        if (!crawlerContext.getRobotsTxtUrlSet().add(robotTxtUrl)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("{} is already visited.", robotTxtUrl);
             }
@@ -816,8 +820,6 @@ public class Hc5HttpClient extends HcHttpClient {
         if (logger.isInfoEnabled()) {
             logger.info("Checking URL: {}", robotTxtUrl);
         }
-        // add url to a set
-        crawlerContext.getRobotsTxtUrlSet().add(robotTxtUrl);
 
         final HttpGet httpGet = new HttpGet(robotTxtUrl);
 
@@ -1062,13 +1064,65 @@ public class Hc5HttpClient extends HcHttpClient {
                     contentType = defaultMimeType;
                 }
             } else {
-                final InputStream responseBodyStream = httpEntity.getContent();
-                try (final DeferredFileOutputStream dfos = DeferredFileOutputStream.builder()
-                        .setThreshold((int) maxCachedContentSize)
-                        .setPrefix("crawler-Hc5HttpClient-")
-                        .setSuffix(".out")
-                        .setDirectory(SystemUtils.getJavaIoTmpDir())
-                        .get()) {
+                // Determine the effective max content length before downloading the body so an
+                // oversized response can be rejected without fully buffering it in memory or on
+                // disk. ContentLengthHelper#getMaxLength() never signals "no limit" via <= 0 --
+                // addMaxLength()/setDefaultMaxLength() both reject negative values -- so, by the
+                // convention used elsewhere in this codebase (see AbstractXmlExtractor#maxTextLength,
+                // ApiExtractor#maxResponseSize), Long.MAX_VALUE is the "effectively unlimited" value.
+                // contentLengthHelper itself may also be null (not injected, e.g. in some unit
+                // tests), which likewise means no length bound applies here. When contentType is
+                // still unknown at this point (no Content-Type header), the actual MIME type can
+                // only be determined by sniffing the body after it has been downloaded, so the
+                // per-type limit that will ultimately apply is not knowable yet either. Using just
+                // the default max here would risk bounding -- and thus truncating -- the stream
+                // below a larger per-type limit before the post-copy check ever runs; that check
+                // only compares the length already read against the limit, it cannot recover bytes
+                // the bound has already discarded. To stay safe, the overall upper bound across the
+                // default and all per-type limits (ContentLengthHelper#getMaxLength()) is used
+                // instead in that case. The post-copy check below still re-evaluates against the
+                // (possibly sniffed) final contentType for the authoritative, exact comparison.
+                final long maxLength;
+                if (contentLengthHelper == null) {
+                    maxLength = Long.MAX_VALUE;
+                } else if (contentType == null) {
+                    maxLength = contentLengthHelper.getMaxLength();
+                } else {
+                    maxLength = contentLengthHelper.getMaxLength(contentType);
+                }
+                final boolean lengthLimited = maxLength < Long.MAX_VALUE;
+
+                // Content-Length precheck: reject an oversized response before downloading
+                // anything, mirroring the robots.txt Content-Length check above. A malformed or
+                // unparseable declared length (e.g. "Content-Length: abc") must not fail the URL --
+                // it is treated as unknown so this precheck is skipped for that response, relying on
+                // the BoundedInputStream cap and the authoritative post-copy check below instead.
+                if (lengthLimited) {
+                    final Header declaredContentLengthHeader = response.getFirstHeader("Content-Length");
+                    if (declaredContentLengthHeader != null) {
+                        final long declaredContentLength = parseDeclaredContentLength(declaredContentLengthHeader.getValue());
+                        if (declaredContentLength >= 0 && declaredContentLength > maxLength) {
+                            throw new MaxLengthExceededException("The content length (" + declaredContentLength + " byte) is over "
+                                    + maxLength + " byte. The url is " + url);
+                        }
+                    }
+                }
+
+                final InputStream entityStream = httpEntity.getContent();
+                // Bound the stream so a chunked/unknown-length body that turns out to be oversized
+                // is capped mid-copy instead of being fully buffered before the size check below
+                // runs. The +1 (via incrementWithoutOverflow) lets one extra byte through so the
+                // post-copy check can still detect and report the excess; when unlimited, the
+                // stream is used as-is so no cap is ever applied.
+                try (final InputStream responseBodyStream = lengthLimited
+                        ? BoundedInputStream.builder().setInputStream(entityStream).setMaxCount(incrementWithoutOverflow(maxLength)).get()
+                        : entityStream;
+                        final DeferredFileOutputStream dfos = DeferredFileOutputStream.builder()
+                                .setThreshold((int) maxCachedContentSize)
+                                .setPrefix("crawler-Hc5HttpClient-")
+                                .setSuffix(".out")
+                                .setDirectory(SystemUtils.getJavaIoTmpDir())
+                                .get()) {
                     CopyUtil.copy(responseBodyStream, dfos);
                     dfos.flush();
 

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/HcHttpClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/HcHttpClient.java
@@ -108,4 +108,45 @@ public abstract class HcHttpClient extends AbstractCrawlerClient {
     protected HcHttpClient() {
         // Default constructor
     }
+
+    /**
+     * Returns {@code value + 1} for use as a {@link org.apache.commons.io.input.BoundedInputStream}
+     * max-count that permits reading one byte past a configured size limit so the caller can detect
+     * an over-limit body. When {@code value} is {@link Long#MAX_VALUE}, returns {@code Long.MAX_VALUE}
+     * unchanged instead of overflowing to a negative number, which {@code BoundedInputStream} treats
+     * as "unbounded" -- silently disabling the cap.
+     *
+     * @param value the configured size limit in bytes
+     * @return {@code value + 1}, or {@code Long.MAX_VALUE} if incrementing would overflow
+     */
+    protected static long incrementWithoutOverflow(final long value) {
+        return value == Long.MAX_VALUE ? Long.MAX_VALUE : value + 1L;
+    }
+
+    /**
+     * Parses a declared {@code Content-Length} header value for the pre-download max-length
+     * precheck, tolerating a value that is missing, blank, not a valid number, or outside the
+     * range of a non-negative {@code long}.
+     * <p>
+     * A malformed or hostile {@code Content-Length} header (e.g. {@code "abc"}) must never cause
+     * the URL to fail: on {@link NumberFormatException} this method treats the declared length as
+     * "unknown" and returns {@code -1} so the caller can skip the precheck comparison for that
+     * response and fall back to the {@link org.apache.commons.io.input.BoundedInputStream} cap and
+     * the authoritative post-copy length check to enforce the limit.
+     * </p>
+     *
+     * @param value the raw {@code Content-Length} header value, may be {@code null}
+     * @return the parsed non-negative content length, or {@code -1} if the value could not be parsed
+     */
+    protected static long parseDeclaredContentLength(final String value) {
+        if (value == null) {
+            return -1L;
+        }
+        try {
+            final long parsed = Long.parseLong(value.trim());
+            return parsed >= 0L ? parsed : -1L;
+        } catch (final NumberFormatException e) {
+            return -1L;
+        }
+    }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/ContentLengthHelper.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/helper/ContentLengthHelper.java
@@ -82,6 +82,33 @@ public class ContentLengthHelper {
     }
 
     /**
+     * Returns the overall maximum content length across the default limit and every
+     * MIME type-specific limit configured on this helper, i.e.
+     * {@code max(defaultMaxLength, max(maxLengthMap.values()))}.
+     * <p>
+     * Callers that must bound or precheck a response before its actual MIME type is known
+     * (e.g. before the body has been downloaded and sniffed) cannot yet call
+     * {@link #getMaxLength(String)} with the right type. Using just {@link #getDefaultMaxLength()}
+     * in that situation would risk applying a bound smaller than a per-type limit that later turns
+     * out to apply, silently truncating the response before the type is ever determined. This
+     * method returns an upper bound that is guaranteed to be at least as large as whatever
+     * {@link #getMaxLength(String)} would return for any MIME type known to this helper, so it can
+     * be used safely in place of the default in that situation without weakening the length
+     * enforcement for any configured type.
+     * </p>
+     * @return the maximum content length across the default and all MIME type-specific limits, in bytes.
+     */
+    public long getMaxLength() {
+        long max = defaultMaxLength;
+        for (final long value : maxLengthMap.values()) {
+            if (value > max) {
+                max = value;
+            }
+        }
+        return max;
+    }
+
+    /**
      * Sets the default maximum content length.
      * @param defaultMaxLength The default maximum content length to set.
      */

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerContextTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerContextTest.java
@@ -366,7 +366,11 @@ public class CrawlerContextTest extends PlainTestCase {
     public void test_robotsTxtUrlSet() {
         Set<String> urlSet = crawlerContext.getRobotsTxtUrlSet();
         assertNotNull(urlSet);
-        assertTrue(urlSet instanceof LruHashSet);
+        // The default set is now wrapped with Collections.synchronizedSet(...) for thread safety
+        // (see CrawlerContext#robotsTxtUrlSet), so it is no longer an LruHashSet instance directly;
+        // its class name still reveals the synchronized-collection wrapper.
+        assertFalse(urlSet instanceof LruHashSet);
+        assertTrue(urlSet.getClass().getName().contains("Synchronized"));
         assertTrue(urlSet.isEmpty());
 
         // Add URLs to default set
@@ -404,6 +408,56 @@ public class CrawlerContextTest extends PlainTestCase {
         assertEquals(10000, urlSet.size());
         assertTrue(urlSet.contains("http://overflow.com/robots.txt"));
         assertFalse(urlSet.contains("http://example0.com/robots.txt")); // First one should be evicted
+    }
+
+    /**
+     * Test that concurrent robots.txt dedup checks for the SAME url only let one caller "win".
+     * <p>
+     * HTTP clients collapse the check-then-add into a single {@code getRobotsTxtUrlSet().add(url)}
+     * call (see Hc4HttpClient/Hc5HttpClient#processRobotsTxt) and rely on exactly one thread getting
+     * {@code true} back so only one thread fetches robots.txt for a given host. This exercises that
+     * contract directly, without needing an HTTP server.
+     */
+    @Test
+    public void test_robotsTxtUrlSet_concurrentAddSameUrl_onlyOneWinner() throws Exception {
+        final String url = "http://concurrent.example.com/robots.txt";
+        final int threadCount = 32;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch endLatch = new CountDownLatch(threadCount);
+        final AtomicInteger winnerCount = new AtomicInteger(0);
+        final List<Exception> exceptions = new ArrayList<>();
+
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        // Mirrors the atomic guard now used in Hc4HttpClient/Hc5HttpClient#processRobotsTxt.
+                        if (crawlerContext.getRobotsTxtUrlSet().add(url)) {
+                            winnerCount.incrementAndGet();
+                        }
+                    } catch (final Exception e) {
+                        synchronized (exceptions) {
+                            exceptions.add(e);
+                        }
+                    } finally {
+                        endLatch.countDown();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            assertTrue(endLatch.await(10, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdown();
+        }
+
+        assertTrue(exceptions.isEmpty());
+        // Exactly one thread must have observed add()==true; the rest must see the url already present.
+        assertEquals(1, winnerCount.get());
+        assertEquals(1, crawlerContext.getRobotsTxtUrlSet().size());
+        assertTrue(crawlerContext.getRobotsTxtUrlSet().contains(url));
     }
 
     /**

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc4HttpClientTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc4HttpClientTest.java
@@ -15,15 +15,24 @@
  */
 package org.codelibs.fess.crawler.client.http;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.util.Date;
 
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.message.BasicHttpResponse;
 import org.codelibs.fess.crawler.CrawlerContext;
 import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
 import org.codelibs.fess.crawler.entity.ResponseData;
 import org.codelibs.fess.crawler.exception.CrawlingAccessException;
+import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
 import org.codelibs.fess.crawler.filter.UrlFilter;
 import org.codelibs.fess.crawler.filter.impl.UrlFilterImpl;
+import org.codelibs.fess.crawler.helper.ContentLengthHelper;
 import org.codelibs.fess.crawler.helper.MemoryDataHelper;
 import org.codelibs.fess.crawler.helper.RobotsTxtHelper;
 import org.codelibs.fess.crawler.helper.impl.MimeTypeHelperImpl;
@@ -34,6 +43,8 @@ import org.dbflute.utflute.core.PlainTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+
+import com.sun.net.httpserver.HttpServer;
 
 /**
  * @author shinsuke
@@ -254,6 +265,324 @@ public class Hc4HttpClientTest extends PlainTestCase {
             assertNotNull(result);
         } catch (Exception e) {
             // May fail depending on URI handling
+        }
+    }
+
+    // Tests for max content length enforcement (precheck + bounded stream)
+
+    /**
+     * A response whose Content-Length header exceeds the max must be rejected without the body
+     * ever being read. The server declares (and later, truthfully, delivers) a small body that
+     * matches its declared Content-Length, but only after an artificial delay; a full-download
+     * implementation would block waiting for that body, while a working precheck rejects based on
+     * the Content-Length header alone and returns almost immediately.
+     */
+    @Test
+    public void test_doGet_contentLengthHeaderExceedsMax_rejectedWithoutDownloading() throws Exception {
+        final SimpleHttpServer server = new SimpleHttpServer();
+        final byte[] body = new byte[1024];
+        server.setHandler(exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try {
+                // A full-download implementation would block here waiting for the body.
+                Thread.sleep(2000);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            final ContentLengthHelper helper = new ContentLengthHelper();
+            helper.setDefaultMaxLength(64L);
+            httpClient.contentLengthHelper = helper;
+            httpClient.init();
+
+            final long start = System.currentTimeMillis();
+            try {
+                httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
+                fail();
+            } catch (final MaxLengthExceededException e) {
+                final long elapsed = System.currentTimeMillis() - start;
+                assertTrue(e.getMessage().contains("over 64 byte"));
+                // The declared Content-Length (1024) must be reported verbatim, confirming the
+                // precheck (not the bounded-stream fallback) is what rejected the response.
+                assertTrue(e.getMessage().contains("(1024 byte)"));
+                // rejection should not wait for the (slow) body
+                assertTrue(elapsed < 1000);
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    /**
+     * A response with no Content-Length header (chunked) whose body exceeds the max must be capped
+     * mid-copy and rejected, instead of being fully buffered first.
+     */
+    @Test
+    public void test_doGet_chunkedOversizeBody_cappedMidStream() throws Exception {
+        final SimpleHttpServer server = new SimpleHttpServer();
+        final byte[] body = new byte[8192];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) ('a' + (i % 26));
+        }
+        server.setHandler(exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            // responseLength == 0 forces chunked Transfer-Encoding, i.e. no Content-Length header.
+            exchange.sendResponseHeaders(200, 0);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            final ContentLengthHelper helper = new ContentLengthHelper();
+            helper.setDefaultMaxLength(64L);
+            httpClient.contentLengthHelper = helper;
+            httpClient.init();
+
+            try {
+                httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
+                fail();
+            } catch (final MaxLengthExceededException e) {
+                assertTrue(e.getMessage().contains("over 64 byte"));
+                // The reported size must be capped near the limit (maxLength+1), not the true 8192
+                // byte body -- proving the copy was aborted mid-stream rather than fully buffered.
+                assertTrue(e.getMessage().contains("(65 byte)"));
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    /**
+     * A within-limit response must be returned unchanged (same behavior as before this change).
+     */
+    @Test
+    public void test_doGet_withinLimit_unaffected() throws Exception {
+        final SimpleHttpServer server = new SimpleHttpServer();
+        final byte[] body = "Hello, crawler!".getBytes("UTF-8");
+        server.setHandler(exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            final ContentLengthHelper helper = new ContentLengthHelper();
+            helper.setDefaultMaxLength(1024L * 1024L);
+            httpClient.contentLengthHelper = helper;
+            httpClient.init();
+
+            final ResponseData responseData = httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
+            assertEquals(200, responseData.getHttpStatusCode());
+            assertEquals((long) body.length, responseData.getContentLength());
+        } finally {
+            server.stop();
+        }
+    }
+
+    /**
+     * When the configured max length is "unlimited" (Long.MAX_VALUE), a large body must not be
+     * rejected and must not be bounded.
+     */
+    @Test
+    public void test_doGet_unlimitedMaxLength_doesNotRejectLargeBody() throws Exception {
+        final SimpleHttpServer server = new SimpleHttpServer();
+        final byte[] body = new byte[256 * 1024];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) ('a' + (i % 26));
+        }
+        server.setHandler(exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            final ContentLengthHelper helper = new ContentLengthHelper();
+            helper.setDefaultMaxLength(Long.MAX_VALUE);
+            httpClient.contentLengthHelper = helper;
+            httpClient.init();
+
+            final ResponseData responseData = httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
+            assertEquals(200, responseData.getHttpStatusCode());
+            assertEquals((long) body.length, responseData.getContentLength());
+        } finally {
+            server.stop();
+        }
+    }
+
+    /**
+     * When no ContentLengthHelper is configured at all (contentLengthHelper == null, e.g. a client
+     * built without DI), a large body must likewise not be rejected.
+     */
+    @Test
+    public void test_doGet_noContentLengthHelper_doesNotRejectLargeBody() throws Exception {
+        final SimpleHttpServer server = new SimpleHttpServer();
+        final byte[] body = new byte[256 * 1024];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) ('a' + (i % 26));
+        }
+        server.setHandler(exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            httpClient.contentLengthHelper = null;
+            httpClient.init();
+
+            final ResponseData responseData = httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
+            assertEquals(200, responseData.getHttpStatusCode());
+            assertEquals((long) body.length, responseData.getContentLength());
+        } finally {
+            server.stop();
+        }
+    }
+
+    // Tests for FIX 1 (guarded Content-Length precheck parse) and FIX 2 (overall-max bound when
+    // contentType is unknown). Unlike Apache HttpClient5, HttpClient4/HttpCore4 (4.5.14/4.4.16)
+    // do NOT validate the Content-Length header at the wire-protocol level: a response with a
+    // malformed value (e.g. "not-a-number") is handed back successfully with the entity's own
+    // content length reported as -1 (unknown) and the raw header value left untouched -- so an
+    // Hc4HttpClient precheck bug here IS directly reachable from a real network response. These
+    // tests nonetheless override executeHttpClient() to avoid depending on that transport-layer
+    // leniency (which is not guaranteed across library versions), exercising the precheck/bound
+    // logic under test deterministically.
+
+    /**
+     * A response with a malformed (non-numeric) Content-Length header must not fail the URL: the
+     * declared length is treated as unknown, the precheck comparison is skipped, and a
+     * well-formed, within-limit body is still downloaded and returned normally.
+     */
+    @Test
+    public void test_doGet_malformedContentLengthHeader_withinLimitBody_succeeds() throws Exception {
+        final byte[] body = "Hello, crawler!".getBytes("UTF-8");
+        final Hc4HttpClient client = new Hc4HttpClient() {
+            @Override
+            protected HttpResponse executeHttpClient(final HttpUriRequest httpRequest) {
+                final BasicHttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 200, "OK");
+                response.setHeader("Content-Type", "text/plain; charset=UTF-8");
+                response.setHeader("Content-Length", "not-a-number");
+                response.setEntity(new ByteArrayEntity(body));
+                return response;
+            }
+        };
+        final ContentLengthHelper helper = new ContentLengthHelper();
+        helper.setDefaultMaxLength(1024L * 1024L);
+        client.contentLengthHelper = helper;
+
+        final ResponseData responseData = client.doGet("http://127.0.0.1/dummy");
+        assertEquals(200, responseData.getHttpStatusCode());
+        assertEquals((long) body.length, responseData.getContentLength());
+    }
+
+    /**
+     * A malformed Content-Length header must not itself cause a failure, but an actually oversized
+     * body must still be capped mid-copy by the BoundedInputStream and rejected by the
+     * authoritative post-copy check -- proving the malformed header only disables the precheck
+     * shortcut, not the enforcement of the limit itself.
+     */
+    @Test
+    public void test_doGet_malformedContentLengthHeader_oversizedBody_stillCappedAndRejected() throws Exception {
+        final byte[] body = new byte[8192];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) ('a' + (i % 26));
+        }
+        final Hc4HttpClient client = new Hc4HttpClient() {
+            @Override
+            protected HttpResponse executeHttpClient(final HttpUriRequest httpRequest) {
+                final BasicHttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 200, "OK");
+                response.setHeader("Content-Type", "text/plain; charset=UTF-8");
+                response.setHeader("Content-Length", "not-a-number");
+                response.setEntity(new ByteArrayEntity(body));
+                return response;
+            }
+        };
+        final ContentLengthHelper helper = new ContentLengthHelper();
+        helper.setDefaultMaxLength(64L);
+        client.contentLengthHelper = helper;
+
+        try {
+            client.doGet("http://127.0.0.1/dummy");
+            fail();
+        } catch (final MaxLengthExceededException e) {
+            assertTrue(e.getMessage().contains("over 64 byte"));
+            // Capped near the limit (maxLength+1), not the true 8192 byte body.
+            assertTrue(e.getMessage().contains("(65 byte)"));
+        }
+    }
+
+    /**
+     * When the response has no Content-Type header (so the type is unknown until the body is
+     * sniffed) and a per-type limit configured for the eventually-sniffed type is larger than the
+     * default, the precheck/bound must use the overall upper bound rather than just the default --
+     * otherwise a body sized in (default, perType] would be capped at default+1 and silently
+     * accepted as truncated once the post-copy check re-evaluates against the larger, sniffed-type
+     * limit. This asserts the body is downloaded and returned in full, unmodified.
+     */
+    @Test
+    public void test_doGet_unknownContentTypeWithLargerPerTypeLimit_notTruncated() throws Exception {
+        final StringBuilder text = new StringBuilder();
+        while (text.length() < 4096) {
+            text.append("The quick brown fox jumps over the lazy dog. ");
+        }
+        final byte[] body = text.toString().getBytes("UTF-8");
+
+        final Hc4HttpClient client = new Hc4HttpClient() {
+            @Override
+            protected HttpResponse executeHttpClient(final HttpUriRequest httpRequest) {
+                final BasicHttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 200, "OK");
+                // Deliberately no Content-Type header -- the type is only knowable after sniffing.
+                response.setEntity(new ByteArrayEntity(body));
+                return response;
+            }
+        };
+        final ContentLengthHelper helper = new ContentLengthHelper();
+        helper.setDefaultMaxLength(100L);
+        helper.addMaxLength("text/plain", 1024L * 1024L);
+        client.contentLengthHelper = helper;
+        client.mimeTypeHelper = new MimeTypeHelperImpl();
+
+        final ResponseData responseData = client.doGet("http://127.0.0.1/dummy");
+        assertEquals(200, responseData.getHttpStatusCode());
+        assertEquals("text/plain", responseData.getMimeType());
+        assertEquals((long) body.length, responseData.getContentLength());
+    }
+
+    /** Lightweight HTTP server used for max-content-length tests, mirroring ApiExtractorTest's helper. */
+    private static class SimpleHttpServer {
+        private HttpServer http;
+        private int boundPort;
+
+        void setHandler(final com.sun.net.httpserver.HttpHandler handler) throws IOException {
+            http = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            http.createContext("/", handler);
+        }
+
+        void start() {
+            http.start();
+            boundPort = http.getAddress().getPort();
+        }
+
+        void stop() {
+            http.stop(0);
+        }
+
+        int port() {
+            return boundPort;
         }
     }
 

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc4HttpClientTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc4HttpClientTest.java
@@ -271,11 +271,12 @@ public class Hc4HttpClientTest extends PlainTestCase {
     // Tests for max content length enforcement (precheck + bounded stream)
 
     /**
-     * A response whose Content-Length header exceeds the max must be rejected without the body
-     * ever being read. The server declares (and later, truthfully, delivers) a small body that
-     * matches its declared Content-Length, but only after an artificial delay; a full-download
-     * implementation would block waiting for that body, while a working precheck rejects based on
-     * the Content-Length header alone and returns almost immediately.
+     * A response whose declared Content-Length exceeds the max must be rejected by the
+     * Content-Length precheck without the body ever being read. The proof that the precheck (not the
+     * bounded-stream fallback) rejected it is the reported size: the precheck reports the declared
+     * Content-Length (1024) verbatim, whereas the fallback path would report the capped number of
+     * bytes actually read (maxLength + 1). This is a deterministic, behavioural check -- it does not
+     * rely on wall-clock timing, which is unreliable under CI load.
      */
     @Test
     public void test_doGet_contentLengthHeaderExceedsMax_rejectedWithoutDownloading() throws Exception {
@@ -284,12 +285,6 @@ public class Hc4HttpClientTest extends PlainTestCase {
         server.setHandler(exchange -> {
             exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
             exchange.sendResponseHeaders(200, body.length);
-            try {
-                // A full-download implementation would block here waiting for the body.
-                Thread.sleep(2000);
-            } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
             try (OutputStream out = exchange.getResponseBody()) {
                 out.write(body);
             }
@@ -301,18 +296,15 @@ public class Hc4HttpClientTest extends PlainTestCase {
             httpClient.contentLengthHelper = helper;
             httpClient.init();
 
-            final long start = System.currentTimeMillis();
             try {
                 httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
                 fail();
             } catch (final MaxLengthExceededException e) {
-                final long elapsed = System.currentTimeMillis() - start;
                 assertTrue(e.getMessage().contains("over 64 byte"));
                 // The declared Content-Length (1024) must be reported verbatim, confirming the
-                // precheck (not the bounded-stream fallback) is what rejected the response.
+                // precheck (not the bounded-stream fallback) is what rejected the response. The
+                // fallback would instead report the capped bytes actually read (maxLength + 1).
                 assertTrue(e.getMessage().contains("(1024 byte)"));
-                // rejection should not wait for the (slow) body
-                assertTrue(elapsed < 1000);
             }
         } finally {
             server.stop();

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc5HttpClientTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc5HttpClientTest.java
@@ -15,6 +15,9 @@
  */
 package org.codelibs.fess.crawler.client.http;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +26,10 @@ import org.apache.hc.client5.http.auth.AuthSchemeFactory;
 import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.impl.auth.BasicSchemeFactory;
 import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 import org.codelibs.fess.crawler.client.http.config.CredentialsConfig;
 import org.codelibs.fess.crawler.client.http.config.WebAuthenticationConfig;
 import org.codelibs.fess.crawler.client.http.config.WebAuthenticationConfig.AuthSchemeType;
@@ -30,8 +37,10 @@ import org.codelibs.fess.crawler.CrawlerContext;
 import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
 import org.codelibs.fess.crawler.entity.ResponseData;
 import org.codelibs.fess.crawler.exception.CrawlingAccessException;
+import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
 import org.codelibs.fess.crawler.filter.UrlFilter;
 import org.codelibs.fess.crawler.filter.impl.UrlFilterImpl;
+import org.codelibs.fess.crawler.helper.ContentLengthHelper;
 import org.codelibs.fess.crawler.helper.MemoryDataHelper;
 import org.codelibs.fess.crawler.helper.RobotsTxtHelper;
 import org.codelibs.fess.crawler.helper.impl.MimeTypeHelperImpl;
@@ -42,6 +51,8 @@ import org.dbflute.utflute.core.PlainTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+
+import com.sun.net.httpserver.HttpServer;
 
 /**
  * @author shinsuke
@@ -611,6 +622,324 @@ public class Hc5HttpClientTest extends PlainTestCase {
             assertNotNull(result);
         } catch (Exception e) {
             // May fail depending on URI handling
+        }
+    }
+
+    // Tests for max content length enforcement (precheck + bounded stream)
+
+    /**
+     * A response whose Content-Length header exceeds the max must be rejected without the body
+     * ever being read. The server declares (and later, truthfully, delivers) a small body that
+     * matches its declared Content-Length, but only after an artificial delay; a full-download
+     * implementation would block waiting for that body, while a working precheck rejects based on
+     * the Content-Length header alone and returns almost immediately.
+     */
+    @Test
+    public void test_doGet_contentLengthHeaderExceedsMax_rejectedWithoutDownloading() throws Exception {
+        final SimpleHttpServer server = new SimpleHttpServer();
+        final byte[] body = new byte[1024];
+        server.setHandler(exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try {
+                // A full-download implementation would block here waiting for the body.
+                Thread.sleep(2000);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            final ContentLengthHelper helper = new ContentLengthHelper();
+            helper.setDefaultMaxLength(64L);
+            httpClient.contentLengthHelper = helper;
+            httpClient.init();
+
+            final long start = System.currentTimeMillis();
+            try {
+                httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
+                fail();
+            } catch (final MaxLengthExceededException e) {
+                final long elapsed = System.currentTimeMillis() - start;
+                assertTrue(e.getMessage().contains("over 64 byte"));
+                // The declared Content-Length (1024) must be reported verbatim, confirming the
+                // precheck (not the bounded-stream fallback) is what rejected the response.
+                assertTrue(e.getMessage().contains("(1024 byte)"));
+                // rejection should not wait for the (slow) body
+                assertTrue(elapsed < 1000);
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    /**
+     * A response with no Content-Length header (chunked) whose body exceeds the max must be capped
+     * mid-copy and rejected, instead of being fully buffered first.
+     */
+    @Test
+    public void test_doGet_chunkedOversizeBody_cappedMidStream() throws Exception {
+        final SimpleHttpServer server = new SimpleHttpServer();
+        final byte[] body = new byte[8192];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) ('a' + (i % 26));
+        }
+        server.setHandler(exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            // responseLength == 0 forces chunked Transfer-Encoding, i.e. no Content-Length header.
+            exchange.sendResponseHeaders(200, 0);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            final ContentLengthHelper helper = new ContentLengthHelper();
+            helper.setDefaultMaxLength(64L);
+            httpClient.contentLengthHelper = helper;
+            httpClient.init();
+
+            try {
+                httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
+                fail();
+            } catch (final MaxLengthExceededException e) {
+                assertTrue(e.getMessage().contains("over 64 byte"));
+                // The reported size must be capped near the limit (maxLength+1), not the true 8192
+                // byte body -- proving the copy was aborted mid-stream rather than fully buffered.
+                assertTrue(e.getMessage().contains("(65 byte)"));
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    /**
+     * A within-limit response must be returned unchanged (same behavior as before this change).
+     */
+    @Test
+    public void test_doGet_withinLimit_unaffected() throws Exception {
+        final SimpleHttpServer server = new SimpleHttpServer();
+        final byte[] body = "Hello, crawler!".getBytes("UTF-8");
+        server.setHandler(exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            final ContentLengthHelper helper = new ContentLengthHelper();
+            helper.setDefaultMaxLength(1024L * 1024L);
+            httpClient.contentLengthHelper = helper;
+            httpClient.init();
+
+            final ResponseData responseData = httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
+            assertEquals(200, responseData.getHttpStatusCode());
+            assertEquals((long) body.length, responseData.getContentLength());
+        } finally {
+            server.stop();
+        }
+    }
+
+    /**
+     * When the configured max length is "unlimited" (Long.MAX_VALUE), a large body must not be
+     * rejected and must not be bounded.
+     */
+    @Test
+    public void test_doGet_unlimitedMaxLength_doesNotRejectLargeBody() throws Exception {
+        final SimpleHttpServer server = new SimpleHttpServer();
+        final byte[] body = new byte[256 * 1024];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) ('a' + (i % 26));
+        }
+        server.setHandler(exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            final ContentLengthHelper helper = new ContentLengthHelper();
+            helper.setDefaultMaxLength(Long.MAX_VALUE);
+            httpClient.contentLengthHelper = helper;
+            httpClient.init();
+
+            final ResponseData responseData = httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
+            assertEquals(200, responseData.getHttpStatusCode());
+            assertEquals((long) body.length, responseData.getContentLength());
+        } finally {
+            server.stop();
+        }
+    }
+
+    /**
+     * When no ContentLengthHelper is configured at all (contentLengthHelper == null, e.g. a client
+     * built without DI), a large body must likewise not be rejected.
+     */
+    @Test
+    public void test_doGet_noContentLengthHelper_doesNotRejectLargeBody() throws Exception {
+        final SimpleHttpServer server = new SimpleHttpServer();
+        final byte[] body = new byte[256 * 1024];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) ('a' + (i % 26));
+        }
+        server.setHandler(exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            httpClient.contentLengthHelper = null;
+            httpClient.init();
+
+            final ResponseData responseData = httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
+            assertEquals(200, responseData.getHttpStatusCode());
+            assertEquals((long) body.length, responseData.getContentLength());
+        } finally {
+            server.stop();
+        }
+    }
+
+    // Tests for FIX 1 (guarded Content-Length precheck parse) and FIX 2 (overall-max bound when
+    // contentType is unknown). Apache HttpClient5 itself validates the Content-Length header at
+    // the wire-protocol level and refuses to hand back a usable response for a malformed value
+    // (confirmed against httpclient5/httpcore5 5.4-5.6.1: DefaultContentLengthStrategy throws
+    // ProtocolException before executeHttpClient() ever returns), so a real network response
+    // carrying a malformed header can never reach doHttpMethod()'s precheck code in practice.
+    // These tests therefore override executeHttpClient() to hand back a fabricated response
+    // directly, which exercises the precheck/bound logic under test deterministically and
+    // independently of transport-layer strictness.
+
+    /**
+     * A response with a malformed (non-numeric) Content-Length header must not fail the URL: the
+     * declared length is treated as unknown, the precheck comparison is skipped, and a
+     * well-formed, within-limit body is still downloaded and returned normally.
+     */
+    @Test
+    public void test_doGet_malformedContentLengthHeader_withinLimitBody_succeeds() throws Exception {
+        final byte[] body = "Hello, crawler!".getBytes("UTF-8");
+        final Hc5HttpClient client = new Hc5HttpClient() {
+            @Override
+            protected ClassicHttpResponse executeHttpClient(final ClassicHttpRequest httpRequest) {
+                final BasicClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK");
+                response.setHeader("Content-Type", "text/plain; charset=UTF-8");
+                response.setHeader("Content-Length", "not-a-number");
+                response.setEntity(new ByteArrayEntity(body, ContentType.TEXT_PLAIN));
+                return response;
+            }
+        };
+        final ContentLengthHelper helper = new ContentLengthHelper();
+        helper.setDefaultMaxLength(1024L * 1024L);
+        client.contentLengthHelper = helper;
+
+        final ResponseData responseData = client.doGet("http://127.0.0.1/dummy");
+        assertEquals(200, responseData.getHttpStatusCode());
+        assertEquals((long) body.length, responseData.getContentLength());
+    }
+
+    /**
+     * A malformed Content-Length header must not itself cause a failure, but an actually oversized
+     * body must still be capped mid-copy by the BoundedInputStream and rejected by the
+     * authoritative post-copy check -- proving the malformed header only disables the precheck
+     * shortcut, not the enforcement of the limit itself.
+     */
+    @Test
+    public void test_doGet_malformedContentLengthHeader_oversizedBody_stillCappedAndRejected() throws Exception {
+        final byte[] body = new byte[8192];
+        for (int i = 0; i < body.length; i++) {
+            body[i] = (byte) ('a' + (i % 26));
+        }
+        final Hc5HttpClient client = new Hc5HttpClient() {
+            @Override
+            protected ClassicHttpResponse executeHttpClient(final ClassicHttpRequest httpRequest) {
+                final BasicClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK");
+                response.setHeader("Content-Type", "text/plain; charset=UTF-8");
+                response.setHeader("Content-Length", "not-a-number");
+                response.setEntity(new ByteArrayEntity(body, ContentType.TEXT_PLAIN));
+                return response;
+            }
+        };
+        final ContentLengthHelper helper = new ContentLengthHelper();
+        helper.setDefaultMaxLength(64L);
+        client.contentLengthHelper = helper;
+
+        try {
+            client.doGet("http://127.0.0.1/dummy");
+            fail();
+        } catch (final MaxLengthExceededException e) {
+            assertTrue(e.getMessage().contains("over 64 byte"));
+            // Capped near the limit (maxLength+1), not the true 8192 byte body.
+            assertTrue(e.getMessage().contains("(65 byte)"));
+        }
+    }
+
+    /**
+     * When the response has no Content-Type header (so the type is unknown until the body is
+     * sniffed) and a per-type limit configured for the eventually-sniffed type is larger than the
+     * default, the precheck/bound must use the overall upper bound rather than just the default --
+     * otherwise a body sized in (default, perType] would be capped at default+1 and silently
+     * accepted as truncated once the post-copy check re-evaluates against the larger, sniffed-type
+     * limit. This asserts the body is downloaded and returned in full, unmodified.
+     */
+    @Test
+    public void test_doGet_unknownContentTypeWithLargerPerTypeLimit_notTruncated() throws Exception {
+        final StringBuilder text = new StringBuilder();
+        while (text.length() < 4096) {
+            text.append("The quick brown fox jumps over the lazy dog. ");
+        }
+        final byte[] body = text.toString().getBytes("UTF-8");
+
+        final Hc5HttpClient client = new Hc5HttpClient() {
+            @Override
+            protected ClassicHttpResponse executeHttpClient(final ClassicHttpRequest httpRequest) {
+                final BasicClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK");
+                // Deliberately no Content-Type header -- the type is only knowable after sniffing.
+                response.setEntity(new ByteArrayEntity(body, ContentType.DEFAULT_BINARY));
+                return response;
+            }
+        };
+        final ContentLengthHelper helper = new ContentLengthHelper();
+        helper.setDefaultMaxLength(100L);
+        helper.addMaxLength("text/plain", 1024L * 1024L);
+        client.contentLengthHelper = helper;
+        client.mimeTypeHelper = new MimeTypeHelperImpl();
+
+        final ResponseData responseData = client.doGet("http://127.0.0.1/dummy");
+        assertEquals(200, responseData.getHttpStatusCode());
+        assertEquals("text/plain", responseData.getMimeType());
+        assertEquals((long) body.length, responseData.getContentLength());
+    }
+
+    /** Lightweight HTTP server used for max-content-length tests, mirroring ApiExtractorTest's helper. */
+    private static class SimpleHttpServer {
+        private HttpServer http;
+        private int boundPort;
+
+        void setHandler(final com.sun.net.httpserver.HttpHandler handler) throws IOException {
+            http = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            http.createContext("/", handler);
+        }
+
+        void start() {
+            http.start();
+            boundPort = http.getAddress().getPort();
+        }
+
+        void stop() {
+            http.stop(0);
+        }
+
+        int port() {
+            return boundPort;
         }
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc5HttpClientTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc5HttpClientTest.java
@@ -628,11 +628,12 @@ public class Hc5HttpClientTest extends PlainTestCase {
     // Tests for max content length enforcement (precheck + bounded stream)
 
     /**
-     * A response whose Content-Length header exceeds the max must be rejected without the body
-     * ever being read. The server declares (and later, truthfully, delivers) a small body that
-     * matches its declared Content-Length, but only after an artificial delay; a full-download
-     * implementation would block waiting for that body, while a working precheck rejects based on
-     * the Content-Length header alone and returns almost immediately.
+     * A response whose declared Content-Length exceeds the max must be rejected by the
+     * Content-Length precheck without the body ever being read. The proof that the precheck (not the
+     * bounded-stream fallback) rejected it is the reported size: the precheck reports the declared
+     * Content-Length (1024) verbatim, whereas the fallback path would report the capped number of
+     * bytes actually read (maxLength + 1). This is a deterministic, behavioural check -- it does not
+     * rely on wall-clock timing, which is unreliable under CI load.
      */
     @Test
     public void test_doGet_contentLengthHeaderExceedsMax_rejectedWithoutDownloading() throws Exception {
@@ -641,12 +642,6 @@ public class Hc5HttpClientTest extends PlainTestCase {
         server.setHandler(exchange -> {
             exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
             exchange.sendResponseHeaders(200, body.length);
-            try {
-                // A full-download implementation would block here waiting for the body.
-                Thread.sleep(2000);
-            } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
             try (OutputStream out = exchange.getResponseBody()) {
                 out.write(body);
             }
@@ -658,18 +653,15 @@ public class Hc5HttpClientTest extends PlainTestCase {
             httpClient.contentLengthHelper = helper;
             httpClient.init();
 
-            final long start = System.currentTimeMillis();
             try {
                 httpClient.doGet("http://127.0.0.1:" + server.port() + "/");
                 fail();
             } catch (final MaxLengthExceededException e) {
-                final long elapsed = System.currentTimeMillis() - start;
                 assertTrue(e.getMessage().contains("over 64 byte"));
                 // The declared Content-Length (1024) must be reported verbatim, confirming the
-                // precheck (not the bounded-stream fallback) is what rejected the response.
+                // precheck (not the bounded-stream fallback) is what rejected the response. The
+                // fallback would instead report the capped bytes actually read (maxLength + 1).
                 assertTrue(e.getMessage().contains("(1024 byte)"));
-                // rejection should not wait for the (slow) body
-                assertTrue(elapsed < 1000);
             }
         } finally {
             server.stop();

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/helper/ContentLengthHelperTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/helper/ContentLengthHelperTest.java
@@ -163,4 +163,36 @@ public class ContentLengthHelperTest extends PlainTestCase {
         assertNotNull(helper);
         assertEquals(DEFAULT_MAX_LENGTH, helper.getDefaultMaxLength());
     }
+
+    @Test
+    public void test_getMaxLength_noArg_noOverrides_returnsDefault() {
+        assertEquals(DEFAULT_MAX_LENGTH, contentLengthHelper.getMaxLength());
+    }
+
+    @Test
+    public void test_getMaxLength_noArg_perTypeLimitLargerThanDefault_returnsPerTypeLimit() {
+        final long largerThanDefault = DEFAULT_MAX_LENGTH * 2;
+        contentLengthHelper.addMaxLength("text/html", largerThanDefault);
+
+        assertEquals(largerThanDefault, contentLengthHelper.getMaxLength());
+        // getMaxLength(String) for the specific type is unaffected.
+        assertEquals(largerThanDefault, contentLengthHelper.getMaxLength("text/html"));
+    }
+
+    @Test
+    public void test_getMaxLength_noArg_perTypeLimitsSmallerThanDefault_returnsDefault() {
+        contentLengthHelper.addMaxLength("text/html", 1000L);
+        contentLengthHelper.addMaxLength("text/plain", 2000L);
+
+        assertEquals(DEFAULT_MAX_LENGTH, contentLengthHelper.getMaxLength());
+    }
+
+    @Test
+    public void test_getMaxLength_noArg_mixedLimits_returnsOverallMaximum() {
+        contentLengthHelper.addMaxLength("text/html", 1000L);
+        contentLengthHelper.addMaxLength("application/pdf", DEFAULT_MAX_LENGTH * 3);
+        contentLengthHelper.addMaxLength("image/jpeg", DEFAULT_MAX_LENGTH * 2);
+
+        assertEquals(DEFAULT_MAX_LENGTH * 3, contentLengthHelper.getMaxLength());
+    }
 }


### PR DESCRIPTION
## Summary

Both HTTP clients (`Hc4HttpClient`, `Hc5HttpClient`) previously copied the **entire** response body into memory / a temp file and only **then** compared it against the configured max content length — so an oversized or hostile response was fully downloaded and spilled to disk before being discarded. This enforces the limit *before* / *during* the download while preserving the exact accept/reject outcome, and fixes a concurrency issue in the robots.txt dedup.

## Changes

**Max content length (efficiency / DoS mitigation)**
- **Content-Length precheck**: when the response declares a `Content-Length` that exceeds the effective max, reject with `MaxLengthExceededException` without opening the body — mirroring the existing robots.txt precheck.
- **Bounded stream**: wrap the entity stream in a commons-io `BoundedInputStream` capped at `maxLength + 1`, so a chunked / unknown-length oversized body is aborted mid-copy instead of fully buffered. The existing **post-copy** `contentLength > maxLength` check is unchanged and remains the authoritative gate, so the accept/reject boundary is provably identical to the old full-download behavior (a body of exactly `maxLength` is accepted; `maxLength + 1` or larger is rejected).
- **No limit** (no `ContentLengthHelper`, or `Long.MAX_VALUE`): the stream is used unwrapped and nothing is prechecked/capped.
- **Robustness**: a malformed/hostile `Content-Length` header is treated as unknown (guarded parse) rather than failing the URL. When the `Content-Type` is not yet known (header absent), the precheck/bound use the **overall maximum** configured limit (`ContentLengthHelper.getMaxLength()`) rather than just the default, so the optimization can never truncate a body that the authoritative per-type check (run after sniffing) would accept. Under Fess's default config (default 10 MB, only `text/html`=2.5 MB ≤ default) this is a no-op.

**robots.txt dedup (thread-safety)**
- `CrawlerContext.robotsTxtUrlSet` is now `Collections.synchronizedSet(new LruHashSet<>(10000))` (LRU bound/eviction unchanged), and the clients' non-atomic `contains()`-then-`add()` is collapsed into a single atomic `add()` (`LruHashSet.add` returns `true` only when newly added). This removes a race where two threads could both fetch the same host's robots.txt and could concurrently modify the backing map.

## Testing

- Precheck rejects an over-declared `Content-Length` without awaiting the body; a chunked oversized body is capped mid-stream; within-limit and unlimited/no-helper cases are unaffected.
- Malformed `Content-Length` header no longer fails the URL (within-limit body succeeds; oversized body is still capped/rejected by the bound + post-copy check).
- Unknown `Content-Type` with a per-type limit larger than the default is not truncated-and-accepted.
- `ContentLengthHelper.getMaxLength()` returns the overall maximum; concurrent robots.txt `add()` yields a single winner.
- Full `fess-crawler` module suite passes (a pre-existing 1 ms-timeout race test is intermittently flaky under parallel load and never touches the modified code); `mvn formatter:format` / `license:format` / `javadoc:jar` clean.
