### PR TITLE
docs: refresh README.md and CLAUDE.md against current source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,31 +4,35 @@ Quick reference for AI assistants working on the Fess Crawler project.
 
 ## Project Overview
 
-**Fess Crawler** is a Java-based web crawling framework for enterprise content extraction.
+**Fess Crawler** is a Java-based web crawling framework for enterprise content extraction. It is the
+crawling engine behind [Fess](https://github.com/codelibs/fess) and is also usable standalone.
 
 ### Essential Info
 
-- **Language**: Java 21+
-- **Build**: Maven 3.x
+- **Language**: Java 21 (`<release>21</release>`)
+- **Build**: Maven, parent POM is `org.codelibs.fess:fess-parent` (branch `main`)
 - **License**: Apache 2.0
-- **DI**: LastaFlute DI
+- **DI**: Lasta DI (`fess-crawler-lasta`) or the standalone `StandardCrawlerContainer`
 - **Repo**: https://github.com/codelibs/fess-crawler
+- **Default branch**: `master`
 
 ### Tech Stack
 
-- **HTTP**: Apache HttpComponents 4.5+ and 5.x (switchable)
-- **Extraction**: Apache Tika, POI, PDFBox
-- **Testing**: JUnit 4, UTFlute, Mockito, Testcontainers
-- **Storage**: In-memory (default), OpenSearch (optional)
-- **Cloud**: AWS SDK v2 (S3), Google Cloud Storage
+- **HTTP**: Apache HttpComponents 5.x (default) and 4.5.x (fallback), switchable at runtime
+- **Extraction**: Apache Tika, POI, PDFBox, commonmark, commons-csv, jlha, jhighlight, JODConverter
+- **Testing**: **JUnit 5 (Jupiter)**, UTFlute, Mockito, Testcontainers
+- **Storage**: In-memory (default), OpenSearch (optional, via fesen-httpclient)
+- **Cloud**: AWS SDK v2 (S3), Google Cloud Storage, MinIO
 
 ### Protocols
 
-HTTP/HTTPS, File, FTP/FTPS, SMB/CIFS (SMB1/SMB2+), Storage (MinIO via `storage://`), S3 (`s3://`), GCS (`gcs://`)
+HTTP/HTTPS, File, FTP/FTPS, SMB/CIFS (SMB2+ via SMBJ, SMB1 via JCIFS), Storage (MinIO,
+`storage://`), S3 (`s3://`), GCS (`gcs://`)
 
 ### Content Formats
 
-Office (Word, Excel, PowerPoint), PDF, Archives (ZIP, TAR, GZ, LHA), HTML, XML, JSON, Markdown, Media metadata, Images (EXIF/IPTC/XMP), Email (EML)
+Office (Word, Excel, PowerPoint, Publisher, Visio), PDF, PostScript, Archives (ZIP, TAR, LHA), HTML,
+XML, JSON, CSV, Markdown, Email (EML), Media metadata, Images (EXIF/IPTC/XMP)
 
 ---
 
@@ -39,7 +43,7 @@ Office (Word, Excel, PowerPoint), PDF, Archives (ZIP, TAR, GZ, LHA), HTML, XML, 
 ```
 fess-crawler-parent/
 ├── fess-crawler/              # Core framework
-├── fess-crawler-lasta/        # LastaFlute DI integration
+├── fess-crawler-lasta/        # Lasta DI integration + shipped crawler.xml wiring
 └── fess-crawler-opensearch/   # OpenSearch backend
 ```
 
@@ -49,7 +53,7 @@ fess-crawler-parent/
 - **Strategy**: `CrawlerClient`, `Extractor`, `Transformer` - pluggable implementations
 - **Builder**: `RequestDataBuilder`, `ExtractorBuilder` - fluent construction
 - **Template Method**: `AbstractCrawlerClient`, `AbstractExtractor` - common logic with overrides
-- **DI**: LastaFlute container with `@Resource` and XML config
+- **DI**: Lasta DI container with `@Resource` and XML config
 
 ### Core Principles
 
@@ -59,52 +63,85 @@ fess-crawler-parent/
 
 **Fault Tolerance**: `FaultTolerantClient` wrapper (retry, circuit breaker), `SwitchableHttpClient` for HTTP client fallback
 
+**Bounded Processing**: content-length caps enforced *during* download (not after), archive-bomb / Zip
+Slip / recursion-depth defenses in the archive and EML extractors, output caps on `CommandExtractor`
+
 ---
 
 ## Key Components
 
 ### Core Classes
 
-- **Crawler** (`Crawler.java`): Main orchestrator - `execute()`, `addUrl()`, `cleanup()`, `stop()`
+- **Crawler** (`Crawler.java`): Main orchestrator - `execute()`, `addUrl()`, `cleanup()`, `stop()`, `close()`. Implements `Runnable, AutoCloseable`
 - **CrawlerContext** (`CrawlerContext.java`): Execution context - `sessionId`, `status`, `accessCount`, `numOfThread`, `maxDepth`, `maxAccessCount`
 - **CrawlerThread** (`CrawlerThread.java`): Worker thread - Poll URL → Validate → Execute → Process → Queue children
+- **CrawlerStatus** (`CrawlerStatus.java`): `INITIALIZING`, `RUNNING`, `DONE`
+
+> **Public-API trap**: `Crawler.crawlerContext` and `Crawler.urlFilter` are **`protected`**, not
+> public. In-repo tests reach them only because they sit in the same package. External code must use
+> `getCrawlerContext()` / `getUrlFilter()`, or the delegating setters `setNumOfThread(int)`,
+> `setMaxDepth(int)`, `setMaxAccessCount(long)`, `setMaxThreadCheckCount(int)`,
+> `addIncludeFilter(String)`, `addExcludeFilter(String)`. Do not write docs or examples that touch
+> the fields directly.
 
 ### HTTP Client Architecture
 
 ```
-SwitchableHttpClient (extends FaultTolerantClient)
-    ├── Hc5HttpClient (default) - Apache HttpComponents 5.x
-    └── Hc4HttpClient (fallback) - Apache HttpComponents 4.x
+SwitchableHttpClient extends FaultTolerantClient implements CrawlerClient
+    └── delegates (not inherits) to one of:
+            ├── Hc5HttpClient (default) - Apache HttpComponents 5.x
+            └── Hc4HttpClient (fallback) - Apache HttpComponents 4.x
 
-HcHttpClient (abstract base class)
-    ├── Hc4HttpClient
-    └── Hc5HttpClient
+AbstractCrawlerClient
+    └── HcHttpClient (abstract; constants only, no setters, no instances)
+            ├── Hc4HttpClient
+            └── Hc5HttpClient
 ```
 
-Switch via system property: `-Dfess.crawler.http.client=hc4` or `hc5` (default)
+Switch via system property `fess.crawler.http.client` (`SwitchableHttpClient.HTTP_CLIENT_PROPERTY`):
+`-Dfess.crawler.http.client=hc4` selects HC4; **any other value, including unset, selects HC5**. It
+is read once in the constructor, so it cannot change per request.
 
-**Key Properties**: `connectionTimeout`, `soTimeout`, `proxyHost`, `proxyPort`, `userAgent`, `robotsTxtEnabled`, `ignoreSslCertificate`, `maxTotalConnection`, `defaultMaxConnectionPerRoute`
+**Key setters** (on the concrete classes — the names differ from the obvious guesses):
+`setConnectionTimeout`, `setSoTimeout` (*not* `setSocketTimeout`), `setMaxTotalConnections` (*not*
+`setMaxConnections`; init-param key is the singular `maxTotalConnection`), `setMaxConnectionsPerRoute`,
+`setUserAgent`, `setProxyHost`/`setProxyPort`, `setIgnoreSslCertificate` (*not*
+`setTrustAllCertificates`), `setRedirectsEnabled`, `setUseRobotsTxtAllows`/`setUseRobotsTxtDisallows`.
+
+Generic knobs inherited from `AbstractCrawlerClient`: `accessTimeout`, `maxContentLength`,
+`maxCachedContentSize`. All settable via `setInitParameterMap(Map<String, Object>)`.
 
 ### CrawlerClientFactory
 
 Pattern-based client selection (from `crawler/client.xml`):
-- `http:.*`, `https:.*` → SwitchableHttpClient
-- `file:.*` → FileSystemClient
-- `smb:.*` → SmbClient (SMB2+), `smb1:.*` → SmbClient (SMB1)
-- `ftp:.*`, `ftps:.*` → FtpClient
-- `storage:.*` → StorageClient, `s3:.*` → S3Client, `gcs:.*` → GcsClient
+- `http:.*`, `https:.*` → `SwitchableHttpClient`
+- `file:.*` → `FileSystemClient`
+- `smb:.*` → `smb.SmbClient` (SMB2+), `smb1:.*` → `smb1.SmbClient` (SMB1)
+- `ftp:.*`, `ftps:.*` → `FtpClient` (one shared component)
+- `storage:.*` → `StorageClient`, `s3:.*` → `S3Client`, `gcs:.*` → `GcsClient`
 
 ### Cloud Storage Clients
 
-- **S3Client**: AWS SDK v2, `s3://bucket/path`, properties: `endpoint`, `accessKey`, `secretKey`, `region`
-- **GcsClient**: Google Cloud SDK, `gcs://bucket/path`, properties: `projectId`, `credentialsFile`, `endpoint`
+- **S3Client**: AWS SDK v2, `s3://bucket/path`, init params: `accessKey`, `secretKey`, `endpoint`,
+  `region` (default `us-east-1`), `crossRegionAccessEnabled` (default `true`). Blank
+  accessKey/secretKey → falls back to the AWS **default credentials provider chain** (IAM role,
+  instance profile, IRSA, env vars, shared profile)
+- **GcsClient**: Google Cloud SDK, `gcs://bucket/path`, init params: `projectId`, `credentialsFile`,
+  `endpoint`. No `credentialsFile` → Application Default Credentials
 - **StorageClient**: MinIO SDK, `storage://bucket/path`
 
 ### Services
 
 - **UrlQueueService**: URL queue management (FIFO), duplicate detection
-- **DataService**: Access result persistence, iteration
-- Implementations: `UrlQueueServiceImpl`, `DataServiceImpl` (in-memory), `OpenSearchDataService` (persistent)
+- **DataService**: Access result persistence, iteration. Generic: `DataService<RESULT extends AccessResult<?>>`
+- **UrlFilterService**: include/exclude pattern persistence
+- Implementations: `UrlQueueServiceImpl`, `DataServiceImpl`, `UrlFilterServiceImpl` (in-memory,
+  all backed by `MemoryDataHelper`); `OpenSearchDataService`, `OpenSearchUrlQueueService`,
+  `OpenSearchUrlFilterService` (persistent)
+
+`AccessResult` carries `getUrl()`, `getHttpStatusCode()`, `getMimeType()`, `getContentLength()`.
+Extracted content is **not** on `AccessResult` — it lives on
+`getAccessResultData().getDataAsString()`.
 
 ### Processing Pipeline
 
@@ -117,21 +154,50 @@ CrawlerThread → Client → ResponseProcessor → Transformer → Extractor →
 
 - **Rule**: Pattern-based response routing (`RegexRule`, `SitemapsRule`)
 - **ResponseProcessor**: `DefaultResponseProcessor`, `SitemapsResponseProcessor`, `NullResponseProcessor`
-- **Transformer**: `HtmlTransformer`, `XmlTransformer`, `FileTransformer`, etc.
-- **Extractor**: Weight-based selection (tries in descending weight order)
+- **Transformer**: `HtmlTransformer`, `XmlTransformer`, `FileTransformer`, `BinaryTransformer`, `TextTransformer`
+- **Extractor**: Weight-based selection — on a MIME-type collision, `ExtractorFactory` returns a
+  composite that tries each extractor in descending `getWeight()` order (default weight `1`)
 
-### Key Extractors
+### Extractors
 
-`TikaExtractor`, `PdfExtractor`, `MsWordExtractor`, `MsExcelExtractor`, `MsPowerPointExtractor`, `ZipExtractor`, `HtmlExtractor`, `MarkdownExtractor`, `EmlExtractor`
+Present in `extractor/impl/`: `ApiExtractor`, `CommandExtractor`, `CsvExtractor`, `EmlExtractor`,
+`FilenameExtractor`, `HtmlExtractor`, `HtmlXpathExtractor`, `JodExtractor`, `JsonExtractor`,
+`LhaExtractor`, `MarkdownExtractor`, `MsExcelExtractor`, `MsPowerPointExtractor`,
+`MsPublisherExtractor`, `MsVisioExtractor`, `MsWordExtractor`, `PdfExtractor`, `PsExtractor`,
+`TarExtractor`, `TextExtractor`, `TikaExtractor`, `XmlExtractor`, `ZipExtractor`.
+Bases: `AbstractExtractor`, `AbstractXmlExtractor`, `PasswordBasedExtractor`.
+
+**Not registered in the default DI** — must be wired manually: `ZipExtractor`, `TarExtractor`,
+`ApiExtractor`, `CommandExtractor`.
+
+`crawler/extractor.xml` declares 19 components but `extractorFactory` maps only 10 by MIME type
+(xml, html, pdf, lha, eml, tika catch-all, json, csv, markdown, ps); the rest are name-addressable
+only and are wired by Fess itself.
+
+**`HtmlExtractor`**: `extractDefaultMetadata` defaults to **true** (title, description, OpenGraph,
+Twitter Card); `extractJsonLd` defaults to **false** and is bounded in nesting depth, size and count.
+
+**DI trap**: redeclaring `extractorFactory` in an outer DI file that `<include>`s `crawler.xml`
+**replaces** it and silently drops every default MIME mapping. Append instead:
+`container.getComponent("extractorFactory").addExtractor(mimeType, extractor)` after init.
 
 ### Helpers
 
 - **RobotsTxtHelper**: RFC 9309 parsing, user-agent matching, crawl-delay, sitemaps
 - **SitemapsHelper**: Sitemap XML parsing, index handling
-- **MimeTypeHelper**: MIME detection via Tika
+- **MimeTypeHelper** / `MimeTypeHelperImpl`: MIME detection via Tika, extension-based overrides
 - **EncodingHelper**: Charset detection with BOM
 - **UrlConvertHelper**: URL normalization
-- **ContentLengthHelper**: Content length limits per MIME type
+- **ContentLengthHelper**: `defaultMaxLength` (10 MB) + per-MIME-type `addMaxLength()`. Owns *all*
+  content-size limits — transformers have no `setMaxContentSize`
+- **LogHelper** / `LogHelperImpl`: crawl event logging
+- **MemoryDataHelper**: in-memory store backing the three `*ServiceImpl` classes
+
+### Interval Control
+
+`DefaultIntervalController` has exactly four `long` millisecond knobs — there is **no**
+`setDefaultIntervalTime`: `delayMillisBeforeProcessing`, `delayMillisAfterProcessing`,
+`delayMillisAtNoUrlInQueue`, `delayMillisForWaitingNewUrl`.
 
 ---
 
@@ -143,29 +209,52 @@ CrawlerThread → Client → ResponseProcessor → Transformer → Extractor →
 mvn clean install              # Build all
 mvn clean install -DskipTests  # Skip tests
 mvn test                       # Run tests
+mvn package                    # What CI runs - includes the javadoc + license gates
 mvn formatter:format           # Format code
 mvn license:format             # Update license headers
+mvn javadoc:jar                # Verify the javadoc gate on its own
 ```
+
+`fess-parent` (branch `main`) must be installed locally when building an unreleased version.
+
+### CI
+
+`.github/workflows/maven.yml`, on push/PR to `master` and `*.x`:
+single **JDK 21** (Temurin), installs `fess-parent`, then `mvn -B package`.
+
+**`mvn test` is not enough.** `package` additionally runs `license:check`, `formatter:format`,
+`jacoco:report`, `source:jar-no-fork` and **`javadoc:jar`**. Javadoc errors — e.g. dropping an import
+while a `{@link Type}` still references it — fail CI while `mvn test` stays green. Always run
+`mvn package` (or at least `mvn javadoc:jar`) before pushing.
 
 ### Code Style
 
-- 4 spaces (no tabs), opening brace on same line, max line length 120
-- JavaDoc required for public APIs
-- License headers required (Apache 2.0)
+- 4 spaces (no tabs), opening brace on same line, **max line length 140**
+- Config is remote, from `fess-parent`: `https://www.codelibs.org/assets/formatter/eclipse-formatter-1.1.xml`
+  (`lineSplit=140`, `comment.line_length=80`). Do not add a local formatter file
+- JavaDoc required for public APIs (enforced by the CI javadoc gate)
+- Apache 2.0 license headers required (`license:check` fails the build without them)
 
 ### Testing
 
-- **Structure**: `src/test/java/org/codelibs/fess/crawler/`
-- **Base class**: Extend `PlainTestCase` from UTFlute
-- **Test Resources**: `src/test/resources/`
-- **Coverage Goal**: >80% line coverage
+- **Framework**: JUnit 5 (Jupiter). There is no `junit:junit` dependency — never add `org.junit.Test`
+- **Base class**: `PlainTestCase` (UTFlute) for core; `LastaDiTestCase` for the DI/OpenSearch modules
+- **Setup hook**: `protected void setUp(final TestInfo testInfo)`, not JUnit 4's `setUp()`
+- **Structure**: `src/test/java/org/codelibs/fess/crawler/`, resources in `src/test/resources/`
+- **Parallel**: surefire runs test **classes** in parallel (`threadCount=4`, `forkCount=1C`) — tests
+  must not share mutable static state
+- `JodExtractorTest` is excluded from the default run (needs local LibreOffice)
+- Testcontainers tests need Docker: `S3ClientTest`, `StorageClientTest`, `GcsClientTest`,
+  `smb/SmbClientTest`, `smb1/SmbClientTest`
+- **Coverage**: JaCoCo reports during `package`, but **no threshold is enforced** — >80% is a goal,
+  not a gate
 
 ### Contributing
 
-1. Fork repo, create feature branch
+1. Fork repo, create feature branch off `master`
 2. Make focused commits with tests
 3. Format code (`mvn formatter:format && mvn license:format`)
-4. Run tests (`mvn test`)
+4. Run `mvn package` (not just `mvn test`)
 5. Open Pull Request
 
 ---
@@ -175,37 +264,66 @@ mvn license:format             # Update license headers
 ### Key File Locations
 
 **Core**: `fess-crawler/src/main/java/org/codelibs/fess/crawler/`
-- `Crawler.java`, `CrawlerContext.java`, `CrawlerThread.java`
+- `Crawler.java`, `CrawlerContext.java`, `CrawlerThread.java`, `CrawlerStatus.java`
 
 **Clients**: `fess-crawler/src/main/java/org/codelibs/fess/crawler/client/`
-- `http/` - `HcHttpClient.java`, `Hc4HttpClient.java`, `Hc5HttpClient.java`, `SwitchableHttpClient.java`
+- root: `CrawlerClient.java`, `AbstractCrawlerClient.java`, `CrawlerClientFactory.java`,
+  `CrawlerClientFactoryWrapper.java`, `CrawlerClientCreator.java`, `FaultTolerantClient.java`,
+  `AccessTimeoutTarget.java`
+- `http/` - `HcHttpClient.java`, `Hc4HttpClient.java`, `Hc5HttpClient.java`, `SwitchableHttpClient.java`,
+  `Hc4Authentication.java`, `Hc5Authentication.java`, `RequestHeader.java`, `*ConnectionMonitorTarget.java`
+- `http/config/` - `CookieConfig`, `CredentialsConfig`, `WebAuthenticationConfig`
+- `http/conn/` - `IdnDnsResolver`, `Hc5IdnDnsResolver`
+- `http/form/` - `Hc4FormScheme`, `Hc5FormScheme`
+- `http/ntlm/` - `JcifsEngine`, `Hc5JcifsEngine`, `SmbjEngine`, `NTLMSchemeProvider`, `Hc5NTLMSchemeFactory`
 - `fs/FileSystemClient.java`, `ftp/FtpClient.java`
 - `smb/SmbClient.java`, `smb1/SmbClient.java`
 - `storage/StorageClient.java`, `s3/S3Client.java`, `gcs/GcsClient.java`
 
 **DI Config**: `fess-crawler-lasta/src/main/resources/`
-- `crawler.xml` (root), `crawler/client.xml`, `crawler/extractor.xml`, `crawler/rule.xml`, `crawler/transformer.xml`, `crawler/transformer_basic.xml`
-- `crawler/mimetype.xml`, `crawler/encoding.xml`, `crawler/robotstxt.xml`, `crawler/sitemaps.xml`
-- `crawler/filter.xml`, `crawler/interval.xml`, `crawler/contentlength.xml`, `crawler/urlconverter.xml`, `crawler/container.xml`, `crawler/log.xml`
+- `crawler.xml` (root), and under `crawler/`: `client.xml`, `container.xml`, `contentlength.xml`,
+  `encoding.xml`, `extractor.xml`, `filter.xml`, `interval.xml`, `log.xml`, `mimetype.xml`,
+  `robotstxt.xml`, `rule.xml`, `sitemaps.xml`, `transformer.xml`, `transformer_basic.xml`,
+  `urlconverter.xml`
+
+**OpenSearch**: `fess-crawler-opensearch/src/main/resources/crawler_opensearch.xml`, `mapping/`
+
+### Reference Wiring
+
+- **Lasta DI**: `fess-crawler-lasta/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java` — the
+  short path; `SingletonLaContainerFactory.setConfigPath("crawler.xml")` + `init()` gives a fully
+  wired crawler
+- **Standalone**: `fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java:84-153` —
+  the ~25-component `StandardCrawlerContainer` setup. Registration is **eager**, so order matters,
+  and `@Resource` injection matches **by field name**. `crawler` must be a `prototype`
+
+`fess-crawler-lasta` declares `jakarta.transaction:jakarta.transaction-api` as **`provided`**, so
+downstream consumers must add it themselves or Lasta DI startup throws
+`ClassNotFoundException: jakarta.transaction.Transactional$TxType`.
 
 ### Exception Hierarchy
 
-All exceptions are unchecked (extend `RuntimeException` via `CrawlerSystemException`).
+All public exceptions are unchecked (extend `RuntimeException` via `CrawlerSystemException`).
 
 ```
 CrawlerSystemException (RuntimeException)
   ├─ CrawlingAccessException
-  │     └─ MaxLengthExceededException
+  │     ├─ MaxLengthExceededException
+  │     └─ MultipleCrawlingAccessException
   ├─ ChildUrlsException
   ├─ ExtractException
-  │     └─ UnsupportedExtractException
+  │     ├─ UnsupportedExtractException
+  │     └─ ExecutionTimeoutException
   ├─ CrawlerLoginFailureException
-  ├─ ExecutionTimeoutException
   ├─ MimeTypeException
-  ├─ MultipleCrawlingAccessException
   ├─ RobotsTxtException
-  └─ SitemapsException
+  ├─ SitemapsException
+  └─ OpenSearchAccessException          (fess-crawler-opensearch module)
 ```
+
+Two internal checked exceptions sit outside this tree and are not part of the public API:
+`ApiExtractor.RetryableStatusException` and `CommandExtractor.OutputSizeExceededException`, both
+`extends IOException`.
 
 ### Thread-Local Storage
 

--- a/README.md
+++ b/README.md
@@ -1,496 +1,543 @@
 # Fess Crawler
 
 [![Java CI with Maven](https://github.com/codelibs/fess-crawler/actions/workflows/maven.yml/badge.svg)](https://github.com/codelibs/fess-crawler/actions/workflows/maven.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/org.codelibs.fess/fess-crawler.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.codelibs.fess/fess-crawler)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.codelibs.fess/fess-crawler-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.codelibs.fess/fess-crawler-parent)
+[![Javadoc](https://javadoc.io/badge2/org.codelibs.fess/fess-crawler/javadoc.svg)](https://javadoc.io/doc/org.codelibs.fess/fess-crawler)
 
-## Overview
+**Fess Crawler** is a Java crawling framework for enterprise-scale content acquisition and text
+extraction. It is the crawling engine behind [Fess](https://github.com/codelibs/fess), and can be
+embedded in any JVM application on its own.
 
-**Fess Crawler** is a powerful, flexible Java-based web crawling framework designed for enterprise-scale content extraction and processing. Built with a modular architecture, it supports multiple protocols (HTTP/HTTPS, File System, FTP, SMB, Cloud Storage) and provides extensive content extraction capabilities from various document formats.
+## Key Features
 
-### Key Features
+- **Multi-protocol**: HTTP/HTTPS, local/network file systems, FTP/FTPS, SMB/CIFS (SMB1 and SMB2+),
+  MinIO-compatible object storage, Amazon S3, Google Cloud Storage
+- **Broad text extraction**: Office documents, PDF, HTML, XML, JSON, CSV, Markdown, e-mail, archives,
+  PostScript, and media/image metadata — via Apache Tika, POI, PDFBox and format-specific extractors
+- **Multi-threaded** crawling with configurable thread pools, depth limits and access-count limits
+- **Fault tolerant**: retry wrapper (`FaultTolerantClient`) and an HTTP client that can fall back
+  between Apache HttpComponents 5.x and 4.x
+- **Polite**: `robots.txt` (RFC 9309) and sitemap support, plus configurable request intervals
+- **Bounded by design**: content-length caps enforced *while* downloading, archive-bomb and Zip Slip
+  defenses, and bounded recursion in nested extractors
+- **Pluggable**: clients, extractors, transformers, rules and filters are all replaceable via DI
+- **Pluggable storage**: in-memory by default, OpenSearch for persistent/distributed crawls
 
-- **Multi-Protocol Support**: HTTP/HTTPS, File System, FTP, SMB/CIFS, Cloud Storage (MinIO, S3)
-- **Comprehensive Content Extraction**: Office documents, PDFs, archives, images, audio/video files
-- **Multi-Threading**: Configurable thread pools for high-performance crawling
-- **Fault Tolerance**: Built-in retry mechanisms and error handling
-- **Flexible Configuration**: XML-based dependency injection with LastaFlute DI
-- **Extensible Architecture**: Plugin system for custom extractors, transformers, and clients
-- **Rate Limiting**: Politeness policies and interval controllers
-- **URL Filtering**: Regex-based inclusion/exclusion patterns
-- **Data Persistence**: Multiple backend options including OpenSearch integration
+## Requirements
 
-## Technology Stack
+- Java 21 or later
+- Maven 3.8 or later (to build from source)
 
-- **Java**: 21+ (requires Java 21 or higher)
-- **Build System**: Maven 3.x
-- **DI Container**: LastaFlute DI
-- **HTTP Client**: Apache HttpComponents
-- **Content Extraction**: Apache Tika, Apache POI, PDFBox
-- **Testing**: JUnit 4, UTFlute, Testcontainers
-- **Storage Backends**: OpenSearch, Memory-based
+## Installation
+
+Add the modules you need. Check the Maven Central badge above for the current release.
+
+```xml
+<properties>
+    <fess.crawler.version>15.7.0</fess.crawler.version>
+</properties>
+
+<dependencies>
+    <!-- Core framework -->
+    <dependency>
+        <groupId>org.codelibs.fess</groupId>
+        <artifactId>fess-crawler</artifactId>
+        <version>${fess.crawler.version}</version>
+    </dependency>
+
+    <!-- Ready-made LastaFlute DI wiring (recommended starting point) -->
+    <dependency>
+        <groupId>org.codelibs.fess</groupId>
+        <artifactId>fess-crawler-lasta</artifactId>
+        <version>${fess.crawler.version}</version>
+    </dependency>
+
+    <!-- Optional: persist the URL queue and results in OpenSearch -->
+    <dependency>
+        <groupId>org.codelibs.fess</groupId>
+        <artifactId>fess-crawler-opensearch</artifactId>
+        <version>${fess.crawler.version}</version>
+    </dependency>
+</dependencies>
+```
+
+> **Note**
+> `fess-crawler-lasta` declares `jakarta.transaction:jakarta.transaction-api` with `provided`
+> scope, so it is *not* pulled in transitively. Lasta DI needs it at runtime — add it to your own
+> dependencies, or container startup fails with
+> `ClassNotFoundException: jakarta.transaction.Transactional$TxType`.
+>
+> You also need an SLF4J/Log4j binding of your choice; none is bundled.
 
 ## Quick Start
 
-### Prerequisites
-
-- Java 21 or higher
-- Maven 3.6 or higher
-
-### Installation
-
-Add the following dependency to your `pom.xml`:
-
-```xml
-<dependency>
-    <groupId>org.codelibs.fess</groupId>
-    <artifactId>fess-crawler</artifactId>
-    <version>15.2.0-SNAPSHOT</version>
-</dependency>
-
-<!-- For LastaFlute DI integration -->
-<dependency>
-    <groupId>org.codelibs.fess</groupId>
-    <artifactId>fess-crawler-lasta</artifactId>
-    <version>15.2.0-SNAPSHOT</version>
-</dependency>
-
-<!-- For OpenSearch backend -->
-<dependency>
-    <groupId>org.codelibs.fess</groupId>
-    <artifactId>fess-crawler-opensearch</artifactId>
-    <version>15.2.0-SNAPSHOT</version>
-</dependency>
-```
-
-### Basic Usage
+`fess-crawler-lasta` ships a complete DI configuration (`crawler.xml`) with every client, extractor,
+transformer and rule already wired, so the shortest working crawler is:
 
 ```java
 import org.codelibs.fess.crawler.Crawler;
-import org.codelibs.fess.crawler.client.http.HcHttpClient;
-import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
-import org.codelibs.fess.crawler.transformer.impl.FileTransformer;
+import org.codelibs.fess.crawler.entity.AccessResult;
+import org.codelibs.fess.crawler.service.DataService;
+import org.lastaflute.di.core.factory.SingletonLaContainerFactory;
 
-public class BasicCrawlerExample {
-    public static void main(String[] args) throws Exception {
-        // Create crawler container
-        StandardCrawlerContainer container = new StandardCrawlerContainer();
-        
-        // Configure basic components
-        container.singleton("crawler", Crawler.class)
-                .singleton("httpClient", HcHttpClient.class)
-                .singleton("fileTransformer", FileTransformer.class);
-        
-        // Get crawler instance
-        Crawler crawler = container.getComponent("crawler");
-        
-        // Configure crawling parameters
-        crawler.addUrl("https://example.com");
-        crawler.crawlerContext.setMaxAccessCount(100);
-        crawler.crawlerContext.setNumOfThread(5);
-        crawler.urlFilter.addInclude("https://example.com/.*");
-        
-        // Execute crawling
-        String sessionId = crawler.execute();
-        System.out.println("Crawling completed. Session ID: " + sessionId);
+public class QuickStart {
+    public static void main(final String[] args) {
+        SingletonLaContainerFactory.setConfigPath("crawler.xml");
+        SingletonLaContainerFactory.init();
+
+        final Crawler crawler = SingletonLaContainerFactory.getContainer().getComponent("crawler");
+        final DataService<AccessResult<?>> dataService =
+                SingletonLaContainerFactory.getContainer().getComponent("dataService");
+
+        try (crawler) {
+            crawler.addUrl("https://example.com/");
+            crawler.addIncludeFilter("https://example.com/.*");
+            crawler.setMaxAccessCount(100L);
+            crawler.setNumOfThread(5);
+            crawler.setMaxDepth(3);
+
+            final String sessionId = crawler.execute(); // blocks until the crawl finishes
+
+            System.out.println("crawled=" + dataService.getCount(sessionId));
+            dataService.iterate(sessionId, result -> System.out.println(result.getUrl()));
+            dataService.delete(sessionId);
+        }
     }
 }
 ```
 
-### File System Crawling
+`crawler` is a **prototype** component: call `getComponent("crawler")` again for each independent
+crawl. `execute()` returns the session ID, which is the key for everything in `DataService` and
+`UrlQueueService`.
+
+Swap the URL for `file:///path/to/dir`, `smb://host/share/`, `ftp://host/dir/`, `s3://bucket/prefix`
+… and the same code crawls that source — client selection is driven by the URL scheme.
+
+## Configuring a Crawl
+
+All of these are `Crawler` methods; there is no need to reach into `CrawlerContext` (its field is
+`protected`, so it is not accessible from outside the `org.codelibs.fess.crawler` package).
 
 ```java
-import org.codelibs.fess.crawler.client.fs.FileSystemClient;
+crawler.setSessionId("nightly-crawl");   // default: generated timestamp
+crawler.setNumOfThread(10);              // worker threads
+crawler.setMaxDepth(3);                  // -1 (default) = unlimited
+crawler.setMaxAccessCount(10_000L);      // 0 (default) = unlimited
+crawler.setMaxThreadCheckCount(20);      // idle polls before a thread gives up
+crawler.setThreadPriority(Thread.NORM_PRIORITY);
 
-// Configure for file system crawling
-container.singleton("fsClient", FileSystemClient.class);
-
-// Add file URL
-crawler.addUrl("file:///path/to/directory");
-crawler.urlFilter.addInclude("file:///path/to/directory/.*");
+crawler.addIncludeFilter("https://example\\.com/.*");
+crawler.addExcludeFilter(".*\\.(css|js|png|jpe?g|gif)$");
 ```
 
-## Configuration
-
-### XML Configuration
-
-Fess Crawler uses XML-based configuration with LastaFlute DI. Place configuration files in your classpath:
-
-```xml
-<!-- crawler.xml -->
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
-    "http://dbflute.org/meta/lastadi10.dtd">
-<components namespace="fessCrawler">
-    <component name="crawler" class="org.codelibs.fess.crawler.Crawler" instance="prototype"/>
-    <component name="httpClient" class="org.codelibs.fess.crawler.client.http.HcHttpClient" instance="singleton"/>
-    <component name="fileTransformer" class="org.codelibs.fess.crawler.transformer.impl.FileTransformer" instance="singleton"/>
-</components>
-```
-
-### Crawler Context Configuration
-
-```java
-// Set maximum number of URLs to crawl
-crawler.crawlerContext.setMaxAccessCount(1000);
-
-// Set number of crawler threads
-crawler.crawlerContext.setNumOfThread(10);
-
-// Set maximum crawl depth
-crawler.crawlerContext.setMaxDepth(3);
-
-// Set request interval (politeness)
-crawler.crawlerContext.setDefaultIntervalTime(1000); // 1 second
-```
-
-### URL Filtering
-
-```java
-// Include patterns
-crawler.urlFilter.addInclude("https://example.com/.*");
-crawler.urlFilter.addInclude(".*\\.pdf$");
-
-// Exclude patterns  
-crawler.urlFilter.addExclude(".*\\.js$");
-crawler.urlFilter.addExclude(".*login.*");
-```
-
-## Supported Protocols and Formats
-
-### Protocols
-- **HTTP/HTTPS**: Full web crawling support with cookies, authentication, redirects
-- **File System**: Local and network file system access
-- **FTP**: FTP server crawling with authentication
-- **SMB/CIFS**: Windows network shares
-- **Storage**: Cloud storage systems (MinIO, S3-compatible)
-
-### Content Formats
-
-#### Office Documents
-- Microsoft Office (Word, Excel, PowerPoint)
-- OpenOffice/LibreOffice documents
-- RTF, WordPerfect
-
-#### PDFs and Images
-- PDF documents (text and metadata extraction)
-- Images (JPEG, PNG, GIF, TIFF, BMP)
-- Image metadata (EXIF, IPTC, XMP)
-
-#### Archives and Compressed Files
-- ZIP, TAR, GZ archives
-- LHA compression format
-- Nested archive extraction
-
-#### Web and Markup
-- HTML, XHTML with XPath support
-- XML documents
-- JSON and structured data
-
-#### Media Files
-- Audio formats (MP3, WAV, FLAC)
-- Video formats (MP4, AVI, MOV)
-- Metadata extraction from media files
-
-## Architecture
-
-### Multi-Module Structure
-
-```
-fess-crawler-parent/
-├── fess-crawler/              # Core crawler framework
-│   ├── client/               # Protocol clients (HTTP, FTP, SMB, etc.)
-│   ├── extractor/           # Content extractors
-│   ├── transformer/         # Data transformers
-│   └── service/             # Core services
-├── fess-crawler-lasta/       # LastaFlute DI integration
-└── fess-crawler-opensearch/  # OpenSearch backend
-```
-
-### Key Components
-
-#### Core Engine
-- **Crawler**: Main orchestrator managing crawl execution
-- **CrawlerContext**: Execution context and configuration
-- **CrawlerThread**: Individual crawler thread implementation
-
-#### Client Architecture
-- **HcHttpClient**: HTTP/HTTPS client using Apache HttpComponents
-- **FileSystemClient**: File system access
-- **FtpClient**: FTP protocol support
-- **SmbClient**: SMB/CIFS network shares
-- **StorageClient**: Cloud storage integration
-
-#### Content Processing Pipeline
-- **Extractors**: Content extraction from various formats
-- **Transformers**: Data transformation and enrichment
-- **Filters**: URL filtering with regex patterns
-- **Rules**: Content processing rules and validation
-
-## Building and Testing
-
-### Build Commands
-
-```bash
-# Build all modules
-mvn clean install
-
-# Build without tests
-mvn clean install -DskipTests
-
-# Build specific module
-mvn clean install -pl fess-crawler
-
-# Generate test coverage report
-mvn jacoco:report
-```
-
-### Code Quality
-
-```bash
-# Format code
-mvn formatter:format
-
-# Update license headers
-mvn license:format
-
-# Run static analysis
-mvn spotbugs:check
-```
-
-### Running Tests
-
-```bash
-# Run all tests
-mvn test
-
-# Run specific test class
-mvn test -Dtest=CrawlerTest
-
-# Run specific test method
-mvn test -Dtest=CrawlerTest#test_execute_web
-
-# Run tests for specific module
-mvn test -pl fess-crawler
-```
-
-## Examples
-
-### Web Crawling with Custom Rules
-
-```java
-// Create crawler with custom configuration
-StandardCrawlerContainer container = new StandardCrawlerContainer();
-
-// Configure HTTP client with custom settings
-container.singleton("httpClient", HcHttpClient.class, client -> {
-    client.setUserAgent("MyBot/1.0");
-    client.setConnectionTimeout(30000);
-    client.setMaxConnections(100);
-});
-
-// Configure URL filtering
-container.singleton("urlFilter", UrlFilterImpl.class, filter -> {
-    filter.addInclude("https://example.com/.*");
-    filter.addExclude(".*\\.(css|js|png|jpg|gif)$");
-});
-
-// Configure content extraction
-container.singleton("tikaExtractor", TikaExtractor.class);
-container.singleton("extractorFactory", ExtractorFactory.class, factory -> {
-    factory.addExtractor("text/html", container.getComponent("tikaExtractor"));
-    factory.addExtractor("application/pdf", container.getComponent("tikaExtractor"));
-});
-
-Crawler crawler = container.getComponent("crawler");
-crawler.addUrl("https://example.com");
-crawler.crawlerContext.setMaxAccessCount(500);
-String sessionId = crawler.execute();
-```
+Invalid regular expressions passed to the filters are logged and ignored rather than thrown, so a
+typo silently widens the crawl — check your logs.
 
 ### Background Crawling
 
 ```java
-// Configure for background execution
 crawler.setBackground(true);
-String sessionId = crawler.execute();
+final String sessionId = crawler.execute();   // returns immediately
 
-// Check crawling status
-while (crawler.crawlerContext.getStatus() == CrawlerStatus.RUNNING) {
-    Thread.sleep(1000);
-    System.out.println("Crawling in progress...");
-}
-
-// Wait for completion
-crawler.awaitTermination();
-System.out.println("Crawling completed");
+// CrawlerStatus is INITIALIZING, RUNNING or DONE
+crawler.awaitTermination();                   // or awaitTermination(millis)
+crawler.stop();                               // request an early stop
+crawler.cleanup(sessionId);                   // drop queue + filter state
 ```
 
-### Custom Content Extractor
+`Crawler` implements `AutoCloseable`; `close()` performs the cleanup for the current session.
+
+### Reading Results
+
+```java
+final DataService<AccessResult<?>> dataService = container.getComponent("dataService");
+
+System.out.println(dataService.getCount(sessionId));
+
+dataService.iterate(sessionId, result -> {
+    System.out.println(result.getUrl());
+    System.out.println(result.getHttpStatusCode());
+    System.out.println(result.getMimeType());
+    System.out.println(result.getContentLength());
+    // Extracted text/binary lives on the child entity, not on AccessResult itself:
+    System.out.println(result.getAccessResultData().getDataAsString());
+});
+
+final AccessResult<?> one = dataService.getAccessResult(sessionId, url);
+dataService.delete(sessionId);
+```
+
+## Supported Sources
+
+Clients are selected by URL pattern (see `crawler/client.xml` in `fess-crawler-lasta`):
+
+| URL pattern | Client | Notes |
+| --- | --- | --- |
+| `http:.*`, `https:.*` | `SwitchableHttpClient` | wraps `Hc5HttpClient` (default) or `Hc4HttpClient` |
+| `file:.*` | `FileSystemClient` | local and mounted network paths |
+| `smb:.*` | `smb.SmbClient` | SMB2+ (SMBJ) |
+| `smb1:.*` | `smb1.SmbClient` | legacy SMB1 (JCIFS) |
+| `ftp:.*`, `ftps:.*` | `FtpClient` | shared component for both schemes |
+| `storage:.*` | `StorageClient` | MinIO / S3-compatible object storage |
+| `s3:.*` | `S3Client` | AWS SDK v2 |
+| `gcs:.*` | `GcsClient` | Google Cloud Storage |
+
+### Content Formats
+
+Extractors registered by MIME type in `crawler/extractor.xml`: HTML, XML/XHTML/RDF/FreeMind, PDF,
+LHA, e-mail (`message/rfc822`), JSON, CSV, Markdown, PostScript, and a large Tika-backed catalogue
+covering Office (Word/Excel/PowerPoint/Publisher/Visio), OpenDocument, RTF, archives, audio, video
+and images (EXIF/IPTC/XMP metadata).
+
+Additional extractors ship in the jar but are **not** wired into the default DI, so you must register
+them yourself if you want them: `ZipExtractor`, `TarExtractor`, `ApiExtractor`, `CommandExtractor`.
+
+## Configuration
+
+### Overriding DI Components
+
+The recommended approach is to include `crawler.xml` from your own Lasta DI file and redefine only
+the components you care about — component names are the contract:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+    "http://dbflute.org/meta/lastadi10.dtd">
+<components namespace="fessCrawler">
+    <include path="crawler.xml"/>
+
+    <component name="internalHttpClient"
+        class="org.codelibs.fess.crawler.client.http.Hc5HttpClient" instance="prototype">
+        <property name="userAgent">"MyBot/1.0 (+https://example.com/bot)"</property>
+        <property name="connectionTimeout">30000</property>
+        <property name="soTimeout">60000</property>
+        <property name="maxTotalConnections">200</property>
+        <property name="maxConnectionsPerRoute">20</property>
+    </component>
+</components>
+```
+
+The DI files you can include or override individually live in `fess-crawler-lasta`'s resources:
+`crawler/` + `client.xml`, `container.xml`, `contentlength.xml`, `encoding.xml`, `extractor.xml`,
+`filter.xml`, `interval.xml`, `log.xml`, `mimetype.xml`, `robotstxt.xml`, `rule.xml`,
+`sitemaps.xml`, `transformer.xml`, `transformer_basic.xml`, `urlconverter.xml`.
+
+### HTTP Client
+
+`HcHttpClient` is an **abstract** base holding the init-parameter constants — register one of the
+concrete classes, `Hc5HttpClient` (default) or `Hc4HttpClient`. `SwitchableHttpClient` extends
+`FaultTolerantClient` and *delegates* to whichever of the two the system property selects:
+
+```
+-Dfess.crawler.http.client=hc4    # anything else, including unset, selects hc5
+```
+
+The property is read once when `SwitchableHttpClient` is constructed.
+
+Commonly tuned setters on `Hc5HttpClient` / `Hc4HttpClient` — note the names, several differ from
+what you might guess:
+
+| Purpose | Setter | Init-parameter key |
+| --- | --- | --- |
+| User agent | `setUserAgent(String)` | `userAgent` |
+| Connect timeout (ms) | `setConnectionTimeout(Integer)` | `connectionTimeout` |
+| Read timeout (ms) | `setSoTimeout(Integer)` | `soTimeout` |
+| Total pool size | `setMaxTotalConnections(Integer)` | `maxTotalConnection` |
+| Per-host pool size | `setMaxConnectionsPerRoute(Integer)` | `maxConnectionsPerRoute` |
+| Skip TLS verification | `setIgnoreSslCertificate(boolean)` | `ignoreSslCertificate` |
+| Proxy | `setProxyHost(String)` / `setProxyPort(Integer)` | `proxyHost` / `proxyPort` |
+| Follow redirects | `setRedirectsEnabled(boolean)` | `redirectsEnabled` |
+| Honour robots.txt | `setUseRobotsTxtDisallows(boolean)` / `setUseRobotsTxtAllows(boolean)` | — |
+
+Disable TLS verification only against hosts you control.
+
+Every client also inherits generic knobs from `AbstractCrawlerClient`: `accessTimeout`,
+`maxContentLength`, `maxCachedContentSize`. Any of these can be supplied as a map instead of via
+setters:
+
+```java
+final Map<String, Object> params = new HashMap<>();
+params.put(HcHttpClient.USER_AGENT_PROPERTY, "MyBot/1.0");
+params.put(HcHttpClient.SO_TIMEOUT_PROPERTY, 60000);
+params.put(AbstractCrawlerClient.MAX_CONTENT_LENGTH, 50L * 1024 * 1024);
+client.setInitParameterMap(params);
+```
+
+### Object Storage Credentials
+
+`S3Client` reads `accessKey`, `secretKey`, `endpoint`, `region` (default `us-east-1`) and
+`crossRegionAccessEnabled` (default `true`). When `accessKey`/`secretKey` are blank it falls back to
+the **AWS default credentials provider chain**, so IAM roles, instance profiles, IRSA, environment
+variables and shared profiles all work without hard-coded keys.
+
+`GcsClient` reads `projectId`, `credentialsFile` and `endpoint`; without `credentialsFile` it uses
+Application Default Credentials.
+
+### Politeness and Intervals
+
+`DefaultIntervalController` exposes four independent delays, all in milliseconds:
+
+```xml
+<component name="intervalController"
+    class="org.codelibs.fess.crawler.interval.impl.DefaultIntervalController">
+    <property name="delayMillisBeforeProcessing">1000</property>
+    <property name="delayMillisAfterProcessing">0</property>
+    <property name="delayMillisAtNoUrlInQueue">500</property>
+    <property name="delayMillisForWaitingNewUrl">1000</property>
+</component>
+```
+
+Use `delayMillisBeforeProcessing` for a fixed per-request delay. `robots.txt` `Crawl-delay` is
+handled separately by `RobotsTxtHelper`.
+
+### Content Size Limits
+
+Size limits are owned by `ContentLengthHelper`, not by the transformers. The default cap is 10 MB and
+can be overridden per MIME type:
+
+```xml
+<component name="contentLengthHelper"
+    class="org.codelibs.fess.crawler.helper.ContentLengthHelper">
+    <property name="defaultMaxLength">10485760</property>
+    <postConstruct name="addMaxLength">
+        <arg>"application/pdf"</arg>
+        <arg>52428800</arg>
+    </postConstruct>
+</component>
+```
+
+HTTP clients enforce this **during** the download and abort as soon as the limit is exceeded, rather
+than buffering the whole body first. Responses larger than `maxCachedContentSize` spill to a
+temporary file, which is deleted when the `ResponseData` is closed — always use try-with-resources
+when handling `ResponseData` yourself.
+
+### HTML Metadata and JSON-LD
+
+`HtmlExtractor` extracts standard metadata (title, description, OpenGraph, Twitter Card) by default.
+JSON-LD extraction is opt-in and bounded in nesting depth, size and item count:
+
+```xml
+<component name="htmlExtractor" class="org.codelibs.fess.crawler.extractor.impl.HtmlExtractor">
+    <property name="extractDefaultMetadata">true</property>   <!-- default -->
+    <property name="extractJsonLd">true</property>            <!-- default: false -->
+</component>
+```
+
+### Extractor Selection
+
+`ExtractorFactory` maps MIME types to extractors. Several extractors may claim the same MIME type; in
+that case they are tried in **descending weight** order until one succeeds (`weight` defaults to `1`,
+set via `AbstractExtractor.setWeight(int)`).
+
+To extract from a stream directly, without running a crawl:
+
+```java
+final ExtractData data = extractorFactory.builder(inputStream, params)
+        .mimeType("application/pdf")
+        .maxContentLength(10 * 1024 * 1024)
+        .extract();
+System.out.println(data.getContent());
+```
+
+When `maxContentLength` is not set, the builder falls back to `ContentLengthHelper`.
+
+## OpenSearch Backend
+
+`fess-crawler-opensearch` replaces the in-memory queue and result store with OpenSearch indices.
+`OpenSearchDataService` has no no-arg constructor and no host/port setters — it is configured
+through `OpenSearchCrawlerConfig`, as in the module's own `crawler_opensearch.xml`:
+
+```xml
+<component name="crawlerConfig"
+    class="org.codelibs.fess.crawler.util.OpenSearchCrawlerConfig">
+    <property name="dataIndex">"fess_crawler.data"</property>
+    <property name="dataShards">5</property>
+    <property name="dataReplicas">1</property>
+</component>
+
+<component name="dataService"
+    class="org.codelibs.fess.crawler.service.impl.OpenSearchDataService">
+    <arg>crawlerConfig</arg>
+</component>
+```
+
+Connectivity comes from an injected `fesenClient`
+([fesen-httpclient](https://github.com/codelibs/fesen-httpclient)); index mappings are created on
+first connect.
+
+## Embedding Without Lasta DI
+
+`StandardCrawlerContainer` is a small standalone container for applications that do not want Lasta
+DI. Be aware of two behaviours before using it:
+
+- Registration **eagerly instantiates** each component, so a component must be registered *after*
+  everything it depends on, and `@Resource` injection is matched **by field name**.
+- `crawler`, `crawlerThread`, `urlQueue`, `accessResult` and the services must be registered as
+  `prototype`; registering `crawler` as a singleton makes every `getComponent("crawler")` return the
+  same instance.
+
+A crawl needs roughly 25 components wired together (crawler + thread + entities, the four services,
+eight helpers, a client factory with at least one client, a rule manager with a rule and a response
+processor, a transformer, an interval controller, and an extractor factory). Rather than reproduce
+all of it here, use
+[`fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java`](fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java)
+as the reference wiring — it is exercised by the test suite on every build. For most applications the
+Lasta DI route in [Quick Start](#quick-start) is considerably less work.
+
+## Architecture
+
+```
+fess-crawler-parent/
+├── fess-crawler/              # Core framework: clients, extractors, transformers, services
+├── fess-crawler-lasta/        # Lasta DI wiring (crawler.xml and friends)
+└── fess-crawler-opensearch/   # OpenSearch-backed queue and result store
+```
+
+### Crawl Pipeline
+
+```
+Crawler ──▶ CrawlerThread ──▶ CrawlerClient ──▶ ResponseData
+                                                    │
+                                            RuleManager (pattern match)
+                                                    │
+                                            ResponseProcessor
+                                                    │
+                                              Transformer ──▶ Extractor ──▶ ExtractData
+                                                    │
+                        ┌───────────────────────────┴───────────────────────────┐
+                        ▼                                                       ▼
+                UrlQueueService (child URLs)                          DataService (results)
+```
+
+`UrlFilter` gates URLs on the way into the queue; `IntervalController` paces the workers;
+`CrawlingParameterUtil` carries the `CrawlerContext` and `UrlQueue` in thread-locals.
+
+### Extending
+
+A custom extractor implements one method:
 
 ```java
 public class CustomExtractor extends AbstractExtractor {
     @Override
-    public ExtractData getText(final InputStream inputStream, final Map<String, String> params) {
-        // Custom extraction logic
-        ExtractData extractData = new ExtractData();
-        // ... implementation
-        return extractData;
+    public ExtractData getText(final InputStream in, final Map<String, String> params) {
+        final ExtractData data = new ExtractData();
+        // ... populate content and metadata
+        return data;
+    }
+
+    @Override
+    public int getWeight() {
+        return 10; // higher wins when several extractors claim the same MIME type
     }
 }
-
-// Register custom extractor
-container.singleton("customExtractor", CustomExtractor.class);
-container.singleton("extractorFactory", ExtractorFactory.class, factory -> {
-    factory.addExtractor("application/custom", container.getComponent("customExtractor"));
-});
 ```
 
-## Advanced Configuration
+Declare it as a component, then **append** it to the existing factory after the container starts:
 
-### Multi-Instance Crawling
-
-```java
-// Create multiple crawler instances
-Crawler crawler1 = container.getComponent("crawler");
-crawler1.setSessionId("session1");
-crawler1.addUrl("https://site1.com");
-
-Crawler crawler2 = container.getComponent("crawler");  
-crawler2.setSessionId("session2");
-crawler2.addUrl("https://site2.com");
-
-// Execute concurrently
-crawler1.setBackground(true);
-crawler2.setBackground(true);
-
-String sessionId1 = crawler1.execute();
-String sessionId2 = crawler2.execute();
-
-crawler1.awaitTermination();
-crawler2.awaitTermination();
+```xml
+<components namespace="fessCrawler">
+    <include path="crawler.xml"/>
+    <component name="customExtractor" class="com.example.CustomExtractor"/>
+</components>
 ```
 
-### Custom Interval Control
-
 ```java
-// Configure politeness policy
-container.singleton("intervalController", DefaultIntervalController.class, controller -> {
-    controller.setDelayMillisForWaitingNewUrl(5000);
-    controller.setDefaultIntervalTime(1000);
-});
+final ExtractorFactory factory = container.getComponent("extractorFactory");
+factory.addExtractor("application/x-custom", container.getComponent("customExtractor"));
 ```
 
-### Sitemap Support
+> **Warning**
+> Do *not* redeclare `extractorFactory` itself in your DI file to add a mapping. The outer
+> definition replaces the included one wholesale, and every default MIME-type mapping — HTML, PDF,
+> Office, everything — is silently lost, leaving `getExtractor()` returning `null`.
 
-```java
-// Enable sitemap processing
-container.singleton("sitemapsRule", SitemapsRule.class, rule -> {
-    rule.addRule("url", ".*sitemap.*");
-});
+Custom clients (`CrawlerClient`), transformers (`Transformer`) and rules (`Rule`) follow the same
+pattern — implement the interface, register the component, map it in the relevant factory.
 
-// Add sitemap URL
-crawler.addUrl("https://example.com/sitemap.xml");
+## Building from Source
+
+```bash
+git clone https://github.com/codelibs/fess-crawler.git
+cd fess-crawler
+
+mvn clean install                 # build + test all modules
+mvn clean install -DskipTests     # skip tests
+mvn clean install -pl fess-crawler
 ```
 
-## Data Access and Storage
+`fess-crawler` builds against `fess-parent`; when working on an unreleased version, build and install
+[codelibs/fess-parent](https://github.com/codelibs/fess-parent) (branch `main`) first — this is
+exactly what CI does.
 
-### Accessing Crawled Data
+### Testing
 
-```java
-// Get data service
-DataService dataService = container.getComponent("dataService");
+Tests use **JUnit 5 (Jupiter)** on top of UTFlute (`PlainTestCase`, or `LastaDiTestCase` for the DI
+modules), with Mockito and Testcontainers where a real backend is needed.
 
-// Iterate through crawled data
-dataService.iterate(sessionId, accessResult -> {
-    System.out.println("URL: " + accessResult.getUrl());
-    System.out.println("Status: " + accessResult.getHttpStatusCode());
-    System.out.println("Content Type: " + accessResult.getMimeType());
-    System.out.println("Content: " + accessResult.getContent());
-    System.out.println("---");
-});
-
-// Get specific result
-AccessResult result = dataService.getAccessResult(sessionId, url);
-
-// Delete session data
-dataService.delete(sessionId);
+```bash
+mvn test
+mvn test -pl fess-crawler
+mvn test -Dtest=CrawlerTest
+mvn test -Dtest=CrawlerTest#test_execute_web
 ```
 
-### OpenSearch Integration
+Surefire runs test **classes in parallel**, so tests must not share mutable static state.
+`JodExtractorTest` is excluded from the default run (it needs a local LibreOffice/JODConverter).
+Container-backed tests (`S3ClientTest`, `StorageClientTest`, `GcsClientTest`, `SmbClientTest`)
+require a working Docker daemon.
 
-```java
-// Add OpenSearch dependency and configure
-container.singleton("opensearchDataService", OpenSearchDataService.class, service -> {
-    service.setIndexName("crawler-data");
-    service.setHostname("localhost");
-    service.setPort(9200);
-});
+JaCoCo produces a coverage report during `package`, but no minimum is enforced by the build.
+
+### Code Quality
+
+```bash
+mvn formatter:format     # Eclipse formatter: 4 spaces, no tabs, 140-column lines
+mvn license:format       # Apache 2.0 headers (license:check runs in the build and fails on gaps)
 ```
 
-## Performance Tuning
+Formatter and license configuration come from `fess-parent`, which points at the shared CodeLibs
+config, so do not add a local formatter file.
 
-### Thread Configuration
+### Continuous Integration
 
-```java
-// Optimize thread pool settings
-crawler.crawlerContext.setNumOfThread(20);           // Number of crawler threads
-crawler.crawlerContext.setMaxThreadCheckCount(50);   // Thread monitoring frequency
-```
+`.github/workflows/maven.yml` runs on pushes and pull requests to `master` and `*.x` branches: a
+single **JDK 21** (Temurin) build that installs `fess-parent` and then runs `mvn -B package`.
 
-### Connection Pool Tuning
+`package` is more than tests — it also runs `license:check`, `formatter:format`, `jacoco:report`,
+`source:jar` and **`javadoc:jar`**. Javadoc errors therefore fail CI even though `mvn test` passes
+locally. If you touch imports or Javadoc, verify with:
 
-```java
-container.singleton("httpClient", HcHttpClient.class, client -> {
-    client.setMaxConnections(200);          // Total connections
-    client.setMaxConnectionsPerRoute(20);   // Per-host connections
-    client.setConnectionTimeout(30000);     // Connection timeout
-    client.setSocketTimeout(60000);         // Read timeout
-});
-```
-
-### Memory Management
-
-```java
-// Configure memory usage
-crawler.crawlerContext.setMaxAccessCount(10000);     // Limit crawled URLs
-crawler.crawlerContext.setMaxDepth(5);               // Limit crawl depth
-
-// Use streaming for large files
-container.singleton("fileTransformer", FileTransformer.class, transformer -> {
-    transformer.setMaxContentSize(10 * 1024 * 1024); // 10MB limit
-});
+```bash
+mvn javadoc:jar
 ```
 
 ## Troubleshooting
 
-### Common Issues
+**Container fails to start with `ClassNotFoundException: jakarta.transaction.Transactional$TxType`**
+Add `jakarta.transaction:jakarta.transaction-api` to your dependencies — `fess-crawler-lasta`
+declares it as `provided`.
 
-#### Connection Timeouts
-```java
-// Increase timeout values
-client.setConnectionTimeout(60000);  // 60 seconds
-client.setSocketTimeout(120000);     // 120 seconds
-```
+**Nothing is crawled beyond the seed URL**
+Include filters are required for child URLs. `crawler.addUrl(url)` alone does not authorize the
+crawler to follow links; add `crawler.addIncludeFilter(url + ".*")`. Also check `setMaxDepth`.
 
-#### Memory Issues
-```java
-// Reduce concurrent threads and batch sizes
-crawler.crawlerContext.setNumOfThread(5);
-crawler.crawlerContext.setMaxAccessCount(1000);
-```
+**Crawl stops early**
+Check `setMaxAccessCount` and `setMaxDepth`, and whether `robots.txt` disallows the paths — set
+`useRobotsTxtDisallows` to `false` on the HTTP client only when you are authorized to ignore it.
 
-#### SSL/TLS Issues
-```java
-// Configure SSL settings
-container.singleton("httpClient", HcHttpClient.class, client -> {
-    client.setTrustAllCertificates(true);  // For testing only
-});
-```
+**Timeouts on slow servers**
+Raise `connectionTimeout` and `soTimeout` on the HTTP client, and `accessTimeout` on the client base.
+
+**Large files are truncated or skipped**
+Raise `ContentLengthHelper.defaultMaxLength` (10 MB default) or add a per-MIME-type override, and
+raise the client's `maxContentLength`.
+
+**High memory use**
+Lower `setNumOfThread`, lower `maxCachedContentSize` so bodies spill to disk sooner, and keep
+`ContentLengthHelper` limits tight.
 
 ### Debug Logging
-
-Enable debug logging by adding to your logging configuration:
 
 ```xml
 <logger name="org.codelibs.fess.crawler" level="DEBUG"/>
@@ -498,53 +545,16 @@ Enable debug logging by adding to your logging configuration:
 <logger name="org.codelibs.fess.crawler.extractor" level="DEBUG"/>
 ```
 
-### Monitoring
-
-```java
-// Monitor crawling progress
-while (crawler.crawlerContext.getStatus() == CrawlerStatus.RUNNING) {
-    int processed = dataService.getCount(sessionId);
-    System.out.println("Processed: " + processed + " URLs");
-    Thread.sleep(5000);
-}
-```
-
 ## Contributing
 
-We welcome contributions to Fess Crawler! Please follow these guidelines:
+1. Fork the repository and create a feature branch
+2. Add tests for your change (JUnit 5)
+3. Run `mvn formatter:format && mvn license:format`
+4. Run `mvn package` — this catches Javadoc and license failures that `mvn test` does not
+5. Open a pull request against `master`
 
-1. **Fork** the repository
-2. **Create** a feature branch (`git checkout -b feature/amazing-feature`)
-3. **Commit** your changes (`git commit -m 'Add amazing feature'`)
-4. **Push** to the branch (`git push origin feature/amazing-feature`)
-5. **Open** a Pull Request
-
-### Development Setup
-
-```bash
-# Clone the repository
-git clone https://github.com/codelibs/fess-crawler.git
-cd fess-crawler
-
-# Build the project
-mvn clean install
-
-# Run tests
-mvn test
-
-# Format code before committing
-mvn formatter:format
-mvn license:format
-```
-
-### Code Style
-
-- Follow Java coding conventions
-- Use proper JavaDoc comments for public APIs
-- Include unit tests for new functionality
-- Ensure all tests pass before submitting PR
+Bug reports and feature requests: https://github.com/codelibs/fess-crawler/issues
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
-
+Apache License 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Brings `README.md` and `CLAUDE.md` back in line with the current source. The immediate trigger was the broken Maven Central badge, but the docs had drifted far enough that most of the README's code examples no longer compiled.

## Badges

`maven-badges.herokuapp.com` now returns **404** (Heroku retired the free tier). Replaced with a shields.io Maven Central badge pointing at `fess-crawler` — the artifact users actually depend on — and added a javadoc.io badge. All badge and link targets verified to return 200.

## Corrections

Every item below was checked against the source, not inferred:

| Documented | Actual |
| --- | --- |
| `15.2.0-SNAPSHOT` | current release |
| JUnit 4 | JUnit 5 (Jupiter) — there is no `junit:junit` dependency |
| `crawler.crawlerContext` / `crawler.urlFilter` | both `protected`; external code needs the delegating setters |
| `container.singleton("httpClient", HcHttpClient.class, ...)` | `HcHttpClient` is **abstract** — use `Hc5HttpClient` |
| `setSocketTimeout` | `setSoTimeout` |
| `setMaxConnections` | `setMaxTotalConnections` (init-param key is the singular `maxTotalConnection`) |
| `setTrustAllCertificates` | `setIgnoreSslCertificate` |
| `crawlerContext.setDefaultIntervalTime(...)` | does not exist — four `delayMillis*` knobs on `DefaultIntervalController` |
| `FileTransformer.setMaxContentSize(...)` | does not exist — limits live on `ContentLengthHelper` |
| `accessResult.getContent()` | `getAccessResultData().getDataAsString()` |
| `OpenSearchDataService` + `setIndexName`/`setHostname`/`setPort` | no no-arg constructor and no such setters; configured via `OpenSearchCrawlerConfig` |
| `ExecutionTimeoutException` under `CrawlerSystemException` | under `ExtractException` |
| `MultipleCrawlingAccessException` under `CrawlerSystemException` | under `CrawlingAccessException` |
| max line length 120 | **140** (per the shared formatter config in `fess-parent`) |

The old "Basic Usage" example registered three components as singletons. `StandardCrawlerContainer` instantiates eagerly, so `@Resource` injection resolved to `null` and `addUrl()` NPE'd; a crawl needs roughly 25 components. The in-repo tests never caught this because they live in the same package as `Crawler` and so can reach its protected fields.

## What replaced it

The Quick Start is now the Lasta DI bootstrap — `SingletonLaContainerFactory.setConfigPath("crawler.xml")` + `init()` — which gives a fully wired crawler in a few lines. It was compiled and **run** against the built jars: it crawls a seed page, follows child links, and reports results through `DataService`.

Every Java snippet in the README was extracted and compiled against `fess-crawler` and `fess-crawler-lasta`. The DI override examples were booted in a real container and their effects asserted.

## Newly documented

- `s3://` and `gcs://` clients, and that `S3Client` falls back to the **AWS default credentials provider chain** when `accessKey`/`secretKey` are blank (IAM roles, IRSA, instance profiles)
- `HtmlExtractor` extracts default metadata by default; JSON-LD is opt-in
- Weight-based extractor selection and `ExtractorBuilder` for extracting from a stream without crawling
- Content-length caps are enforced *during* download, not after buffering
- `fess-crawler-lasta` declares `jakarta.transaction-api` as `provided`, so consumers must add it or startup fails with `ClassNotFoundException: jakarta.transaction.Transactional$TxType`
- `ZipExtractor`, `TarExtractor`, `ApiExtractor` and `CommandExtractor` ship in the jar but are **not** in the default DI
- Redefining `extractorFactory` in a DI file that includes `crawler.xml` replaces it wholesale and silently drops every default MIME mapping — verified: `getExtractor("text/html")` returns `null`. The README now shows appending instead, with a warning
- CI runs `mvn -B package` on a single JDK 21, so `javadoc:jar` and `license:check` gate the build even when `mvn test` is green
- JaCoCo reports coverage but enforces no threshold — the ">80%" line was aspirational
- Surefire runs test classes in parallel; `JodExtractorTest` is excluded; several tests need Docker

## Notes

Documentation only — no source or build changes.
