### PR TITLE
build: declare central-publishing-maven-plugin explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,16 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<!-- This project publishes to Maven Central. fess-parent only manages this
+			     plugin in pluginManagement, because the Fess plugins deploy to
+			     maven.codelibs.org instead. -->
+			<plugin>
+				<groupId>org.sonatype.central</groupId>
+				<artifactId>central-publishing-maven-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
 	</build>
 	<repositories>
 		<repository>


### PR DESCRIPTION
## Summary

Companion change for codelibs/fess-parent#61. Maven Central introduced an upload limit that
makes it impractical to keep releasing the Fess plugin artifacts there, so `fess-parent` moved
`central-publishing-maven-plugin` from `build/plugins` to `pluginManagement` and the plugin
repositories now deploy to `maven.codelibs.org`.

`fess-crawler` stays on Maven Central, so it declares the plugin itself. The `version` and the
`publishingServerId` configuration are still inherited from `fess-parent`.

The declaration is inheritable (no `inherited=false`), so `fess-crawler`,
`fess-crawler-lasta` and `fess-crawler-opensearch` are all published exactly as before.

## Verification

- Before the change: `mvn validate` no longer logged `Installing Central Publishing features`
  (i.e. the Maven Central path had been lost)
- After the change: `Inspecting build with total of 4 modules` and
  `Installing Central Publishing features` are logged again
- `mvn package -DskipTests` succeeds for all four modules

## Depends on

codelibs/fess-parent#61 (must be merged first)
