### PR TITLE
fix(crawler): scope the charset declaration scan to meta tags

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformer.java
@@ -133,8 +133,23 @@ public class HtmlTransformer extends AbstractTransformer {
     /** Precompiled pattern for collapsing repeated slashes (except after a scheme colon) in {@link #normalizeUrl(String)}. */
     private static final Pattern MULTI_SLASH_PATTERN = Pattern.compile("([^:])/+");
 
-    /** Precompiled pattern for extracting a charset value from a content string in {@link #parseCharset(String)}. */
-    private static final Pattern CHARSET_PATTERN = Pattern.compile("; *charset *= *([a-zA-Z0-9\\-_]+)", Pattern.CASE_INSENSITIVE);
+    /**
+     * Precompiled pattern for extracting a charset value from a content string in {@link #parseCharset(String)}.
+     * <p>
+     * The {@code ; charset=} part is deliberately anchored to an opening {@code <meta} tag. The string it is
+     * matched against is the first {@link #preloadSizeForCharset} bytes of the raw response body, which is neither
+     * parsed nor guaranteed to be well-formed HTML, so without that anchor any occurrence of {@code ; charset=}
+     * in ordinary body text (an article about character encodings, a code sample, ...) would be picked up as the
+     * declared encoding of the whole document.
+     * <p>
+     * The tag is delimited with {@code [^<>]*} rather than by matching a complete {@code <meta ...>} element on
+     * purpose: {@code >} keeps the match from running past the end of the tag into the body, {@code <} stops it at
+     * the next tag when the {@code <meta>} tag itself is malformed, and requiring neither a closing quote nor a
+     * closing {@code >} still detects a declaration in a tag that the preload window cut in half. A negated
+     * character class also matches line terminators, so attributes spread over several lines are handled.
+     */
+    private static final Pattern CHARSET_PATTERN =
+            Pattern.compile("<meta\\s[^<>]*; *charset *= *([a-zA-Z0-9\\-_]+)", Pattern.CASE_INSENSITIVE);
 
     /** The crawler container for dependency injection. */
     @Resource
@@ -467,6 +482,11 @@ public class HtmlTransformer extends AbstractTransformer {
 
     /**
      * Parses the charset from the content string.
+     * <p>
+     * Only a {@code charset} parameter declared inside a {@code <meta>} tag, such as
+     * {@code <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">}, is recognized. An occurrence
+     * elsewhere in the content, for example in body text, is ignored. The HTML5 short form
+     * {@code <meta charset="...">} is not recognized because it carries no {@code ;} separator.
      *
      * @param content the content to parse
      * @return the parsed charset name, or null if not found

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformerTest.java
@@ -137,27 +137,109 @@ public class HtmlTransformerTest extends PlainTestCase {
     public void test_parseCharset() {
         String content;
 
-        content = "...;charset=UTF-8\"...";
+        content = "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=UTF-8\">";
         assertEquals("UTF-8", htmlTransformer.parseCharset(content));
 
-        content = "...; charset=UTF-8\"...";
+        content = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">";
         assertEquals("UTF-8", htmlTransformer.parseCharset(content));
 
-        content = "...;charset = UTF-8\"...";
+        content = "<meta http-equiv=\"Content-Type\" content=\"text/html;charset = UTF-8\">";
         assertEquals("UTF-8", htmlTransformer.parseCharset(content));
 
-        content = "...;charset=UTF-8 \"...";
+        content = "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=UTF-8 \">";
         assertEquals("UTF-8", htmlTransformer.parseCharset(content));
 
-        content = "...;charset=Shift_JIS\"...";
+        content = "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=Shift_JIS\">";
         assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
 
-        content = "...;Charset=Shift_JIS\"...";
+        content = "<meta http-equiv=\"Content-Type\" content=\"text/html;Charset=Shift_JIS\">";
         assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
 
-        content = "...;charset=EUC-JP\"...";
+        content = "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=EUC-JP\">";
         assertEquals("EUC-JP", htmlTransformer.parseCharset(content));
 
+    }
+
+    @Test
+    public void test_parseCharset_metaTagVariations() {
+        String content;
+
+        // upper case tag and attribute names
+        content = "<META HTTP-EQUIV=\"Content-Type\" CONTENT=\"text/html; charset=EUC-JP\">";
+        assertEquals("EUC-JP", htmlTransformer.parseCharset(content));
+
+        // unquoted attribute values
+        content = "<meta http-equiv=Content-Type content=text/html; charset=Shift_JIS>";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+
+        // attributes split over several lines
+        content = "<meta http-equiv=\"Content-Type\"\n      content=\"text/html; charset=Shift_JIS\">";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+
+        // XHTML style self-closing tag
+        content = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS\" />";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+
+        // the preloaded window cuts the tag before its closing quote and bracket
+        content = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+
+        // the declaration is preceded by other meta tags
+        content = "<html><head><meta name=\"viewport\" content=\"width=device-width\">"
+                + "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS\"></head>";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+    }
+
+    @Test
+    public void test_parseCharset_outsideMetaTag() {
+        String content;
+
+        // body text merely mentioning a content type must not be treated as a declaration
+        content = "<html><head><title>test</title></head>" + "<body><p>Content-Type: text/html; charset=Shift_JIS</p></body></html>";
+        assertNull(htmlTransformer.parseCharset(content));
+
+        // a meta tag without a charset must not let the following text match
+        content = "<html><head><meta name=\"viewport\" content=\"width=device-width\"></head>"
+                + "<body>text/html; charset=EUC-JP</body></html>";
+        assertNull(htmlTransformer.parseCharset(content));
+
+        // an attribute of a non-meta tag must not match either
+        content = "<html><body><span data-type=\"text/html; charset=EUC-JP\">x</span></body></html>";
+        assertNull(htmlTransformer.parseCharset(content));
+
+        // no declaration at all
+        content = "<html><head><title>test</title></head><body>hello</body></html>";
+        assertNull(htmlTransformer.parseCharset(content));
+    }
+
+    @Test
+    public void test_transform_charsetInBodyText() throws Exception {
+        // a UTF-8 page whose body only mentions a charset must keep its own encoding
+        final String content = "<html><head><title>文字コード</title></head>" + "<body><p>Content-Type: text/html; charset=Shift_JIS</p>" //
+                + "<p>こんにちは</p></body></html>";
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://hoge/test.html");
+        responseData.setResponseBody(content.getBytes(Constants.UTF_8));
+        responseData.setMimeType("text/html");
+        final ResultData resultData = htmlTransformer.transform(responseData);
+        assertEquals(Constants.UTF_8, responseData.getCharSet());
+        assertEquals(Constants.UTF_8, resultData.getEncoding());
+        assertEquals(content, new String(resultData.getData(), resultData.getEncoding()));
+    }
+
+    @Test
+    public void test_transform_charsetInMetaTag() throws Exception {
+        // a declared charset is still honoured
+        final String content = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS\">"
+                + "</head><body><p>こんにちは</p></body></html>";
+        final ResponseData responseData = new ResponseData();
+        responseData.setUrl("http://hoge/test.html");
+        responseData.setResponseBody(content.getBytes("Shift_JIS"));
+        responseData.setMimeType("text/html");
+        final ResultData resultData = htmlTransformer.transform(responseData);
+        assertEquals("Shift_JIS", responseData.getCharSet());
+        assertEquals("Shift_JIS", resultData.getEncoding());
+        assertEquals(content, new String(resultData.getData(), resultData.getEncoding()));
     }
 
     @Test


### PR DESCRIPTION
## Problem

`HtmlTransformer.loadCharset` reads the first `preloadSizeForCharset` bytes of a response body (2048 by default) and runs `CHARSET_PATTERN` over that whole window:

```java
private static final Pattern CHARSET_PATTERN = Pattern.compile("; *charset *= *([a-zA-Z0-9\\-_]+)", Pattern.CASE_INSENSITIVE);
```

The pattern is not tied to a `<meta>` tag, so a bare `; charset=<name>` anywhere in those bytes counts as the document's declared encoding. Ordinary body text matches it: an article about character encodings, a code sample, a quoted HTTP header. `updateCharset` then overwrites the response charset with the value it found and the whole document decodes as mojibake.

The scan lives in the transformer, not in a transport, so this reaches every crawler client rather than one of them.

## Fix

The pattern is anchored to an opening `<meta` tag:

```java
Pattern.compile("<meta\\s[^<>]*; *charset *= *([a-zA-Z0-9\\-_]+)", Pattern.CASE_INSENSITIVE)
```

`parseCharset(String)` keeps its signature and its `protected` visibility, so an override or a caller outside this repository still compiles.

### Why the tag is delimited with `[^<>]*`

The string being matched is raw response bytes: not parsed, not necessarily well formed, and cut at an arbitrary byte offset. Matching a complete `<meta ...>` element would assume more structure than that window has, so the tag is bounded by a negated character class instead.

- `>` stops the match at the end of the tag, which is what keeps body text after a `<meta>` tag from matching.
- `<` stops it at the next tag, so a malformed, never-closed `<meta` does not swallow the document.
- Neither a closing quote nor a closing `>` is required, so a declaration still resolves when the preload window cuts the tag in half. Requiring the full element would silently lose those pages.
- A negated character class matches line terminators, so attributes spread over several lines keep working.

The trade-off is a `<meta>` tag that carries a literal `>` inside an attribute value placed *before* `content=`; that tag is no longer read. Bounding the scan without a tokenizer cannot avoid it, and it is far rarer than the misdetection being fixed.

`HtmlExtractor.metaCharsetPattern` already scopes to `<meta>` in this repository, so this brings the transformer in line with the extractor.

## Scope

Recognising the HTML5 short form `<meta charset="...">` is deliberately **not** part of this change. It is a separate behaviour change: the short form has no `;`, so it never matched before either, and pages that declare only it are currently read as UTF-8 by default, which is almost always what they are. Turning it on also changes which pages the Playwright client and this transformer agree about (see below), which is a wider blast radius than this fix needs. It is worth considering in a separate PR, together with the Playwright side.

## The existing test

`test_parseCharset` asserted on bare fragments:

```java
content = "...;charset=UTF-8\"...";
assertEquals("UTF-8", htmlTransformer.parseCharset(content));
```

The ellipses and the trailing `"` abbreviate the `<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">` those values come from. The test was pinning the shape of the regex — its tolerance of spacing and letter case — not a rule that a declaration may appear anywhere in the document. The inputs are expanded to the markup they abbreviate and **every expectation is kept unchanged**; no expected value was rewritten to make the suite green.

New tests:

- `test_parseCharset_outsideMetaTag` — body text, a `<meta>` tag with no charset followed by matching text, and a non-`<meta>` attribute all return `null`.
- `test_transform_charsetInBodyText` — end to end: a UTF-8 page whose body mentions `; charset=Shift_JIS` keeps UTF-8 and round-trips its Japanese text.
- `test_transform_charsetInMetaTag` — the counterpart: a declared Shift_JIS page is still detected and still round-trips.
- `test_parseCharset_metaTagVariations` — upper case, unquoted, self-closing, multi-line and window-truncated tags.

The two negative tests fail on `master` (`expected: <null> but was: <Shift_JIS>`, `expected: <UTF-8> but was: <Shift_JIS>`) and pass with this change.

## Follow-up required in fess-crawler-playwright

**codelibs/fess-crawler-playwright#64 duplicates this exact pattern on purpose** and has to be updated in lockstep. That PR mirrors the rule so `PlaywrightClient` encodes the bytes it emits with the charset this transformer will read them back with; if the two rules diverge, the disagreement it exists to prevent comes back. It pins the rule with `test_downstreamContract`, which calls the real `parseCharset` and `getPreloadSizeForCharset` and will turn red against this change — by design.

That side needs:

- `CONTENT_CHARSET_PATTERN` changed to `<meta\s[^<>]*; *charset *= *([a-zA-Z0-9\-_]+)`, and its Javadoc, plus the paragraph in `encodeContent` that describes the rule as "not anchored to a meta tag", updated to match.
- `test_downstreamContract`: the assertion that body text counts as a declaration inverted to `assertNull`.
- `test_encodeContent_declarationInsideWindow` and `test_encodeContent_declarationOutsideWindow`: their `<span>; charset=Shift_JIS</span>` replaced with a real `<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">`, so the window assertions still exercise a declaration both sides can see.

`scanCharset` decodes the window as ISO-8859-1, which preserves `<meta` as well as it preserves `; charset=`, so the anchoring needs no other change there.

## Verification

- `mvn -o clean test` over all three modules: `Tests run: 2055, Failures: 0, Errors: 0, Skipped: 0` in `fess-crawler`, all modules green.
- `mvn -o -B clean package -DskipTests` from a clean tree, so `javadoc:jar` is exercised rather than served from a stale `target/`.
