### PR TITLE
fix: read the proxy credentials as the configuration type they are

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/Hc4HttpClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/Hc4HttpClient.java
@@ -1083,7 +1083,7 @@ public class Hc4HttpClient extends HcHttpClient {
             final HttpHost proxy = new HttpHost(proxyHost, proxyPort);
             final DefaultProxyRoutePlanner defaultRoutePlanner = new DefaultProxyRoutePlanner(proxy);
 
-            final Credentials credentials = getInitParameter(PROXY_CREDENTIALS_PROPERTY, proxyCredentials, Credentials.class);
+            final Credentials credentials = getProxyCredentials();
             if (credentials != null) {
                 credentialsProvider.setCredentials(new AuthScope(proxyHost, proxyPort), credentials);
                 final AuthScheme authScheme = getInitParameter(PROXY_AUTH_SCHEME_PROPERTY, proxyAuthScheme, AuthScheme.class);
@@ -1418,6 +1418,34 @@ public class Hc4HttpClient extends HcHttpClient {
             }
         }
         return result.toArray(new Hc4Authentication[0]);
+    }
+
+    /**
+     * Resolves the credentials to authenticate with the configured proxy.
+     *
+     * <p>{@link WebAuthenticationConfig} is the library-independent shape a crawl config configures a
+     * proxy authentication in. Credentials set on this client directly are still accepted.</p>
+     *
+     * <p>The value is matched with {@code instanceof} rather than read through
+     * {@code getInitParameter}, which casts unchecked: a value of a shape the cast does not name threw
+     * {@link ClassCastException} instead of being ignored, which failed the crawl rather than the proxy
+     * authentication.</p>
+     *
+     * @return The proxy credentials, or null when none are configured.
+     */
+    protected Credentials getProxyCredentials() {
+        final Object value = initParamMap != null ? initParamMap.get(PROXY_CREDENTIALS_PROPERTY) : null;
+        if (value == null) {
+            return proxyCredentials;
+        }
+        if (value instanceof final WebAuthenticationConfig config) {
+            return convertCredentials(config.getCredentials());
+        }
+        if (value instanceof final Credentials credentials) {
+            return credentials;
+        }
+        logger.warn("Unknown proxy credentials type: type={}", value.getClass().getName());
+        return proxyCredentials;
     }
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/Hc5HttpClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/Hc5HttpClient.java
@@ -595,6 +595,56 @@ public class Hc5HttpClient extends HcHttpClient {
     }
 
     /**
+     * Resolves the credentials to authenticate with the configured proxy.
+     *
+     * <p>{@link WebAuthenticationConfig} is the library-independent shape a crawl config configures a
+     * proxy authentication in. Credentials set on this client directly are still accepted, as is the
+     * HC4 shape earlier callers handed over.</p>
+     *
+     * <p>The value is matched with {@code instanceof} rather than read through
+     * {@code getInitParameter}, which casts unchecked: a value of a shape the cast does not name threw
+     * {@link ClassCastException} instead of being ignored, which failed the crawl rather than the proxy
+     * authentication.</p>
+     *
+     * @return The proxy credentials, or null when none are configured.
+     */
+    protected Credentials getProxyCredentials() {
+        final Object value = initParamMap != null ? initParamMap.get(PROXY_CREDENTIALS_PROPERTY) : null;
+        if (value == null) {
+            return proxyCredentials;
+        }
+        if (value instanceof final WebAuthenticationConfig config) {
+            return convertCredentials(config.getCredentials());
+        }
+        if (value instanceof final Credentials credentials) {
+            return credentials;
+        }
+        if (value instanceof final org.apache.http.auth.Credentials hc4Credentials) {
+            return convertFromHc4Credentials(hc4Credentials);
+        }
+        logger.warn("Unknown proxy credentials type: type={}", value.getClass().getName());
+        return proxyCredentials;
+    }
+
+    /**
+     * Converts HC4 credentials to HC5 credentials.
+     * This provides backward compatibility for existing configurations.
+     *
+     * @param hc4Credentials the HC4 credentials
+     * @return the HC5 credentials, or null if the credentials are null or of an unknown type
+     */
+    protected Credentials convertFromHc4Credentials(final org.apache.http.auth.Credentials hc4Credentials) {
+        if (hc4Credentials instanceof final org.apache.http.auth.NTCredentials nt) {
+            return new NTCredentials(nt.getUserName(), nt.getPassword() != null ? nt.getPassword().toCharArray() : null,
+                    nt.getWorkstation(), nt.getDomain());
+        }
+        if (hc4Credentials instanceof final org.apache.http.auth.UsernamePasswordCredentials up) {
+            return new UsernamePasswordCredentials(up.getUserName(), up.getPassword() != null ? up.getPassword().toCharArray() : null);
+        }
+        return null;
+    }
+
+    /**
      * Converts HC4 Hc4Authentication array to HC5 Hc5Authentication array.
      * This provides backward compatibility for existing configurations.
      *
@@ -609,17 +659,7 @@ public class Hc5HttpClient extends HcHttpClient {
                 final AuthScope hc5Scope =
                         new AuthScope(hc4Scope.getScheme(), hc4Scope.getHost(), hc4Scope.getPort(), hc4Scope.getRealm(), null);
 
-                final org.apache.http.auth.Credentials hc4Creds = hc4Auth.getCredentials();
-                Credentials hc5Creds = null;
-                if (hc4Creds instanceof org.apache.http.auth.UsernamePasswordCredentials) {
-                    final org.apache.http.auth.UsernamePasswordCredentials up = (org.apache.http.auth.UsernamePasswordCredentials) hc4Creds;
-                    hc5Creds = new UsernamePasswordCredentials(up.getUserName(),
-                            up.getPassword() != null ? up.getPassword().toCharArray() : null);
-                } else if (hc4Creds instanceof org.apache.http.auth.NTCredentials) {
-                    final org.apache.http.auth.NTCredentials nt = (org.apache.http.auth.NTCredentials) hc4Creds;
-                    hc5Creds = new NTCredentials(nt.getUserName(), nt.getPassword() != null ? nt.getPassword().toCharArray() : null,
-                            nt.getWorkstation(), nt.getDomain());
-                }
+                final Credentials hc5Creds = convertFromHc4Credentials(hc4Auth.getCredentials());
 
                 AuthScheme hc5AuthScheme = null;
                 final org.apache.http.auth.AuthScheme hc4AuthScheme = hc4Auth.getAuthScheme();
@@ -1322,7 +1362,7 @@ public class Hc5HttpClient extends HcHttpClient {
             final HttpHost proxy = new HttpHost(proxyHost, proxyPort);
             final DefaultProxyRoutePlanner defaultRoutePlanner = new DefaultProxyRoutePlanner(proxy);
 
-            final Credentials credentials = getInitParameter(PROXY_CREDENTIALS_PROPERTY, proxyCredentials, Credentials.class);
+            final Credentials credentials = getProxyCredentials();
             if (credentials != null) {
                 credentialsProvider.setCredentials(new AuthScope(proxyHost, proxyPort), credentials);
                 final AuthScheme authScheme = getInitParameter(PROXY_AUTH_SCHEME_PROPERTY, proxyAuthScheme, AuthScheme.class);

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/HcHttpClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/HcHttpClient.java
@@ -29,7 +29,7 @@ import org.codelibs.fess.crawler.client.AbstractCrawlerClient;
  *   <li>PROXY_HOST_PROPERTY: Proxy host setting.</li>
  *   <li>PROXY_PORT_PROPERTY: Proxy port setting.</li>
  *   <li>PROXY_AUTH_SCHEME_PROPERTY: Proxy authentication scheme.</li>
- *   <li>PROXY_CREDENTIALS_PROPERTY: Proxy credentials.</li>
+ *   <li>PROXY_CREDENTIALS_PROPERTY: Proxy credentials, as a WebAuthenticationConfig.</li>
  *   <li>USER_AGENT_PROPERTY: User agent string.</li>
  *   <li>ROBOTS_TXT_ENABLED_PROPERTY: Enable or disable robots.txt parsing.</li>
  *   <li>AUTHENTICATIONS_PROPERTY: Web authentications.</li>
@@ -63,7 +63,11 @@ public abstract class HcHttpClient extends AbstractCrawlerClient {
     /** Property name for proxy authentication scheme setting */
     public static final String PROXY_AUTH_SCHEME_PROPERTY = "proxyAuthScheme";
 
-    /** Property name for proxy credentials setting */
+    /**
+     * Property name for proxy credentials setting.
+     * The value is a {@code WebAuthenticationConfig} carrying the credentials to authenticate with the
+     * proxy; credentials of the underlying HTTP library are accepted as well.
+     */
     public static final String PROXY_CREDENTIALS_PROPERTY = "proxyCredentials";
 
     /** Property name for user agent setting */

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/ProxyCredentialsConfigTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/ProxyCredentialsConfigTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.client.http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codelibs.fess.crawler.client.http.config.CredentialsConfig;
+import org.codelibs.fess.crawler.client.http.config.WebAuthenticationConfig;
+import org.dbflute.utflute.core.PlainTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests how the HTTP clients read the credentials configured for the proxy.
+ *
+ * <p>The shape that matters is the library-independent one a crawl config produces:
+ * {@link WebAuthenticationConfig}. Both clients used to read the parameter as their own library's
+ * {@code Credentials}, which threw {@link ClassCastException} at the call site - failing the crawl
+ * rather than the proxy authentication - for every other shape, including the one the other library
+ * uses.</p>
+ */
+public class ProxyCredentialsConfigTest extends PlainTestCase {
+
+    private WebAuthenticationConfig createConfig(final String username, final String password) {
+        final WebAuthenticationConfig config = new WebAuthenticationConfig();
+        final CredentialsConfig credentials = new CredentialsConfig();
+        credentials.setUsername(username);
+        credentials.setPassword(password);
+        config.setCredentials(credentials);
+        return config;
+    }
+
+    private Map<String, Object> createInitParamMap(final Object proxyCredentials) {
+        final Map<String, Object> initParamMap = new HashMap<>();
+        if (proxyCredentials != null) {
+            initParamMap.put(HcHttpClient.PROXY_CREDENTIALS_PROPERTY, proxyCredentials);
+        }
+        return initParamMap;
+    }
+
+    private Hc5HttpClient createHc5Client(final Object proxyCredentials) {
+        final Hc5HttpClient client = new Hc5HttpClient();
+        client.setInitParameterMap(createInitParamMap(proxyCredentials));
+        return client;
+    }
+
+    private Hc4HttpClient createHc4Client(final Object proxyCredentials) {
+        final Hc4HttpClient client = new Hc4HttpClient();
+        client.setInitParameterMap(createInitParamMap(proxyCredentials));
+        return client;
+    }
+
+    @Test
+    public void test_hc5_config() {
+        final org.apache.hc.client5.http.auth.Credentials credentials =
+                createHc5Client(createConfig("proxyuser", "proxypass")).getProxyCredentials();
+
+        assertNotNull(credentials);
+        assertEquals("proxyuser", credentials.getUserPrincipal().getName());
+        assertEquals("proxypass", new String(credentials.getPassword()));
+    }
+
+    @Test
+    public void test_hc5_ntlmConfig() {
+        final WebAuthenticationConfig config = createConfig("proxyuser", "proxypass");
+        config.getCredentials().setType(CredentialsConfig.CredentialsType.NTLM);
+        config.getCredentials().setDomain("MYDOMAIN");
+        config.getCredentials().setWorkstation("MYWORKSTATION");
+
+        final org.apache.hc.client5.http.auth.Credentials credentials = createHc5Client(config).getProxyCredentials();
+
+        assertTrue(credentials instanceof org.apache.hc.client5.http.auth.NTCredentials);
+        assertEquals("MYDOMAIN\\proxyuser", credentials.getUserPrincipal().getName());
+    }
+
+    /**
+     * Credentials of the client's own library are still accepted.
+     */
+    @Test
+    public void test_hc5_ownCredentials() {
+        final org.apache.hc.client5.http.auth.UsernamePasswordCredentials configured =
+                new org.apache.hc.client5.http.auth.UsernamePasswordCredentials("proxyuser", "proxypass".toCharArray());
+
+        assertTrue(createHc5Client(configured).getProxyCredentials() == configured);
+    }
+
+    /**
+     * The HC4 shape earlier callers handed over is converted rather than thrown on.
+     */
+    @Test
+    public void test_hc5_hc4Credentials() {
+        final org.apache.hc.client5.http.auth.Credentials credentials =
+                createHc5Client(new org.apache.http.auth.UsernamePasswordCredentials("proxyuser", "proxypass")).getProxyCredentials();
+
+        assertNotNull(credentials);
+        assertEquals("proxyuser", credentials.getUserPrincipal().getName());
+        assertEquals("proxypass", new String(credentials.getPassword()));
+    }
+
+    @Test
+    public void test_hc5_unsupportedShape() {
+        assertNull(createHc5Client("not a credential").getProxyCredentials());
+    }
+
+    @Test
+    public void test_hc5_noParameter() {
+        assertNull(createHc5Client(null).getProxyCredentials());
+
+        final Hc5HttpClient clientWithoutMap = new Hc5HttpClient();
+        clientWithoutMap.setInitParameterMap(null);
+        assertNull(clientWithoutMap.getProxyCredentials());
+    }
+
+    @Test
+    public void test_hc4_config() {
+        final org.apache.http.auth.Credentials credentials = createHc4Client(createConfig("proxyuser", "proxypass")).getProxyCredentials();
+
+        assertNotNull(credentials);
+        assertEquals("proxyuser", credentials.getUserPrincipal().getName());
+        assertEquals("proxypass", credentials.getPassword());
+    }
+
+    /**
+     * Credentials of the client's own library are still accepted.
+     */
+    @Test
+    public void test_hc4_ownCredentials() {
+        final org.apache.http.auth.UsernamePasswordCredentials configured =
+                new org.apache.http.auth.UsernamePasswordCredentials("proxyuser", "proxypass");
+
+        assertTrue(createHc4Client(configured).getProxyCredentials() == configured);
+    }
+
+    @Test
+    public void test_hc4_unsupportedShape() {
+        assertNull(createHc4Client("not a credential").getProxyCredentials());
+    }
+
+    @Test
+    public void test_hc4_noParameter() {
+        assertNull(createHc4Client(null).getProxyCredentials());
+    }
+}


### PR DESCRIPTION
## Problem

Fess configures the proxy credentials as an HC4 `org.apache.http.auth.UsernamePasswordCredentials`, in all three places that build a crawl's init parameters. `Hc5HttpClient` — the default client since the HttpComponents 5.x migration — reads that parameter as an HC5 `org.apache.hc.client5.http.auth.Credentials`:

```java
final Credentials credentials = getInitParameter(PROXY_CREDENTIALS_PROPERTY, proxyCredentials, Credentials.class);
```

`AbstractCrawlerClient#convertObj` ends in an unchecked `(T) value`, and the `checkcast` the compiler inserts lands at the call site — outside `getInitParameter`'s own `try`. So the mismatch is not ignored, and it is not confined to the proxy authentication either:

```
java.lang.ClassCastException: class org.apache.http.auth.UsernamePasswordCredentials
  cannot be cast to class org.apache.hc.client5.http.auth.Credentials
```

Every crawl that runs behind an authenticated proxy fails. Nothing catches it, because the only tests that set this parameter build an HC5 `UsernamePasswordCredentials` — a shape no crawl config produces.

## Fix

Read the parameter as `WebAuthenticationConfig`, the library-independent shape the `webAuthentications` parameter already uses, and match it with `instanceof` rather than casting:

- a `WebAuthenticationConfig` is converted with the `convertCredentials` each client already has,
- credentials of the client's own library — what `setProxyCredentials` takes — are still returned as they are,
- `Hc5HttpClient` converts the HC4 shape as well, the same backward compatibility `getAuthenticationArray` already offers, so an unchanged caller keeps working,
- anything else is logged and skipped, which fails the proxy authentication rather than the crawl.

Both clients are treated the same way, since `SwitchableHttpClient` picks between them at runtime.

The HC4 → HC5 credentials conversion `convertFromHc4Authentication` did inline is now a method of its own, so the two paths cannot drift.

## Tests

`ProxyCredentialsConfigTest` (new) pins the read for both clients: the configured shape, an NTLM configuration, the client's own credentials, the HC4 shape, the absent parameter, and an unsupported value.

Checked that they actually fail without the fix — restoring the cast fails 4 of the 10, including the HC4 case with the `ClassCastException` above.

`mvn test` is green: 2065 tests. (`FtpClientTest#test_doHead_accessTimeoutTarget` is timing-sensitive and fails intermittently on a loaded machine; it passes on its own and does not touch this code.)

## Note

`WebConfig` / `DataConfig` / `CrawlingConfig` in Fess are updated to hand over the configuration shape in codelibs/fess#3285, and the Playwright client reads it the same way in codelibs/fess-crawler-playwright#68. This change is what makes those safe: it keeps accepting what Fess sends today, so the three can land in any order.
