### PR TITLE
build: bump fess-parent to released 15.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.8.0-SNAPSHOT</version>
+		<version>15.8.0</version>
 	</parent>
 	<modules>
 		<module>fess-crawler</module>


### PR DESCRIPTION
## Summary
Points the parent POM at the released `fess-parent` 15.8.0 instead of the `15.8.0-SNAPSHOT` build.

## Changes Made
- Updated `<parent><version>` in `pom.xml` from `15.8.0-SNAPSHOT` to `15.8.0`

## Testing
- N/A (dependency version bump only)

## Breaking Changes
- None

## Additional Notes
- Requires `fess-parent` 15.8.0 to be published before this can build cleanly against the public/central repos.
