### PR TITLE
refactor(opensearch): walk search results with a point in time and search_after

### DIFF
--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/client/FesenClient.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/client/FesenClient.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.logging.log4j.LogManager;
@@ -61,6 +62,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.ClearScrollRequest;
 import org.opensearch.action.search.ClearScrollRequestBuilder;
 import org.opensearch.action.search.ClearScrollResponse;
+import org.opensearch.action.search.CreatePitAction;
 import org.opensearch.action.search.CreatePitRequest;
 import org.opensearch.action.search.CreatePitResponse;
 import org.opensearch.action.search.DeletePitRequest;
@@ -94,6 +96,8 @@ import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.Scroll;
 import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.PointInTimeBuilder;
+import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
@@ -143,7 +147,7 @@ public class FesenClient implements Client {
     private volatile boolean connected;
 
     /**
-     * Scroll for delete operations.
+     * Keep alive of the point in time used by delete operations.
      */
     protected Scroll scrollForDelete = new Scroll(TimeValue.timeValueMinutes(1));
 
@@ -607,7 +611,7 @@ public class FesenClient implements Client {
     }
 
     /**
-     * Deletes documents matching the specified query using scroll and bulk delete.
+     * Deletes documents matching the specified query using a point in time and bulk delete.
      *
      * @param index The index to delete from.
      * @param type The document type (deprecated, no longer used).
@@ -622,7 +626,7 @@ public class FesenClient implements Client {
     }
 
     /**
-     * Deletes documents matching the specified query using scroll and bulk delete.
+     * Deletes documents matching the specified query using a point in time and bulk delete.
      *
      * @param index The index to delete from.
      * @param queryBuilder The query to match documents for deletion.
@@ -630,51 +634,93 @@ public class FesenClient implements Client {
      * @throws OpenSearchAccessException if the deletion fails.
      */
     public int deleteByQuery(final String index, final QueryBuilder queryBuilder) {
-        SearchResponse response =
-                get(c -> c.prepareSearch(index).setScroll(scrollForDelete).setSize(sizeForDelete).setQuery(queryBuilder).execute());
-        String scrollId = response.getScrollId();
-        int count = 0;
+        final int[] count = new int[1];
+        pitSearch(index, scrollForDelete.keepAlive(), prepareSearch().setSize(sizeForDelete).setQuery(queryBuilder), response -> {
+            final SearchHit[] hits = response.getHits().getHits();
+            count[0] += hits.length;
+            final BulkResponse bulkResponse = get(c -> {
+                final BulkRequestBuilder bulkRequest = client.prepareBulk();
+                for (final SearchHit hit : hits) {
+                    bulkRequest.add(client.prepareDelete().setIndex(hit.getIndex()).setId(hit.getId()));
+                }
+                return bulkRequest.execute();
+            });
+            if (bulkResponse.hasFailures()) {
+                throw new OpenSearchAccessException(bulkResponse.buildFailureMessage());
+            }
+            return true;
+        });
+        return count[0];
+    }
+
+    /**
+     * Walks every document matching the given search request, one page at a time, over a point in time.
+     *
+     * <p>The pages are ordered by the request's own sort followed by a {@code _shard_doc} tiebreaker, which
+     * makes the order total so that {@code search_after} can walk it without skipping or repeating a
+     * document. The point in time is released in every case, and the walk stops as soon as the page handler
+     * returns {@code false}.</p>
+     *
+     * <p>The builder must be created by {@link #prepareSearch(String...)} <em>without</em> indices: a point in
+     * time carries the indices, routing and preference itself, and a search that repeats any of them is
+     * rejected with a 400 ({@code [indices] cannot be used with point in time}). Over HTTP such a 400 on a
+     * request with a body does not surface as an error, it hangs. Routing and preference already set on the
+     * builder are therefore moved onto the point in time and stripped off the search.</p>
+     *
+     * @param index The index to walk.
+     * @param keepAlive How long the point in time stays alive, extended by every page.
+     * @param builder The search request builder, created without indices.
+     * @param pageHandler Called once per non-empty page; returning false ends the walk.
+     */
+    public void pitSearch(final String index, final TimeValue keepAlive, final SearchRequestBuilder builder,
+            final Predicate<SearchResponse> pageHandler) {
+        builder.addSort(SortBuilders.shardDocSort());
+
+        final SearchRequest request = builder.request();
+        final CreatePitRequest createPitRequest = new CreatePitRequest(keepAlive, true, index);
+        if (request.preference() != null) {
+            createPitRequest.setPreference(request.preference());
+            request.preference(null);
+        }
+        if (request.routing() != null) {
+            createPitRequest.setRouting(request.routing());
+            request.routing((String) null);
+        }
+        final String pitId = get(c -> c.execute(CreatePitAction.INSTANCE, createPitRequest)).getId();
         try {
-            while (scrollId != null) {
+            builder.setPointInTime(new PointInTimeBuilder(pitId).setKeepAlive(keepAlive));
+            Object[] searchAfter = null;
+            while (true) {
+                if (searchAfter != null) {
+                    builder.searchAfter(searchAfter);
+                }
+                final SearchResponse response = get(c -> builder.execute());
                 final SearchHit[] hits = response.getHits().getHits();
                 if (hits.length == 0) {
                     break;
                 }
 
-                count += hits.length;
-                final BulkResponse bulkResponse = get(c -> {
-                    final BulkRequestBuilder bulkRequest = client.prepareBulk();
-                    for (final SearchHit hit : hits) {
-                        bulkRequest.add(client.prepareDelete().setIndex(hit.getIndex()).setId(hit.getId()));
-                    }
-                    return bulkRequest.execute();
-                });
-                if (bulkResponse.hasFailures()) {
-                    throw new OpenSearchAccessException(bulkResponse.buildFailureMessage());
+                if (!pageHandler.test(response)) {
+                    break;
                 }
 
-                final String previousScrollId = scrollId;
-                response = get(c -> c.prepareSearchScroll(previousScrollId).setScroll(scrollForDelete).execute());
-                scrollId = response.getScrollId();
-                if (!previousScrollId.equals(scrollId)) {
-                    clearScroll(previousScrollId);
-                }
+                searchAfter = hits[hits.length - 1].getSortValues();
             }
         } finally {
-            clearScroll(scrollId);
+            deletePitContext(pitId);
         }
-        return count;
     }
 
     /**
-     * Clears a scroll context.
+     * Releases a point in time context. A failure is logged and not rethrown, so that it cannot mask the
+     * exception that is already unwinding.
      *
-     * @param scrollId The scroll ID to clear.
+     * @param pitId The point in time ID to release.
      */
-    public void clearScroll(final String scrollId) {
-        if (scrollId != null) {
-            prepareClearScroll().addScrollId(scrollId)
-                    .execute(ActionListener.wrap(res -> {}, e -> logger.warn("Failed to clear scroll context: scrollId={}", scrollId, e)));
+    public void deletePitContext(final String pitId) {
+        if (pitId != null) {
+            deletePits(new DeletePitRequest(pitId),
+                    ActionListener.wrap(res -> {}, e -> logger.warn("Failed to delete the point in time: pitId={}", pitId, e)));
         }
     }
 
@@ -689,9 +735,10 @@ public class FesenClient implements Client {
     }
 
     /**
-     * Sets the scroll configuration for delete operations.
+     * Sets the keep alive of the point in time used by delete operations.
+     * Only the keep alive of the given value is used; no scroll context is created.
      *
-     * @param scrollForDelete The scroll configuration.
+     * @param scrollForDelete The value carrying the keep alive.
      */
     public void setScrollForDelete(final Scroll scrollForDelete) {
         this.scrollForDelete = scrollForDelete;

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/AbstractCrawlerService.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/AbstractCrawlerService.java
@@ -157,12 +157,12 @@ public abstract class AbstractCrawlerService {
     protected String index;
 
     /**
-     * Scroll timeout in milliseconds.
+     * Keep alive of the point in time used to walk search results, in milliseconds.
      */
     protected int scrollTimeout = 60000;
 
     /**
-     * Scroll size for search requests.
+     * Number of hits fetched per page when walking search results.
      */
     protected int scrollSize = 100;
 
@@ -648,47 +648,31 @@ public abstract class AbstractCrawlerService {
 
     /**
      * Deletes documents from the OpenSearch index based on the specified search criteria.
-     * Uses scroll and bulk delete operations for efficient deletion of large result sets.
+     * Walks the matching documents over a point in time and deletes them in bulk, which keeps the
+     * deletion efficient for large result sets.
      *
      * @param callback The callback to configure the search request for identifying documents to delete.
      * @throws OpenSearchAccessException if the deletion fails.
      */
     public void delete(final Consumer<SearchRequestBuilder> callback) {
-        SearchResponse response = getClient().get(c -> {
-            final SearchRequestBuilder builder = c.prepareSearch(index).setScroll(new TimeValue(scrollTimeout)).setSize(scrollSize);
-            callback.accept(builder);
-            return builder.execute();
-        });
-        String scrollId = response.getScrollId();
-        try {
-            while (scrollId != null) {
-                final SearchHits searchHits = response.getHits();
-                if (searchHits.getHits().length == 0) {
-                    break;
+        // The index is carried by the point in time, so the search itself must not name it.
+        final SearchRequestBuilder builder = getClient().prepareSearch().setSize(scrollSize);
+        callback.accept(builder);
+        getClient().pitSearch(index, new TimeValue(scrollTimeout), builder, response -> {
+            final SearchHits searchHits = response.getHits();
+            final BulkResponse bulkResponse = getClient().get(c -> {
+                final BulkRequestBuilder bulkBuilder = c.prepareBulk();
+                for (final SearchHit searchHit : searchHits) {
+                    bulkBuilder.add(c.prepareDelete().setIndex(index).setId(searchHit.getId()));
                 }
 
-                final BulkResponse bulkResponse = getClient().get(c -> {
-                    final BulkRequestBuilder bulkBuilder = c.prepareBulk();
-                    for (final SearchHit searchHit : searchHits) {
-                        bulkBuilder.add(c.prepareDelete().setIndex(index).setId(searchHit.getId()));
-                    }
-
-                    return bulkBuilder.execute();
-                });
-                if (bulkResponse.hasFailures()) {
-                    throw new OpenSearchAccessException(bulkResponse.buildFailureMessage());
-                }
-
-                final String sid = scrollId;
-                response = getClient().get(c -> c.prepareSearchScroll(sid).setScroll(new TimeValue(scrollTimeout)).execute());
-                if (!scrollId.equals(response.getScrollId())) {
-                    getClient().clearScroll(scrollId);
-                }
-                scrollId = response.getScrollId();
+                return bulkBuilder.execute();
+            });
+            if (bulkResponse.hasFailures()) {
+                throw new OpenSearchAccessException(bulkResponse.buildFailureMessage());
             }
-        } finally {
-            getClient().clearScroll(scrollId);
-        }
+            return true;
+        });
 
         refresh();
     }
@@ -766,35 +750,35 @@ public abstract class AbstractCrawlerService {
     }
 
     /**
-     * Gets the scroll timeout in milliseconds.
+     * Gets the keep alive of the point in time used to walk search results, in milliseconds.
      *
-     * @return The scroll timeout.
+     * @return The keep alive in milliseconds.
      */
     public int getScrollTimeout() {
         return scrollTimeout;
     }
 
     /**
-     * Sets the scroll timeout.
-     * @param scrollTimeout The scroll timeout.
+     * Sets the keep alive of the point in time used to walk search results, in milliseconds.
+     * @param scrollTimeout The keep alive in milliseconds.
      */
     public void setScrollTimeout(final int scrollTimeout) {
         this.scrollTimeout = scrollTimeout;
     }
 
     /**
-     * Gets the scroll size for search operations.
+     * Gets the number of hits fetched per page when walking search results.
      *
-     * @return The scroll size.
+     * @return The page size.
      */
     public int getScrollSize() {
         return scrollSize;
     }
 
     /**
-     * Sets the scroll size for search operations.
+     * Sets the number of hits fetched per page when walking search results.
      *
-     * @param scrollSize The scroll size.
+     * @param scrollSize The page size.
      */
     public void setScrollSize(final int scrollSize) {
         this.scrollSize = scrollSize;

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/OpenSearchDataService.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/OpenSearchDataService.java
@@ -224,49 +224,32 @@ public class OpenSearchDataService extends AbstractCrawlerService implements Dat
 
     /**
      * Iterates through all access results for a session, calling the callback for each result.
-     * Uses OpenSearch scroll API for efficient iteration over large result sets.
+     * Walks the results over a point in time, which keeps the iteration efficient for large result sets.
      *
      * @param sessionId The session ID.
      * @param callback The callback to execute for each access result.
      */
     @Override
     public void iterate(final String sessionId, final AccessResultCallback<OpenSearchAccessResult> callback) {
-        SearchResponse response = getClient().get(c -> c.prepareSearch(index)
-                .setScroll(new TimeValue(scrollTimeout))
+        // The index is carried by the point in time, so the search itself must not name it.
+        final SearchRequestBuilder builder = getClient().prepareSearch()
                 .setQuery(QueryBuilders.boolQuery().filter(QueryBuilders.termQuery(SESSION_ID, sessionId)))
-                .setSize(scrollSize)
-                .execute());
-        String scrollId = response.getScrollId();
-        try {
-            while (scrollId != null) {
-                final SearchHits searchHits = response.getHits();
-                if (searchHits.getHits().length == 0) {
-                    break;
+                .setSize(scrollSize);
+        getClient().pitSearch(index, new TimeValue(scrollTimeout), builder, response -> {
+            for (final SearchHit searchHit : response.getHits()) {
+                final Map<String, Object> source = searchHit.getSourceAsMap();
+                final OpenSearchAccessResult accessResult = BeanUtil.copyMapToNewBean(source, OpenSearchAccessResult.class, option -> {
+                    option.converter(new EsTimestampConverter(), timestampFields).excludeWhitespace();
+                    option.exclude(OpenSearchAccessResult.ACCESS_RESULT_DATA);
+                });
+                @SuppressWarnings("unchecked")
+                final Map<String, Object> data = (Map<String, Object>) source.get(OpenSearchAccessResult.ACCESS_RESULT_DATA);
+                if (data != null) {
+                    accessResult.setAccessResultData(new OpenSearchAccessResultData(data));
                 }
-
-                for (final SearchHit searchHit : searchHits) {
-                    final Map<String, Object> source = searchHit.getSourceAsMap();
-                    final OpenSearchAccessResult accessResult = BeanUtil.copyMapToNewBean(source, OpenSearchAccessResult.class, option -> {
-                        option.converter(new EsTimestampConverter(), timestampFields).excludeWhitespace();
-                        option.exclude(OpenSearchAccessResult.ACCESS_RESULT_DATA);
-                    });
-                    @SuppressWarnings("unchecked")
-                    final Map<String, Object> data = (Map<String, Object>) source.get(OpenSearchAccessResult.ACCESS_RESULT_DATA);
-                    if (data != null) {
-                        accessResult.setAccessResultData(new OpenSearchAccessResultData(data));
-                    }
-                    callback.iterate(accessResult);
-                }
-
-                final String sid = scrollId;
-                response = getClient().get(c -> c.prepareSearchScroll(sid).setScroll(new TimeValue(scrollTimeout)).execute());
-                if (!scrollId.equals(response.getScrollId())) {
-                    getClient().clearScroll(scrollId);
-                }
-                scrollId = response.getScrollId();
+                callback.iterate(accessResult);
             }
-        } finally {
-            getClient().clearScroll(scrollId);
-        }
+            return true;
+        });
     }
 }

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueService.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueService.java
@@ -36,7 +36,7 @@ import org.codelibs.fess.crawler.util.OpenSearchCrawlerConfig;
 import org.opensearch.action.DocWriteRequest.OpType;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
-import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import org.opensearch.action.update.UpdateRequestBuilder;
 import org.opensearch.common.unit.TimeValue;
@@ -139,43 +139,29 @@ public class OpenSearchUrlQueueService extends AbstractCrawlerService implements
      */
     @Override
     public void updateSessionId(final String oldSessionId, final String newSessionId) {
-        SearchResponse response = getClient().get(c -> c.prepareSearch(index)
-                .setScroll(new TimeValue(scrollTimeout))
+        // The index is carried by the point in time, so the search itself must not name it. The point in
+        // time also freezes the view of the queue, so rewriting the very field the query filters on cannot
+        // make the walk skip or revisit a document.
+        final SearchRequestBuilder builder = getClient().prepareSearch()
                 .setQuery(QueryBuilders.boolQuery().filter(QueryBuilders.termQuery(SESSION_ID, oldSessionId)))
-                .setSize(scrollSize)
-                .execute());
-        String scrollId = response.getScrollId();
-        try {
-            while (scrollId != null) {
-                final SearchHits searchHits = response.getHits();
-                if (searchHits.getHits().length == 0) {
-                    break;
+                .setSize(scrollSize);
+        getClient().pitSearch(index, new TimeValue(scrollTimeout), builder, response -> {
+            final SearchHits searchHits = response.getHits();
+            final BulkResponse bulkResponse = getClient().get(c -> {
+                final BulkRequestBuilder bulkBuilder = c.prepareBulk();
+                for (final SearchHit searchHit : searchHits) {
+                    final UpdateRequestBuilder updateRequest =
+                            c.prepareUpdate().setIndex(index).setId(searchHit.getId()).setDoc(SESSION_ID, newSessionId);
+                    bulkBuilder.add(updateRequest);
                 }
 
-                final BulkResponse bulkResponse = getClient().get(c -> {
-                    final BulkRequestBuilder builder = c.prepareBulk();
-                    for (final SearchHit searchHit : searchHits) {
-                        final UpdateRequestBuilder updateRequest =
-                                c.prepareUpdate().setIndex(index).setId(searchHit.getId()).setDoc(SESSION_ID, newSessionId);
-                        builder.add(updateRequest);
-                    }
-
-                    return builder.execute();
-                });
-                if (bulkResponse.hasFailures()) {
-                    throw new OpenSearchAccessException(bulkResponse.buildFailureMessage());
-                }
-
-                final String sid = scrollId;
-                response = getClient().get(c -> c.prepareSearchScroll(sid).setScroll(new TimeValue(scrollTimeout)).execute());
-                if (!scrollId.equals(response.getScrollId())) {
-                    getClient().clearScroll(scrollId);
-                }
-                scrollId = response.getScrollId();
+                return bulkBuilder.execute();
+            });
+            if (bulkResponse.hasFailures()) {
+                throw new OpenSearchAccessException(bulkResponse.buildFailureMessage());
             }
-        } finally {
-            getClient().clearScroll(scrollId);
-        }
+            return true;
+        });
     }
 
     /**

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/client/FesenClientTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/client/FesenClientTest.java
@@ -15,16 +15,17 @@
  */
 package org.codelibs.fess.crawler.client;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -47,23 +48,27 @@ import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.crawler.client.FesenClient.OnConnectListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteRequestBuilder;
-import org.opensearch.action.search.ClearScrollRequestBuilder;
-import org.opensearch.action.search.ClearScrollResponse;
+import org.opensearch.action.search.CreatePitAction;
+import org.opensearch.action.search.CreatePitRequest;
+import org.opensearch.action.search.CreatePitResponse;
+import org.opensearch.action.search.DeletePitRequest;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.search.SearchScrollRequestBuilder;
 import org.opensearch.common.action.ActionFuture;
-import org.opensearch.core.action.ActionListener;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.search.Scroll;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.builder.PointInTimeBuilder;
+import org.opensearch.search.sort.ShardDocSortBuilder;
 import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.ClusterAdminClient;
@@ -250,20 +255,22 @@ public class FesenClientTest {
 
     /**
      * Test: deleteByQuery with new signature (without type parameter)
-     * Verifies the improved scroll cleanup logic
+     * Verifies the point in time walk, the bulk delete and the point in time cleanup
      */
     @Test
     public void testDeleteByQueryNewSignature() {
         final SearchRequestBuilder mockSearchBuilder = mock(SearchRequestBuilder.class);
-        final SearchResponse mockSearchResponse = mock(SearchResponse.class);
-        final SearchHits mockSearchHits = mock(SearchHits.class);
-        final SearchHit mockHit = mock(SearchHit.class);
+        final SearchRequest searchRequest = new SearchRequest();
         final ActionFuture<SearchResponse> mockSearchFuture = mock(ActionFuture.class);
 
-        final SearchScrollRequestBuilder mockScrollBuilder = mock(SearchScrollRequestBuilder.class);
-        final SearchResponse mockScrollResponse = mock(SearchResponse.class);
-        final SearchHits mockScrollHits = mock(SearchHits.class);
-        final ActionFuture<SearchResponse> mockScrollFuture = mock(ActionFuture.class);
+        final SearchResponse mockFirstPage = mock(SearchResponse.class);
+        final SearchHits mockFirstHits = mock(SearchHits.class);
+        final SearchResponse mockLastPage = mock(SearchResponse.class);
+        final SearchHits mockLastHits = mock(SearchHits.class);
+        final SearchHit mockHit = mock(SearchHit.class);
+
+        final CreatePitResponse mockCreatePitResponse = mock(CreatePitResponse.class);
+        final ActionFuture<CreatePitResponse> mockCreatePitFuture = mock(ActionFuture.class);
 
         final BulkRequestBuilder mockBulkBuilder = mock(BulkRequestBuilder.class);
         final BulkResponse mockBulkResponse = mock(BulkResponse.class);
@@ -271,27 +278,27 @@ public class FesenClientTest {
 
         final DeleteRequestBuilder mockDeleteBuilder = mock(DeleteRequestBuilder.class);
 
-        final ClearScrollRequestBuilder mockClearScrollBuilder = mock(ClearScrollRequestBuilder.class);
-
-        // Setup search response with one hit
-        when(mockClient.prepareSearch("test-index")).thenReturn(mockSearchBuilder);
-        when(mockSearchBuilder.setScroll(any(Scroll.class))).thenReturn(mockSearchBuilder);
+        // The search must be prepared without indices: the point in time carries them itself.
+        when(mockClient.prepareSearch()).thenReturn(mockSearchBuilder);
         when(mockSearchBuilder.setSize(10)).thenReturn(mockSearchBuilder);
         when(mockSearchBuilder.setQuery(any())).thenReturn(mockSearchBuilder);
+        when(mockSearchBuilder.request()).thenReturn(searchRequest);
         when(mockSearchBuilder.execute()).thenReturn(mockSearchFuture);
-        when(mockSearchFuture.actionGet(anyLong(), any(TimeUnit.class))).thenReturn(mockSearchResponse);
-        when(mockSearchResponse.getScrollId()).thenReturn("scroll1", "scroll1");
-        when(mockSearchResponse.getHits()).thenReturn(mockSearchHits);
-        when(mockSearchHits.getHits()).thenReturn(new SearchHit[] { mockHit }, new SearchHit[0]);
+        when(mockSearchFuture.actionGet(anyLong(), any(TimeUnit.class))).thenReturn(mockFirstPage, mockLastPage);
+
+        // One hit on the first page, then an empty page ends the walk.
+        when(mockFirstPage.getHits()).thenReturn(mockFirstHits);
+        when(mockFirstHits.getHits()).thenReturn(new SearchHit[] { mockHit });
+        when(mockLastPage.getHits()).thenReturn(mockLastHits);
+        when(mockLastHits.getHits()).thenReturn(new SearchHit[0]);
         when(mockHit.getIndex()).thenReturn("test-index");
         when(mockHit.getId()).thenReturn("doc1");
+        when(mockHit.getSortValues()).thenReturn(new Object[] { 1L });
 
-        // Setup scroll response (empty on second call)
-        when(mockClient.prepareSearchScroll("scroll1")).thenReturn(mockScrollBuilder);
-        when(mockScrollBuilder.setScroll(any(Scroll.class))).thenReturn(mockScrollBuilder);
-        when(mockScrollBuilder.execute()).thenReturn(mockScrollFuture);
-        when(mockScrollFuture.actionGet(anyLong(), any(TimeUnit.class))).thenReturn(mockScrollResponse);
-        when(mockScrollResponse.getHits()).thenReturn(mockScrollHits);
+        // Setup the point in time creation
+        when(mockClient.execute(eq(CreatePitAction.INSTANCE), any(CreatePitRequest.class))).thenReturn(mockCreatePitFuture);
+        when(mockCreatePitFuture.actionGet(anyLong(), any(TimeUnit.class))).thenReturn(mockCreatePitResponse);
+        when(mockCreatePitResponse.getId()).thenReturn("pit1");
 
         // Setup bulk delete
         when(mockClient.prepareBulk()).thenReturn(mockBulkBuilder);
@@ -303,19 +310,25 @@ public class FesenClientTest {
         when(mockBulkFuture.actionGet(anyLong(), any(TimeUnit.class))).thenReturn(mockBulkResponse);
         when(mockBulkResponse.hasFailures()).thenReturn(false);
 
-        // Setup clear scroll
-        when(mockClient.prepareClearScroll()).thenReturn(mockClearScrollBuilder);
-        when(mockClearScrollBuilder.addScrollId(any(String.class))).thenReturn(mockClearScrollBuilder);
-        doAnswer(invocation -> {
-            ActionListener<ClearScrollResponse> listener = invocation.getArgument(0);
-            listener.onResponse(mock(ClearScrollResponse.class));
-            return null;
-        }).when(mockClearScrollBuilder).execute(any(ActionListener.class));
-
         final int deleted = fesenClient.deleteByQuery("test-index", QueryBuilders.matchAllQuery());
 
         assertEquals(1, deleted);
-        verify(mockClearScrollBuilder, times(1)).addScrollId("scroll1");
+
+        // The index belongs to the point in time, never to the search request.
+        final ArgumentCaptor<CreatePitRequest> pitRequestCaptor = ArgumentCaptor.forClass(CreatePitRequest.class);
+        verify(mockClient, times(1)).execute(eq(CreatePitAction.INSTANCE), pitRequestCaptor.capture());
+        assertArrayEquals(new String[] { "test-index" }, pitRequestCaptor.getValue().getIndices());
+        assertEquals(0, searchRequest.indices().length);
+
+        // search_after needs a total order, so a _shard_doc tiebreaker is appended.
+        verify(mockSearchBuilder, times(1)).addSort(any(ShardDocSortBuilder.class));
+        verify(mockSearchBuilder, times(1)).setPointInTime(any(PointInTimeBuilder.class));
+        verify(mockSearchBuilder, times(1)).searchAfter(new Object[] { 1L });
+
+        // The point in time is always released.
+        final ArgumentCaptor<DeletePitRequest> deletePitCaptor = ArgumentCaptor.forClass(DeletePitRequest.class);
+        verify(mockClient, times(1)).deletePits(deletePitCaptor.capture(), any());
+        assertEquals(List.of("pit1"), deletePitCaptor.getValue().getPitIds());
     }
 
     /**
@@ -326,36 +339,76 @@ public class FesenClientTest {
     @SuppressWarnings("deprecation")
     public void testDeleteByQueryDeprecatedMethodDelegates() {
         final SearchRequestBuilder mockSearchBuilder = mock(SearchRequestBuilder.class);
+        final SearchRequest searchRequest = new SearchRequest();
         final SearchResponse mockSearchResponse = mock(SearchResponse.class);
         final SearchHits mockSearchHits = mock(SearchHits.class);
         final ActionFuture<SearchResponse> mockSearchFuture = mock(ActionFuture.class);
 
-        final ClearScrollRequestBuilder mockClearScrollBuilder = mock(ClearScrollRequestBuilder.class);
+        final CreatePitResponse mockCreatePitResponse = mock(CreatePitResponse.class);
+        final ActionFuture<CreatePitResponse> mockCreatePitFuture = mock(ActionFuture.class);
 
-        when(mockClient.prepareSearch("test-index")).thenReturn(mockSearchBuilder);
-        when(mockSearchBuilder.setScroll(any(Scroll.class))).thenReturn(mockSearchBuilder);
+        when(mockClient.prepareSearch()).thenReturn(mockSearchBuilder);
         when(mockSearchBuilder.setSize(10)).thenReturn(mockSearchBuilder);
         when(mockSearchBuilder.setQuery(any())).thenReturn(mockSearchBuilder);
+        when(mockSearchBuilder.request()).thenReturn(searchRequest);
         when(mockSearchBuilder.execute()).thenReturn(mockSearchFuture);
         when(mockSearchFuture.actionGet(anyLong(), any(TimeUnit.class))).thenReturn(mockSearchResponse);
-        when(mockSearchResponse.getScrollId()).thenReturn("scroll1");
         when(mockSearchResponse.getHits()).thenReturn(mockSearchHits);
         when(mockSearchHits.getHits()).thenReturn(new SearchHit[0]);
 
-        when(mockClient.prepareClearScroll()).thenReturn(mockClearScrollBuilder);
-        when(mockClearScrollBuilder.addScrollId(any(String.class))).thenReturn(mockClearScrollBuilder);
-        doAnswer(invocation -> {
-            ActionListener<ClearScrollResponse> listener = invocation.getArgument(0);
-            listener.onResponse(mock(ClearScrollResponse.class));
-            return null;
-        }).when(mockClearScrollBuilder).execute(any(ActionListener.class));
+        when(mockClient.execute(eq(CreatePitAction.INSTANCE), any(CreatePitRequest.class))).thenReturn(mockCreatePitFuture);
+        when(mockCreatePitFuture.actionGet(anyLong(), any(TimeUnit.class))).thenReturn(mockCreatePitResponse);
+        when(mockCreatePitResponse.getId()).thenReturn("pit1");
 
         // Call deprecated method with type parameter
         final int deleted = fesenClient.deleteByQuery("test-index", "_doc", QueryBuilders.matchAllQuery());
 
         assertEquals(0, deleted);
         // Verify it used the same search logic (type parameter is ignored)
-        verify(mockClient).prepareSearch("test-index");
+        verify(mockClient, times(1)).prepareSearch();
+        verify(mockClient, times(1)).deletePits(any(DeletePitRequest.class), any());
+    }
+
+    /**
+     * Test: pitSearch moves the indices, routing and preference onto the point in time.
+     * OpenSearch rejects a point in time search that repeats any of them with a 400, and over HTTP
+     * that 400 does not surface as an error but hangs, so the search must not carry them.
+     */
+    @Test
+    public void testPitSearchMovesRoutingAndPreferenceOntoPit() {
+        final SearchRequestBuilder mockSearchBuilder = mock(SearchRequestBuilder.class);
+        final SearchRequest searchRequest = new SearchRequest();
+        searchRequest.preference("_local");
+        searchRequest.routing("route1");
+        final SearchResponse mockSearchResponse = mock(SearchResponse.class);
+        final SearchHits mockSearchHits = mock(SearchHits.class);
+        final ActionFuture<SearchResponse> mockSearchFuture = mock(ActionFuture.class);
+
+        final CreatePitResponse mockCreatePitResponse = mock(CreatePitResponse.class);
+        final ActionFuture<CreatePitResponse> mockCreatePitFuture = mock(ActionFuture.class);
+
+        when(mockSearchBuilder.request()).thenReturn(searchRequest);
+        when(mockSearchBuilder.execute()).thenReturn(mockSearchFuture);
+        when(mockSearchFuture.actionGet(anyLong(), any(TimeUnit.class))).thenReturn(mockSearchResponse);
+        when(mockSearchResponse.getHits()).thenReturn(mockSearchHits);
+        when(mockSearchHits.getHits()).thenReturn(new SearchHit[0]);
+
+        when(mockClient.execute(eq(CreatePitAction.INSTANCE), any(CreatePitRequest.class))).thenReturn(mockCreatePitFuture);
+        when(mockCreatePitFuture.actionGet(anyLong(), any(TimeUnit.class))).thenReturn(mockCreatePitResponse);
+        when(mockCreatePitResponse.getId()).thenReturn("pit1");
+
+        fesenClient.pitSearch("test-index", TimeValue.timeValueMinutes(1), mockSearchBuilder, response -> true);
+
+        final ArgumentCaptor<CreatePitRequest> pitRequestCaptor = ArgumentCaptor.forClass(CreatePitRequest.class);
+        verify(mockClient, times(1)).execute(eq(CreatePitAction.INSTANCE), pitRequestCaptor.capture());
+        final CreatePitRequest pitRequest = pitRequestCaptor.getValue();
+        assertArrayEquals(new String[] { "test-index" }, pitRequest.getIndices());
+        assertEquals("_local", pitRequest.getPreference());
+        assertEquals("route1", pitRequest.getRouting());
+
+        assertEquals(0, searchRequest.indices().length);
+        assertNull(searchRequest.preference());
+        assertNull(searchRequest.routing());
     }
 
     /**

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
@@ -19,6 +19,7 @@ import static org.codelibs.fess.crawler.util.OpenSearchRunnerUtil.findFreePort;
 import static org.codelibs.opensearch.runner.OpenSearchRunner.newConfigs;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -31,6 +32,7 @@ import org.dbflute.utflute.lastadi.LastaDiTestCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.SearchHit;
 
 import jakarta.annotation.Resource;
 
@@ -39,6 +41,8 @@ import jakarta.annotation.Resource;
  *
  */
 public class OpenSearchUrlQueueServiceTest extends LastaDiTestCase {
+    private static final String QUEUE_INDEX = "fess_crawler.queue";
+
     @Resource
     private OpenSearchUrlQueueService urlQueueService;
 
@@ -186,6 +190,97 @@ public class OpenSearchUrlQueueServiceTest extends LastaDiTestCase {
                 .getHits()
                 .getTotalHits()
                 .value() > 0);
+    }
+
+    @Test
+    public void test_updateSessionIdTx() {
+        final String oldSessionId = "update_session_old";
+        final String newSessionId = "update_session_new";
+        final String otherSessionId = "update_session_other";
+
+        // A page size below the document count forces the search_after walk over more than one page.
+        urlQueueService.setScrollSize(2);
+
+        final List<String> urls = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            final OpenSearchUrlQueue urlQueue = new OpenSearchUrlQueue();
+            urlQueue.setCreateTime(System.currentTimeMillis());
+            urlQueue.setDepth(1);
+            urlQueue.setMethod("GET");
+            urlQueue.setSessionId(oldSessionId);
+            urlQueue.setUrl("http://www.example.com/update" + i);
+            urlQueueService.insert(urlQueue);
+            urls.add(urlQueue.getUrl());
+        }
+
+        final OpenSearchUrlQueue otherQueue = new OpenSearchUrlQueue();
+        otherQueue.setCreateTime(System.currentTimeMillis());
+        otherQueue.setDepth(1);
+        otherQueue.setMethod("GET");
+        otherQueue.setSessionId(otherSessionId);
+        otherQueue.setUrl("http://www.example.com/other");
+        urlQueueService.insert(otherQueue);
+
+        urlQueueService.updateSessionId(oldSessionId, newSessionId);
+        refreshQueueIndex();
+
+        // Every document of the old session moved exactly once, and no other session was touched.
+        assertEquals(0L, countBySessionId(oldSessionId));
+        assertEquals(5L, countBySessionId(newSessionId));
+        assertEquals(1L, countBySessionId(otherSessionId));
+
+        final List<String> movedUrls = new ArrayList<>();
+        for (final SearchHit hit : fesenClient.prepareSearch(QUEUE_INDEX)
+                .setQuery(QueryBuilders.termQuery("sessionId", newSessionId))
+                .setSize(10)
+                .execute()
+                .actionGet()
+                .getHits()) {
+            movedUrls.add(hit.getSourceAsMap().get("url").toString());
+        }
+        Collections.sort(urls);
+        Collections.sort(movedUrls);
+        assertEquals(urls, movedUrls);
+
+        urlQueueService.delete(newSessionId);
+        urlQueueService.delete(otherSessionId);
+    }
+
+    @Test
+    public void test_updateSessionId_noMatchTx() {
+        final String sessionId = "update_session_keep";
+
+        final OpenSearchUrlQueue urlQueue = new OpenSearchUrlQueue();
+        urlQueue.setCreateTime(System.currentTimeMillis());
+        urlQueue.setDepth(1);
+        urlQueue.setMethod("GET");
+        urlQueue.setSessionId(sessionId);
+        urlQueue.setUrl("http://www.example.com/keep");
+        urlQueueService.insert(urlQueue);
+
+        // An empty result set must release the point in time and leave the index untouched.
+        urlQueueService.updateSessionId("update_session_missing", "update_session_created");
+        refreshQueueIndex();
+
+        assertEquals(1L, countBySessionId(sessionId));
+        assertEquals(0L, countBySessionId("update_session_created"));
+
+        urlQueueService.delete(sessionId);
+    }
+
+    private void refreshQueueIndex() {
+        fesenClient.admin().indices().prepareRefresh(QUEUE_INDEX).execute().actionGet();
+    }
+
+    private long countBySessionId(final String sessionId) {
+        return fesenClient.prepareSearch(QUEUE_INDEX)
+                .setQuery(QueryBuilders.termQuery("sessionId", sessionId))
+                .setSize(0)
+                .execute()
+                .actionGet()
+                .getHits()
+                .getTotalHits()
+                .value();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Replaces the scroll API with a point in time and `search_after` everywhere
`fess-crawler-opensearch` walks a whole result set.

The scroll API keeps a search context alive on the server for the length of the walk, and
OpenSearch steers callers towards a point in time with `search_after` instead.

## Changes

`FesenClient` gains a shared `pitSearch` pager: it appends a `_shard_doc` tiebreaker so the
sort is a total order, opens the point in time, pages with `search_after`, and releases the
point in time in every case. All four walks go through it:

- `FesenClient#deleteByQuery`
- `AbstractCrawlerService#delete`, which backs `deleteBySessionId` and `deleteAll`
- `OpenSearchUrlQueueService#updateSessionId`
- `OpenSearchDataService#iterate`

A point in time carries the indices, routing and preference itself, and a search that repeats
any of them is rejected with a 400 — which over HTTP hangs rather than fails, since the socket
timeout is disabled by default. So each walk searches without an index and `pitSearch` moves
routing and preference onto the create request.

`clearScroll(String)`, the scroll-only helper, is replaced by `deletePitContext(String)`. The
`Client` methods `clearScroll`, `prepareClearScroll`, `prepareSearchScroll` and `searchScroll`
remain, since the interface declares them.

## Compatibility

- **Requires an OpenSearch 3.x server.** `_shard_doc` is not implemented on 2.x, which answers
  400 `No mapping found for [_shard_doc] in order to sort on`.
- No signature changes outside `FesenClient`. `AbstractCrawlerService#delete`,
  `OpenSearchUrlQueueService#updateSessionId`, `OpenSearchDataService#iterate` and the
  `scrollTimeout` / `scrollSize` / `scrollForDelete` accessors are untouched, including their
  types; only their javadoc now says the value is a point-in-time keep-alive.

## Test plan

- `fess-crawler-opensearch`: 43 tests, all passing, across all five test classes
- `fess-crawler-lasta`: 15 tests, all passing
- New coverage:
  - `FesenClientTest` pins that the indices reach `CreatePitRequest` while `SearchRequest`
    carries none, that `_shard_doc` is added once, that `searchAfter` is fed the previous
    page's sort values, and that the point in time is released even on an empty result.
  - A new test pins that routing and preference move onto the create request and are cleared
    from the search — the direct guard against the 400-that-hangs.
  - `OpenSearchUrlQueueService#updateSessionId` had no test at all. Two new ones run against a
    real OpenSearch and cover paging across several pages while rewriting the very field the
    walk selects on, plus the zero-match case.

The reactor-wide `mvn test` was not run green: `FtpClientTest#test_doHead_accessTimeoutTarget`
in the unrelated `fess-crawler` module fails under load (a 1s timeout against a 2s sleep while
three Testcontainers start) and passes on its own. Nothing in this PR touches that module.
