### PR TITLE
feat!: migrate to Jackson 3

### DIFF
--- a/fess-crawler/pom.xml
+++ b/fess-crawler/pom.xml
@@ -146,7 +146,7 @@
 			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
+			<groupId>tools.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
 		</dependency>

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
@@ -51,10 +51,11 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadConstraints;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -533,7 +534,7 @@ public class HtmlExtractor extends AbstractXmlExtractor {
                 return;
             }
             collectTypeNodes(root, typeList);
-        } catch (final JsonProcessingException e) {
+        } catch (final JacksonException e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Skipping malformed JSON-LD block.", e);
             } else {
@@ -601,7 +602,7 @@ public class HtmlExtractor extends AbstractXmlExtractor {
         // @graph, mainEntity, author, publisher, itemListElement, ...) also
         // contribute their @type values. Skip @type (already handled) and
         // @context (vocabulary term definitions, not data).
-        node.fields().forEachRemaining(field -> {
+        node.properties().forEach(field -> {
             final String fieldName = field.getKey();
             if ("@type".equals(fieldName) || "@context".equals(fieldName)) {
                 return;
@@ -628,13 +629,12 @@ public class HtmlExtractor extends AbstractXmlExtractor {
             synchronized (this) {
                 mapper = objectMapper;
                 if (mapper == null) {
-                    mapper = new ObjectMapper();
                     final StreamReadConstraints constraints = StreamReadConstraints.builder()
                             .maxNestingDepth(JSONLD_MAX_NESTING_DEPTH)
                             .maxStringLength(JSONLD_MAX_STRING_LENGTH)
                             .maxNumberLength(JSONLD_MAX_NUMBER_LENGTH)
                             .build();
-                    mapper.getFactory().setStreamReadConstraints(constraints);
+                    mapper = new ObjectMapper(JsonFactory.builder().streamReadConstraints(constraints).build());
                     objectMapper = mapper;
                 }
             }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/JsonExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/JsonExtractor.java
@@ -15,7 +15,6 @@
  */
 package org.codelibs.fess.crawler.extractor.impl;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -30,11 +29,13 @@ import org.codelibs.fess.crawler.entity.ExtractData;
 import org.codelibs.fess.crawler.exception.ExtractException;
 import org.codelibs.fess.crawler.exception.MaxLengthExceededException;
 
-import com.fasterxml.jackson.core.StreamReadConstraints;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Extracts text content and metadata from JSON files.
@@ -103,7 +104,7 @@ public class JsonExtractor extends AbstractExtractor {
     protected static final int MAX_NUMBER_LENGTH = 1000;
 
     /** Jackson ObjectMapper for JSON parsing. */
-    protected final ObjectMapper objectMapper = new ObjectMapper();
+    protected final ObjectMapper objectMapper;
 
     /** Maximum depth for nested structure extraction. */
     protected int maxDepth = 10;
@@ -153,7 +154,7 @@ public class JsonExtractor extends AbstractExtractor {
                 .maxStringLength(MAX_STRING_LENGTH)
                 .maxNumberLength(MAX_NUMBER_LENGTH)
                 .build();
-        objectMapper.getFactory().setStreamReadConstraints(constraints);
+        objectMapper = new ObjectMapper(JsonFactory.builder().streamReadConstraints(constraints).build());
     }
 
     @Override
@@ -190,7 +191,7 @@ public class JsonExtractor extends AbstractExtractor {
             }
 
             return extractData;
-        } catch (final IOException e) {
+        } catch (final JacksonException e) {
             throw new ExtractException("Failed to parse JSON content", e);
         }
     }
@@ -281,7 +282,7 @@ public class JsonExtractor extends AbstractExtractor {
      */
     protected void extractObject(final ObjectNode node, final String parentKey, final TextAccumulator textAccumulator,
             final Map<String, List<String>> metadataMap, final int depth) {
-        final Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+        final Iterator<Map.Entry<String, JsonNode>> fields = node.properties().iterator();
         while (fields.hasNext() && !textAccumulator.truncated) {
             final Map.Entry<String, JsonNode> field = fields.next();
             final String fieldName = field.getKey();

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PasswordBasedExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/PasswordBasedExtractor.java
@@ -29,8 +29,8 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.misc.Pair;
 import org.codelibs.fess.crawler.entity.ExtractData;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * PasswordBasedExtractor is an abstract base class for extractors that can handle password-protected files.


### PR DESCRIPTION
## Summary

Moves `jackson-databind` to the `tools.jackson.core` groupId at `${jackson.version}` and updates the three extractors that use Jackson.

## Source changes

Jackson 3 is not only a package rename here -- three APIs this repository relies on changed shape:

**`TokenStreamFactory` is immutable.** `HtmlExtractor` and `JsonExtractor` hardened their mappers by calling `mapper.getFactory().setStreamReadConstraints(...)` after construction, which Jackson 3 no longer allows. Both now build the factory first and pass it to the mapper:

```java
objectMapper = new ObjectMapper(JsonFactory.builder().streamReadConstraints(constraints).build());
```

The configured limits (max nesting depth, max string length, max number length) are unchanged, so the protection against hostile input is identical.

**`JsonNode.fields()` was removed**, replaced by `properties()`. `JsonExtractor.extractObject` keeps iterating over an `Iterator` rather than switching to `forEach`, so its `maxTextLength` early exit still applies mid-object.

**`JsonProcessingException` is gone** and its replacement `JacksonException` is unchecked, which left `JsonExtractor`'s `catch (IOException)` unreachable. It now catches `JacksonException` and still raises `ExtractException("Failed to parse JSON content", e)`, so a malformed document is reported exactly as before. `HtmlExtractor`'s JSON-LD handler catches `JacksonException` ahead of its existing `catch (RuntimeException)`.

## Verification

- `mvn test`: **2097 tests, 0 failures, 0 errors**
- The three touched extractors' own suites pass: `JsonExtractorTest` (14), `HtmlExtractorTest` (55), `PasswordBasedExtractorTest` (18)

## Merge order

Requires codelibs/fess-parent (`jackson.version` -> 3.2.1) to merge first.
