### PR TITLE
feat: make the URL queue fetch order pluggable

### DIFF
--- a/fess-crawler-lasta/src/main/resources/crawler/container.xml
+++ b/fess-crawler-lasta/src/main/resources/crawler/container.xml
@@ -3,6 +3,8 @@
 	"http://dbflute.org/meta/lastadi10.dtd">
 <components namespace="fessCrawler">
 
+	<include path="crawler/weigher.xml" />
+
 	<component class="org.lastaflute.di.naming.StyledNamingConvention">
 	</component>
 

--- a/fess-crawler-lasta/src/main/resources/crawler/rule.xml
+++ b/fess-crawler-lasta/src/main/resources/crawler/rule.xml
@@ -4,6 +4,7 @@
 <components namespace="fessCrawler">
 	<include path="crawler/container.xml" />
 	<include path="crawler/transformer.xml" />
+	<include path="crawler/weigher.xml" />
 
 	<component name="ruleManager"
 		class="org.codelibs.fess.crawler.rule.impl.RuleManagerImpl" instance="prototype">

--- a/fess-crawler-lasta/src/main/resources/crawler/rule.xml
+++ b/fess-crawler-lasta/src/main/resources/crawler/rule.xml
@@ -4,7 +4,6 @@
 <components namespace="fessCrawler">
 	<include path="crawler/container.xml" />
 	<include path="crawler/transformer.xml" />
-	<include path="crawler/weigher.xml" />
 
 	<component name="ruleManager"
 		class="org.codelibs.fess.crawler.rule.impl.RuleManagerImpl" instance="prototype">

--- a/fess-crawler-lasta/src/main/resources/crawler/weigher.xml
+++ b/fess-crawler-lasta/src/main/resources/crawler/weigher.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+	"http://dbflute.org/meta/lastadi10.dtd">
+<components namespace="fessCrawler">
+	<component name="urlQueueWeigher"
+		class="org.codelibs.fess.crawler.weight.impl.DefaultUrlQueueWeigher">
+	</component>
+</components>

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/UrlQueueOrder.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/UrlQueueOrder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.order;
+
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.search.sort.SortBuilder;
+
+/**
+ * Decides which queued URLs are fetched next, and in what order.
+ *
+ * <p>
+ * The session filter and the fetch size are applied by the queue service, so an
+ * implementation only describes the additional narrowing and the sort order.
+ * </p>
+ */
+public interface UrlQueueOrder {
+
+    /**
+     * Returns an additional query that narrows the candidates.
+     *
+     * @param sessionId the crawling session ID
+     * @return the additional query, or {@literal null} to match all queued URLs
+     */
+    default QueryBuilder buildQuery(final String sessionId) {
+        return null;
+    }
+
+    /**
+     * Returns the sort conditions that decide the fetch order.
+     *
+     * @param sessionId the crawling session ID
+     * @return the sort conditions, or an empty array to use the default order
+     */
+    SortBuilder<?>[] buildSorts(String sessionId);
+}

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/DepthFirstUrlQueueOrder.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/DepthFirstUrlQueueOrder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.order.impl;
+
+import org.codelibs.fess.crawler.entity.OpenSearchUrlQueue;
+import org.codelibs.fess.crawler.order.UrlQueueOrder;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
+
+/**
+ * Fetches the deepest queued URLs first, approximating a depth-first crawl.
+ *
+ * <p>
+ * The approximation is bounded by the polling fetch size: a batch is fetched, then fully
+ * consumed before the next one, so URLs discovered mid-batch wait for the following batch.
+ * </p>
+ */
+public class DepthFirstUrlQueueOrder implements UrlQueueOrder {
+
+    /**
+     * Creates a new DepthFirstUrlQueueOrder instance.
+     */
+    public DepthFirstUrlQueueOrder() {
+        // NOP
+    }
+
+    @Override
+    public SortBuilder<?>[] buildSorts(final String sessionId) {
+        return new SortBuilder<?>[] { SortBuilders.fieldSort(OpenSearchUrlQueue.DEPTH).order(SortOrder.DESC),
+                SortBuilders.fieldSort(OpenSearchUrlQueue.CREATE_TIME).order(SortOrder.DESC) };
+    }
+}

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/NewestFirstUrlQueueOrder.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/NewestFirstUrlQueueOrder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.order.impl;
+
+import org.codelibs.fess.crawler.entity.OpenSearchUrlQueue;
+import org.codelibs.fess.crawler.order.UrlQueueOrder;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
+
+/**
+ * Fetches the most recently queued URLs first (last in, first out).
+ */
+public class NewestFirstUrlQueueOrder implements UrlQueueOrder {
+
+    /**
+     * Creates a new NewestFirstUrlQueueOrder instance.
+     */
+    public NewestFirstUrlQueueOrder() {
+        // NOP
+    }
+
+    @Override
+    public SortBuilder<?>[] buildSorts(final String sessionId) {
+        return new SortBuilder<?>[] { SortBuilders.fieldSort(OpenSearchUrlQueue.CREATE_TIME).order(SortOrder.DESC) };
+    }
+}

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/RandomUrlQueueOrder.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/RandomUrlQueueOrder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.order.impl;
+
+import org.codelibs.fess.crawler.order.UrlQueueOrder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
+import org.opensearch.index.query.functionscore.RandomScoreFunctionBuilder;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
+
+/**
+ * Fetches queued URLs in a random order, seeded per session.
+ */
+public class RandomUrlQueueOrder implements UrlQueueOrder {
+
+    /**
+     * Creates a new RandomUrlQueueOrder instance.
+     */
+    public RandomUrlQueueOrder() {
+        // NOP
+    }
+
+    @Override
+    public QueryBuilder buildQuery(final String sessionId) {
+        return QueryBuilders.functionScoreQuery(QueryBuilders.matchAllQuery(), new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
+                new FunctionScoreQueryBuilder.FilterFunctionBuilder(new RandomScoreFunctionBuilder().seed(sessionId.hashCode())) });
+    }
+
+    @Override
+    public SortBuilder<?>[] buildSorts(final String sessionId) {
+        return new SortBuilder<?>[] { SortBuilders.scoreSort().order(SortOrder.DESC) };
+    }
+}

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/SequentialUrlQueueOrder.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/SequentialUrlQueueOrder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.order.impl;
+
+import org.codelibs.fess.crawler.entity.OpenSearchUrlQueue;
+import org.codelibs.fess.crawler.order.UrlQueueOrder;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
+
+/**
+ * Fetches queued URLs by descending weight, then by discovery order. This is the default.
+ */
+public class SequentialUrlQueueOrder implements UrlQueueOrder {
+
+    /**
+     * Creates a new SequentialUrlQueueOrder instance.
+     */
+    public SequentialUrlQueueOrder() {
+        // NOP
+    }
+
+    @Override
+    public SortBuilder<?>[] buildSorts(final String sessionId) {
+        return new SortBuilder<?>[] { SortBuilders.fieldSort(OpenSearchUrlQueue.WEIGHT).order(SortOrder.DESC),
+                SortBuilders.fieldSort(OpenSearchUrlQueue.CREATE_TIME).order(SortOrder.ASC) };
+    }
+}

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/WeightFirstUrlQueueOrder.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/WeightFirstUrlQueueOrder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.order.impl;
+
+import org.codelibs.fess.crawler.entity.OpenSearchUrlQueue;
+import org.codelibs.fess.crawler.order.UrlQueueOrder;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
+
+/**
+ * Fetches queued URLs by descending weight only, leaving ties in the index order.
+ */
+public class WeightFirstUrlQueueOrder implements UrlQueueOrder {
+
+    /**
+     * Creates a new WeightFirstUrlQueueOrder instance.
+     */
+    public WeightFirstUrlQueueOrder() {
+        // NOP
+    }
+
+    @Override
+    public SortBuilder<?>[] buildSorts(final String sessionId) {
+        return new SortBuilder<?>[] { SortBuilders.fieldSort(OpenSearchUrlQueue.WEIGHT).order(SortOrder.DESC) };
+    }
+}

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/AbstractCrawlerService.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/AbstractCrawlerService.java
@@ -540,16 +540,11 @@ public abstract class AbstractCrawlerService {
             final Integer size, final SortBuilder<?>... sortBuilders) {
         return getList(clazz, builder -> {
             if (StringUtil.isNotBlank(sessionId)) {
-                if (queryBuilder instanceof BoolQueryBuilder) {
-                    ((BoolQueryBuilder) queryBuilder).filter(QueryBuilders.termQuery(SESSION_ID, sessionId));
-                    builder.setQuery(queryBuilder);
-                } else {
-                    final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery(SESSION_ID, sessionId));
-                    if (queryBuilder != null) {
-                        boolQuery.must(queryBuilder);
-                    }
-                    builder.setQuery(boolQuery);
+                final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery(SESSION_ID, sessionId));
+                if (queryBuilder != null) {
+                    boolQuery.must(queryBuilder);
                 }
+                builder.setQuery(boolQuery);
             } else if (queryBuilder != null) {
                 builder.setQuery(queryBuilder);
             } else {

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/AbstractCrawlerService.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/AbstractCrawlerService.java
@@ -542,6 +542,7 @@ public abstract class AbstractCrawlerService {
             if (StringUtil.isNotBlank(sessionId)) {
                 if (queryBuilder instanceof BoolQueryBuilder) {
                     ((BoolQueryBuilder) queryBuilder).filter(QueryBuilders.termQuery(SESSION_ID, sessionId));
+                    builder.setQuery(queryBuilder);
                 } else {
                     final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery(SESSION_ID, sessionId));
                     if (queryBuilder != null) {

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueService.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueService.java
@@ -31,6 +31,8 @@ import org.codelibs.fess.crawler.entity.AccessResult;
 import org.codelibs.fess.crawler.entity.OpenSearchUrlQueue;
 import org.codelibs.fess.crawler.entity.UrlQueue;
 import org.codelibs.fess.crawler.exception.OpenSearchAccessException;
+import org.codelibs.fess.crawler.order.UrlQueueOrder;
+import org.codelibs.fess.crawler.order.impl.SequentialUrlQueueOrder;
 import org.codelibs.fess.crawler.service.UrlQueueService;
 import org.codelibs.fess.crawler.util.OpenSearchCrawlerConfig;
 import org.opensearch.action.DocWriteRequest.OpType;
@@ -43,8 +45,6 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
-import org.opensearch.search.sort.SortBuilders;
-import org.opensearch.search.sort.SortOrder;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -82,6 +82,11 @@ public class OpenSearchUrlQueueService extends AbstractCrawlerService implements
      * The maximum size of the crawling queue.
      */
     protected int maxCrawlingQueueSize = 100;
+
+    /**
+     * The order in which queued URLs are fetched.
+     */
+    protected UrlQueueOrder urlQueueOrder = new SequentialUrlQueueOrder();
 
     /**
      * Creates a new instance of OpenSearchUrlQueueService.
@@ -307,14 +312,24 @@ public class OpenSearchUrlQueueService extends AbstractCrawlerService implements
     }
 
     /**
+     * Returns the fetch order to apply to this session.
+     * Subclasses override this to switch the order per session.
+     *
+     * @param sessionId The session ID.
+     * @return The fetch order.
+     */
+    protected UrlQueueOrder getUrlQueueOrder(final String sessionId) {
+        return urlQueueOrder;
+    }
+
+    /**
      * Fetches a list of URL queues for a given session ID.
      * @param sessionId The session ID.
      * @return A list of OpenSearchUrlQueue objects.
      */
     protected List<OpenSearchUrlQueue> fetchUrlQueueList(final String sessionId) {
-        return getList(OpenSearchUrlQueue.class, sessionId, null, 0, pollingFetchSize,
-                SortBuilders.fieldSort(OpenSearchUrlQueue.WEIGHT).order(SortOrder.DESC),
-                SortBuilders.fieldSort(CREATE_TIME).order(SortOrder.ASC));
+        final UrlQueueOrder order = getUrlQueueOrder(sessionId);
+        return getList(OpenSearchUrlQueue.class, sessionId, order.buildQuery(sessionId), 0, pollingFetchSize, order.buildSorts(sessionId));
     }
 
     /**
@@ -453,5 +468,13 @@ public class OpenSearchUrlQueueService extends AbstractCrawlerService implements
      */
     public void setMaxCrawlingQueueSize(final int maxCrawlingQueueSize) {
         this.maxCrawlingQueueSize = maxCrawlingQueueSize;
+    }
+
+    /**
+     * Sets the order in which queued URLs are fetched.
+     * @param urlQueueOrder The fetch order.
+     */
+    public void setUrlQueueOrder(final UrlQueueOrder urlQueueOrder) {
+        this.urlQueueOrder = urlQueueOrder;
     }
 }

--- a/fess-crawler-opensearch/src/main/resources/crawler/order.xml
+++ b/fess-crawler-opensearch/src/main/resources/crawler/order.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+	"http://dbflute.org/meta/lastadi10.dtd">
+<components namespace="fessCrawler">
+	<component name="sequentialUrlQueueOrder"
+		class="org.codelibs.fess.crawler.order.impl.SequentialUrlQueueOrder">
+	</component>
+	<component name="randomUrlQueueOrder"
+		class="org.codelibs.fess.crawler.order.impl.RandomUrlQueueOrder">
+	</component>
+	<component name="depthFirstUrlQueueOrder"
+		class="org.codelibs.fess.crawler.order.impl.DepthFirstUrlQueueOrder">
+	</component>
+	<component name="newestFirstUrlQueueOrder"
+		class="org.codelibs.fess.crawler.order.impl.NewestFirstUrlQueueOrder">
+	</component>
+	<component name="weightFirstUrlQueueOrder"
+		class="org.codelibs.fess.crawler.order.impl.WeightFirstUrlQueueOrder">
+	</component>
+</components>

--- a/fess-crawler-opensearch/src/main/resources/crawler_opensearch.xml
+++ b/fess-crawler-opensearch/src/main/resources/crawler_opensearch.xml
@@ -13,6 +13,7 @@
     <include path="crawler/urlconverter.xml"/>
     <include path="crawler/log.xml"/>
     <include path="crawler/sitemaps.xml"/>
+    <include path="crawler/order.xml"/>
 
     <include path="crawler/opensearch.xml"/>
 

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/order/impl/UrlQueueOrderTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/order/impl/UrlQueueOrderTest.java
@@ -20,6 +20,7 @@ import org.dbflute.utflute.core.PlainTestCase;
 import org.junit.jupiter.api.Test;
 import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.opensearch.search.sort.FieldSortBuilder;
+import org.opensearch.search.sort.ScoreSortBuilder;
 import org.opensearch.search.sort.SortBuilder;
 import org.opensearch.search.sort.SortOrder;
 
@@ -75,6 +76,7 @@ public class UrlQueueOrderTest extends PlainTestCase {
         assertTrue(order.buildQuery("s1") instanceof FunctionScoreQueryBuilder);
         final SortBuilder<?>[] sorts = order.buildSorts("s1");
         assertEquals(1, sorts.length);
+        assertTrue(sorts[0] instanceof ScoreSortBuilder);
         assertEquals(SortOrder.DESC, sorts[0].order());
     }
 

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/order/impl/UrlQueueOrderTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/order/impl/UrlQueueOrderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.order.impl;
+
+import org.codelibs.fess.crawler.order.UrlQueueOrder;
+import org.dbflute.utflute.core.PlainTestCase;
+import org.junit.jupiter.api.Test;
+import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
+import org.opensearch.search.sort.FieldSortBuilder;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortOrder;
+
+public class UrlQueueOrderTest extends PlainTestCase {
+
+    private void assertFieldSort(final SortBuilder<?> sort, final String fieldName, final SortOrder order) {
+        assertTrue(sort instanceof FieldSortBuilder);
+        assertEquals(fieldName, ((FieldSortBuilder) sort).getFieldName());
+        assertEquals(order, sort.order());
+    }
+
+    @Test
+    public void test_sequential() {
+        final UrlQueueOrder order = new SequentialUrlQueueOrder();
+        assertNull(order.buildQuery("s1"));
+        final SortBuilder<?>[] sorts = order.buildSorts("s1");
+        assertEquals(2, sorts.length);
+        assertFieldSort(sorts[0], "weight", SortOrder.DESC);
+        assertFieldSort(sorts[1], "createTime", SortOrder.ASC);
+    }
+
+    @Test
+    public void test_depthFirst() {
+        final UrlQueueOrder order = new DepthFirstUrlQueueOrder();
+        assertNull(order.buildQuery("s1"));
+        final SortBuilder<?>[] sorts = order.buildSorts("s1");
+        assertEquals(2, sorts.length);
+        assertFieldSort(sorts[0], "depth", SortOrder.DESC);
+        assertFieldSort(sorts[1], "createTime", SortOrder.DESC);
+    }
+
+    @Test
+    public void test_newestFirst() {
+        final UrlQueueOrder order = new NewestFirstUrlQueueOrder();
+        assertNull(order.buildQuery("s1"));
+        final SortBuilder<?>[] sorts = order.buildSorts("s1");
+        assertEquals(1, sorts.length);
+        assertFieldSort(sorts[0], "createTime", SortOrder.DESC);
+    }
+
+    @Test
+    public void test_weightFirst() {
+        final UrlQueueOrder order = new WeightFirstUrlQueueOrder();
+        assertNull(order.buildQuery("s1"));
+        final SortBuilder<?>[] sorts = order.buildSorts("s1");
+        assertEquals(1, sorts.length);
+        assertFieldSort(sorts[0], "weight", SortOrder.DESC);
+    }
+
+    @Test
+    public void test_random_buildsFunctionScoreQuery() {
+        final UrlQueueOrder order = new RandomUrlQueueOrder();
+        assertTrue(order.buildQuery("s1") instanceof FunctionScoreQueryBuilder);
+        final SortBuilder<?>[] sorts = order.buildSorts("s1");
+        assertEquals(1, sorts.length);
+        assertEquals(SortOrder.DESC, sorts[0].order());
+    }
+
+    @Test
+    public void test_random_seedIsStablePerSession() {
+        final UrlQueueOrder order = new RandomUrlQueueOrder();
+        assertEquals(order.buildQuery("s1").toString(), order.buildQuery("s1").toString());
+        assertFalse(order.buildQuery("s1").toString().equals(order.buildQuery("s2").toString()));
+    }
+}

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
@@ -519,4 +519,30 @@ public class OpenSearchUrlQueueServiceTest extends LastaDiTestCase {
         assertTrue(count <= 2); // At most 2 items (may be deduplicated)
         urlQueueService.delete(sessionId);
     }
+
+    @Test
+    public void test_getList_boolQueryIsFilteredBySessionId() {
+        final OpenSearchUrlQueue target = new OpenSearchUrlQueue();
+        target.setSessionId("session-a");
+        target.setUrl("http://www.example.com/a");
+        target.setCreateTime(System.currentTimeMillis());
+        target.setDepth(1);
+        target.setMethod("GET");
+        urlQueueService.insert(target);
+
+        final OpenSearchUrlQueue other = new OpenSearchUrlQueue();
+        other.setSessionId("session-b");
+        other.setUrl("http://www.example.com/b");
+        other.setCreateTime(System.currentTimeMillis());
+        other.setDepth(1);
+        other.setMethod("GET");
+        urlQueueService.insert(other);
+
+        final List<OpenSearchUrlQueue> list = urlQueueService.getList(OpenSearchUrlQueue.class, "session-a",
+                QueryBuilders.boolQuery().filter(QueryBuilders.rangeQuery(OpenSearchUrlQueue.DEPTH).gte(0)), 0, 10);
+
+        assertEquals(1, list.size());
+        assertEquals("session-a", list.get(0).getSessionId());
+        assertEquals("http://www.example.com/a", list.get(0).getUrl());
+    }
 }

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
@@ -27,6 +27,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.codelibs.fess.crawler.client.FesenClient;
 import org.codelibs.fess.crawler.entity.OpenSearchUrlQueue;
+import org.codelibs.fess.crawler.order.UrlQueueOrder;
+import org.codelibs.fess.crawler.order.impl.DepthFirstUrlQueueOrder;
+import org.codelibs.fess.crawler.order.impl.SequentialUrlQueueOrder;
 import org.codelibs.opensearch.runner.OpenSearchRunner;
 import org.dbflute.utflute.lastadi.LastaDiTestCase;
 import org.junit.jupiter.api.Test;
@@ -544,5 +547,41 @@ public class OpenSearchUrlQueueServiceTest extends LastaDiTestCase {
         assertEquals(1, list.size());
         assertEquals("session-a", list.get(0).getSessionId());
         assertEquals("http://www.example.com/a", list.get(0).getUrl());
+    }
+
+    @Test
+    public void test_poll_followsTheConfiguredOrder() {
+        final String sessionId = "order-session";
+        for (int depth = 1; depth <= 3; depth++) {
+            final OpenSearchUrlQueue urlQueue = new OpenSearchUrlQueue();
+            urlQueue.setSessionId(sessionId);
+            urlQueue.setUrl("http://www.example.com/depth" + depth);
+            urlQueue.setCreateTime(System.currentTimeMillis() + depth);
+            urlQueue.setDepth(depth);
+            urlQueue.setMethod("GET");
+            urlQueueService.insert(urlQueue);
+        }
+
+        urlQueueService.setUrlQueueOrder(new DepthFirstUrlQueueOrder());
+        try {
+            for (int depth = 3; depth >= 1; depth--) {
+                final OpenSearchUrlQueue polled = urlQueueService.poll(sessionId);
+                assertNotNull(polled);
+                assertEquals("http://www.example.com/depth" + depth, polled.getUrl());
+            }
+        } finally {
+            urlQueueService.setUrlQueueOrder(new SequentialUrlQueueOrder());
+            urlQueueService.clearCache();
+        }
+    }
+
+    @Test
+    public void test_di_registersTheBuiltInOrders() {
+        for (final String name : new String[] { "sequentialUrlQueueOrder", "randomUrlQueueOrder", "depthFirstUrlQueueOrder",
+                "newestFirstUrlQueueOrder", "weightFirstUrlQueueOrder" }) {
+            final Object component = getComponent(name);
+            assertNotNull(component);
+            assertTrue(component instanceof UrlQueueOrder);
+        }
     }
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerThread.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerThread.java
@@ -20,6 +20,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.codelibs.core.io.CloseableUtil;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.lang.SystemUtil;
@@ -82,6 +84,9 @@ import jakarta.annotation.Resource;
  *
  */
 public class CrawlerThread implements Runnable {
+    /** Logger instance for this class. */
+    private static final Logger logger = LogManager.getLogger(CrawlerThread.class);
+
     /**
      * Constructs a new CrawlerThread.
      */
@@ -465,7 +470,12 @@ public class CrawlerThread implements Runnable {
         if (childList.isEmpty()) {
             return;
         }
-        urlQueueWeigher.apply(crawlerContext.sessionId, childList);
+        try {
+            urlQueueWeigher.apply(crawlerContext.sessionId, childList);
+        } catch (final Exception e) {
+            logger.warn("Failed to apply weigher {} to child URLs. Falling back to inherited weights.",
+                    urlQueueWeigher.getClass().getName(), e);
+        }
         urlQueueService.offerAll(crawlerContext.sessionId, childList);
     }
 

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerThread.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerThread.java
@@ -41,6 +41,7 @@ import org.codelibs.fess.crawler.rule.Rule;
 import org.codelibs.fess.crawler.service.DataService;
 import org.codelibs.fess.crawler.service.UrlQueueService;
 import org.codelibs.fess.crawler.util.CrawlingParameterUtil;
+import org.codelibs.fess.crawler.weight.UrlQueueWeigher;
 
 import jakarta.annotation.Resource;
 
@@ -93,6 +94,12 @@ public class CrawlerThread implements Runnable {
      */
     @Resource
     protected UrlQueueService<UrlQueue<?>> urlQueueService;
+
+    /**
+     * Weigher applied to child URLs before they are queued.
+     */
+    @Resource
+    protected UrlQueueWeigher urlQueueWeigher;
 
     /**
      * Service for managing access result data.
@@ -419,7 +426,7 @@ public class CrawlerThread implements Runnable {
             uq.setWeight(d.getWeight());
             childList.add(uq);
         }
-        urlQueueService.offerAll(crawlerContext.sessionId, childList);
+        offerChildUrls(childList);
     }
 
     /**
@@ -446,8 +453,20 @@ public class CrawlerThread implements Runnable {
             uq.setUrl(childUrl);
             uq.setWeight(weight);
             childList.add(uq);
-            urlQueueService.offerAll(crawlerContext.sessionId, childList);
+            offerChildUrls(childList);
         }
+    }
+
+    /**
+     * Applies the weigher to the child URLs and adds them to the queue.
+     * @param childList The child URLs to queue.
+     */
+    protected void offerChildUrls(final List<UrlQueue<?>> childList) {
+        if (childList.isEmpty()) {
+            return;
+        }
+        urlQueueWeigher.apply(crawlerContext.sessionId, childList);
+        urlQueueService.offerAll(crawlerContext.sessionId, childList);
     }
 
     /**

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/DefaultResponseProcessor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/DefaultResponseProcessor.java
@@ -276,7 +276,12 @@ public class DefaultResponseProcessor implements ResponseProcessor {
                 .collect(Collectors.toList());
 
         if (!childList.isEmpty()) {
-            urlQueueWeigher.apply(crawlerContext.getSessionId(), childList);
+            try {
+                urlQueueWeigher.apply(crawlerContext.getSessionId(), childList);
+            } catch (final Exception e) {
+                logger.warn("Failed to apply weigher {} to child URLs. Falling back to inherited weights.",
+                        urlQueueWeigher.getClass().getName(), e);
+            }
             CrawlingParameterUtil.getUrlQueueService().offerAll(crawlerContext.getSessionId(), childList);
         }
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/DefaultResponseProcessor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/DefaultResponseProcessor.java
@@ -37,6 +37,7 @@ import org.codelibs.fess.crawler.processor.ResponseProcessor;
 import org.codelibs.fess.crawler.service.UrlQueueService;
 import org.codelibs.fess.crawler.transformer.Transformer;
 import org.codelibs.fess.crawler.util.CrawlingParameterUtil;
+import org.codelibs.fess.crawler.weight.UrlQueueWeigher;
 
 import jakarta.annotation.Resource;
 
@@ -72,6 +73,12 @@ public class DefaultResponseProcessor implements ResponseProcessor {
     /** Container for managing crawler components */
     @Resource
     protected CrawlerContainer crawlerContainer;
+
+    /**
+     * Weigher applied to child URLs before they are queued.
+     */
+    @Resource
+    protected UrlQueueWeigher urlQueueWeigher;
 
     /** Transformer used to transform response data */
     protected Transformer transformer;
@@ -269,6 +276,7 @@ public class DefaultResponseProcessor implements ResponseProcessor {
                 .collect(Collectors.toList());
 
         if (!childList.isEmpty()) {
+            urlQueueWeigher.apply(crawlerContext.getSessionId(), childList);
             CrawlingParameterUtil.getUrlQueueService().offerAll(crawlerContext.getSessionId(), childList);
         }
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/weight/UrlQueueWeigher.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/weight/UrlQueueWeigher.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.weight;
+
+import java.util.List;
+
+import org.codelibs.fess.crawler.entity.UrlQueue;
+
+/**
+ * Assigns the weight of child URLs just before they are added to the queue.
+ *
+ * <p>
+ * The weight decides the fetch order under the weight-based {@code UrlQueueOrder}
+ * implementations. Callers do not catch exceptions, so an implementation must not throw.
+ * </p>
+ */
+public interface UrlQueueWeigher {
+
+    /**
+     * Sets the weight of the child URLs that are about to be queued.
+     *
+     * @param sessionId the crawling session ID
+     * @param childList the child URLs extracted from a single parent page
+     */
+    void apply(String sessionId, List<UrlQueue<?>> childList);
+}

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/weight/UrlQueueWeigher.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/weight/UrlQueueWeigher.java
@@ -24,7 +24,16 @@ import org.codelibs.fess.crawler.entity.UrlQueue;
  *
  * <p>
  * The weight decides the fetch order under the weight-based {@code UrlQueueOrder}
- * implementations. Callers do not catch exceptions, so an implementation must not throw.
+ * implementations. An implementation must not throw: call sites wrap {@link #apply} in a
+ * try/catch, log a warning naming the weigher, and continue with the child URLs' inherited
+ * weights, but a throwing implementation still loses its own weighting for that batch.
+ * </p>
+ *
+ * <p>
+ * Implementations must only set the {@code weight} of the entries already present in
+ * {@code childList}; they must not add or remove entries. By the time {@code apply} runs,
+ * {@code childList} membership has already been finalized by the URL-filter and max-depth
+ * checks upstream, so adding or removing entries here would bypass those checks.
  * </p>
  */
 public interface UrlQueueWeigher {
@@ -33,7 +42,8 @@ public interface UrlQueueWeigher {
      * Sets the weight of the child URLs that are about to be queued.
      *
      * @param sessionId the crawling session ID
-     * @param childList the child URLs extracted from a single parent page
+     * @param childList the child URLs extracted from a single parent page; implementations
+     *        must only mutate the weight of existing entries, not add or remove entries
      */
     void apply(String sessionId, List<UrlQueue<?>> childList);
 }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/weight/impl/DefaultUrlQueueWeigher.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/weight/impl/DefaultUrlQueueWeigher.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.weight.impl;
+
+import java.util.List;
+
+import org.codelibs.fess.crawler.entity.UrlQueue;
+import org.codelibs.fess.crawler.weight.UrlQueueWeigher;
+
+/**
+ * Leaves the weight as the crawler set it, which is the parent's weight.
+ */
+public class DefaultUrlQueueWeigher implements UrlQueueWeigher {
+
+    /**
+     * Creates a new DefaultUrlQueueWeigher instance.
+     */
+    public DefaultUrlQueueWeigher() {
+        // NOP
+    }
+
+    @Override
+    public void apply(final String sessionId, final List<UrlQueue<?>> childList) {
+        // NOP
+    }
+}

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerTest.java
@@ -52,6 +52,7 @@ import org.codelibs.fess.crawler.service.impl.UrlFilterServiceImpl;
 import org.codelibs.fess.crawler.service.impl.UrlQueueServiceImpl;
 import org.codelibs.fess.crawler.transformer.impl.FileTransformer;
 import org.codelibs.fess.crawler.util.CrawlerWebServer;
+import org.codelibs.fess.crawler.weight.impl.DefaultUrlQueueWeigher;
 import org.dbflute.utflute.core.PlainTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -104,6 +105,7 @@ public class CrawlerTest extends PlainTestCase {
                 .prototype("urlQueueService", UrlQueueServiceImpl.class)
                 .prototype("dataService", DataServiceImpl.class)
                 .prototype("urlFilter", UrlFilterImpl.class)
+                .singleton("urlQueueWeigher", DefaultUrlQueueWeigher.class)
                 .singleton("urlConvertHelper", UrlConvertHelper.class)
                 .singleton("intervalController", DefaultIntervalController.class)
                 .singleton("sitemapsHelper", SitemapsHelper.class)

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerThreadTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerThreadTest.java
@@ -398,6 +398,33 @@ public class CrawlerThreadTest extends PlainTestCase {
     }
 
     /**
+     * Test that a throwing weigher does not lose the child URLs: they are still offered to the
+     * queue with their inherited weights instead of the whole batch being dropped.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_storeChildUrls_throwingWeigherKeepsInheritedWeights() throws Exception {
+        final Set<RequestData> childUrlList = new HashSet<>();
+        childUrlList.add(RequestDataBuilder.newRequestData().url("http://example.com/child1").weight(3.0f).build());
+
+        when(urlFilter.match(anyString())).thenReturn(true);
+        when(crawlerContainer.getComponent("urlQueue")).thenReturn(new UrlQueueImpl<>());
+
+        crawlerThread.urlQueueWeigher = (sessionId, childList) -> {
+            throw new RuntimeException("weigher failure");
+        };
+
+        final java.lang.reflect.Method method = CrawlerThread.class.getDeclaredMethod("storeChildUrls", Set.class, String.class, int.class);
+        method.setAccessible(true);
+        method.invoke(crawlerThread, childUrlList, "http://example.com/", 2);
+
+        final org.mockito.ArgumentCaptor<List<UrlQueue<?>>> captor = org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(urlQueueService, times(1)).offerAll(anyString(), captor.capture());
+        assertEquals(1, captor.getValue().size());
+        assertEquals(Float.valueOf(3.0f), Float.valueOf(captor.getValue().get(0).getWeight()));
+    }
+
+    /**
      * Test that the default weigher leaves the inherited weight untouched.
      */
     @SuppressWarnings("unchecked")

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerThreadTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/CrawlerThreadTest.java
@@ -22,7 +22,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.codelibs.fess.crawler.builder.RequestDataBuilder;
@@ -41,6 +43,7 @@ import org.codelibs.fess.crawler.rule.Rule;
 import org.codelibs.fess.crawler.rule.RuleManager;
 import org.codelibs.fess.crawler.service.DataService;
 import org.codelibs.fess.crawler.service.UrlQueueService;
+import org.codelibs.fess.crawler.weight.impl.DefaultUrlQueueWeigher;
 import org.dbflute.utflute.core.PlainTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,6 +89,7 @@ public class CrawlerThreadTest extends PlainTestCase {
         crawlerContext.ruleManager = ruleManager;
 
         crawlerThread.urlQueueService = urlQueueService;
+        crawlerThread.urlQueueWeigher = new DefaultUrlQueueWeigher();
         crawlerThread.dataService = dataService;
         crawlerThread.crawlerContainer = crawlerContainer;
         crawlerThread.logHelper = logHelper;
@@ -363,6 +367,55 @@ public class CrawlerThreadTest extends PlainTestCase {
         method.invoke(crawlerThread, childUrlList, "http://example.com/", 5); // Exceeds maxDepth
 
         verify(urlQueueService, times(0)).offerAll(anyString(), any());
+    }
+
+    /**
+     * Test that the weigher is applied to child URLs before they are queued.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_storeChildUrls_appliesWeigher() throws Exception {
+        final Set<RequestData> childUrlList = new HashSet<>();
+        childUrlList.add(RequestDataBuilder.newRequestData().url("http://example.com/child1").build());
+
+        when(urlFilter.match(anyString())).thenReturn(true);
+        when(crawlerContainer.getComponent("urlQueue")).thenReturn(new UrlQueueImpl<>());
+
+        final List<UrlQueue<?>> weighed = new ArrayList<>();
+        crawlerThread.urlQueueWeigher = (sessionId, childList) -> {
+            weighed.addAll(childList);
+            childList.forEach(uq -> uq.setWeight(7.5f));
+        };
+
+        final java.lang.reflect.Method method = CrawlerThread.class.getDeclaredMethod("storeChildUrls", Set.class, String.class, int.class);
+        method.setAccessible(true);
+        method.invoke(crawlerThread, childUrlList, "http://example.com/", 2);
+
+        assertEquals(1, weighed.size());
+        assertEquals("test-session", weighed.get(0).getSessionId());
+        assertEquals(Float.valueOf(7.5f), Float.valueOf(weighed.get(0).getWeight()));
+        verify(urlQueueService, times(1)).offerAll(anyString(), any());
+    }
+
+    /**
+     * Test that the default weigher leaves the inherited weight untouched.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_storeChildUrl_defaultWeigherKeepsInheritedWeight() throws Exception {
+        when(urlFilter.match("http://example.com/child")).thenReturn(true);
+        final UrlQueueImpl<Long> queued = new UrlQueueImpl<>();
+        when(crawlerContainer.getComponent("urlQueue")).thenReturn(queued);
+
+        crawlerThread.urlQueueWeigher = new DefaultUrlQueueWeigher();
+
+        final java.lang.reflect.Method method =
+                CrawlerThread.class.getDeclaredMethod("storeChildUrl", String.class, String.class, float.class, int.class);
+        method.setAccessible(true);
+        method.invoke(crawlerThread, "http://example.com/child", "http://example.com/", 3.0f, 2);
+
+        assertEquals(Float.valueOf(3.0f), Float.valueOf(queued.getWeight()));
+        verify(urlQueueService, times(1)).offerAll(anyString(), any());
     }
 
     /**

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/processor/impl/DefaultResponseProcessorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/processor/impl/DefaultResponseProcessorTest.java
@@ -15,9 +15,30 @@
  */
 package org.codelibs.fess.crawler.processor.impl;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.codelibs.fess.crawler.CrawlerContext;
+import org.codelibs.fess.crawler.builder.RequestDataBuilder;
+import org.codelibs.fess.crawler.container.CrawlerContainer;
+import org.codelibs.fess.crawler.entity.RequestData;
 import org.codelibs.fess.crawler.entity.ResponseData;
-import org.junit.jupiter.api.Test;
+import org.codelibs.fess.crawler.entity.UrlQueue;
+import org.codelibs.fess.crawler.entity.UrlQueueImpl;
+import org.codelibs.fess.crawler.filter.UrlFilter;
+import org.codelibs.fess.crawler.service.UrlQueueService;
+import org.codelibs.fess.crawler.util.CrawlingParameterUtil;
 import org.dbflute.utflute.core.PlainTestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author shinsuke
@@ -59,5 +80,87 @@ public class DefaultResponseProcessorTest extends PlainTestCase {
         assertFalse(processor.isNotModified(responseData));
         responseData.setHttpStatusCode(404);
         assertFalse(processor.isNotModified(responseData));
+    }
+
+    /**
+     * Test that storeChildUrls applies the configured weigher to the queued child URLs
+     * before offering them to the URL queue service.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_storeChildUrls_appliesWeigher() {
+        final DefaultResponseProcessor processor = new DefaultResponseProcessor();
+
+        final CrawlerContainer crawlerContainer = mock(CrawlerContainer.class);
+        when(crawlerContainer.getComponent("urlQueue")).thenReturn(new UrlQueueImpl<>());
+        processor.crawlerContainer = crawlerContainer;
+
+        final List<UrlQueue<?>> weighed = new ArrayList<>();
+        processor.urlQueueWeigher = (sessionId, childList) -> {
+            weighed.addAll(childList);
+            childList.forEach(uq -> uq.setWeight(7.5f));
+        };
+
+        final UrlFilter urlFilter = mock(UrlFilter.class);
+        when(urlFilter.match(anyString())).thenReturn(true);
+        final CrawlerContext crawlerContext = new CrawlerContext();
+        crawlerContext.setSessionId("test-session");
+        crawlerContext.setUrlFilter(urlFilter);
+
+        final UrlQueueService<UrlQueue<?>> urlQueueService = mock(UrlQueueService.class);
+        CrawlingParameterUtil.setUrlQueueService(urlQueueService);
+        try {
+            final Set<RequestData> childUrlList = new HashSet<>();
+            childUrlList.add(RequestDataBuilder.newRequestData().get().url("http://example.com/child1").build());
+
+            processor.storeChildUrls(crawlerContext, childUrlList, "http://example.com/", 2, "UTF-8");
+
+            assertEquals(1, weighed.size());
+            assertEquals("test-session", weighed.get(0).getSessionId());
+            assertEquals(Float.valueOf(7.5f), Float.valueOf(weighed.get(0).getWeight()));
+            verify(urlQueueService, times(1)).offerAll(anyString(), any());
+        } finally {
+            CrawlingParameterUtil.setUrlQueueService(null);
+        }
+    }
+
+    /**
+     * Test that a throwing weigher does not lose the child URLs: they are still offered to the
+     * queue with their inherited weights instead of the whole batch being dropped.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_storeChildUrls_throwingWeigherKeepsInheritedWeights() {
+        final DefaultResponseProcessor processor = new DefaultResponseProcessor();
+
+        final CrawlerContainer crawlerContainer = mock(CrawlerContainer.class);
+        when(crawlerContainer.getComponent("urlQueue")).thenReturn(new UrlQueueImpl<>());
+        processor.crawlerContainer = crawlerContainer;
+
+        processor.urlQueueWeigher = (sessionId, childList) -> {
+            throw new RuntimeException("weigher failure");
+        };
+
+        final UrlFilter urlFilter = mock(UrlFilter.class);
+        when(urlFilter.match(anyString())).thenReturn(true);
+        final CrawlerContext crawlerContext = new CrawlerContext();
+        crawlerContext.setSessionId("test-session");
+        crawlerContext.setUrlFilter(urlFilter);
+
+        final UrlQueueService<UrlQueue<?>> urlQueueService = mock(UrlQueueService.class);
+        CrawlingParameterUtil.setUrlQueueService(urlQueueService);
+        try {
+            final Set<RequestData> childUrlList = new HashSet<>();
+            childUrlList.add(RequestDataBuilder.newRequestData().get().url("http://example.com/child1").weight(3.0f).build());
+
+            processor.storeChildUrls(crawlerContext, childUrlList, "http://example.com/", 2, "UTF-8");
+
+            final org.mockito.ArgumentCaptor<List<UrlQueue<?>>> captor = org.mockito.ArgumentCaptor.forClass(List.class);
+            verify(urlQueueService, times(1)).offerAll(anyString(), captor.capture());
+            assertEquals(1, captor.getValue().size());
+            assertEquals(Float.valueOf(3.0f), Float.valueOf(captor.getValue().get(0).getWeight()));
+        } finally {
+            CrawlingParameterUtil.setUrlQueueService(null);
+        }
     }
 }


### PR DESCRIPTION
The URL queue was effectively breadth-first and not changeable. `OpenSearchUrlQueueService.fetchUrlQueueList()` hard-coded a `weight DESC, createTime ASC` sort, so the only way to crawl in a different order was to subclass the service. This adds two extension points and fixes a latent bug that opening the first one would have exposed.

## `UrlQueueOrder` — which URLs are fetched next

A new interface in `fess-crawler-opensearch` describes the fetch order as an optional narrowing query plus a sort order:

```java
public interface UrlQueueOrder {
    default QueryBuilder buildQuery(String sessionId) { return null; }
    SortBuilder<?>[] buildSorts(String sessionId);
}
```

The session filter and the fetch size stay with the queue service rather than being delegated, so an implementation cannot widen a search past its own crawl session. `fetchUrlQueueList()` now delegates to `getUrlQueueOrder(sessionId)`, which subclasses can override to switch the order per session.

Five implementations ship as DI components in a new `crawler/order.xml`:

| Component | Sort |
| --- | --- |
| `sequentialUrlQueueOrder` | `weight DESC, createTime ASC` (the previous behavior, still the default) |
| `randomUrlQueueOrder` | `function_score(random_score(seed=sessionId.hashCode()))`, `_score DESC` |
| `depthFirstUrlQueueOrder` | `depth DESC, createTime DESC` |
| `newestFirstUrlQueueOrder` | `createTime DESC` |
| `weightFirstUrlQueueOrder` | `weight DESC` |

`depthFirstUrlQueueOrder` is bounded by the polling batch rather than being a strict traversal: a batch is fetched and consumed before the next one, so URLs discovered mid-batch wait for the following batch. Its javadoc says so.

## `UrlQueueWeigher` — what weight a child URL gets

Child URLs have always inherited the parent's weight, which left the `weight` field at its `1.0` default and gave the weight-based sorts nothing to order by. A new interface in the core module runs at the three points where newly discovered children are queued:

```java
public interface UrlQueueWeigher {
    void apply(String sessionId, List<UrlQueue<?>> childList);
}
```

The default implementation is a no-op, so nothing changes unless one is configured. `CrawlerThread.storeChildUrls` and `storeChildUrl` now both route through a single `offerChildUrls` helper; `DefaultResponseProcessor.storeChildUrls` calls the weigher directly. The requeue of a cancelled URL is deliberately left alone — that entry is not a newly discovered child and has already been weighed. Both call sites catch and log a failing weigher rather than losing the page's entire child frontier.

`urlQueueWeigher` is registered in `crawler/container.xml` rather than a more specific file, because LastaDi resolves `@Resource` fields within the declaring component's own include subtree, and downstream projects ship their own `crawler/rule.xml`.

## Session filter fix in `getList`

`AbstractCrawlerService.getList` attached the session filter to a caller-supplied `BoolQueryBuilder` but never called `setQuery`, so such a search silently ran as match_all across every session. No existing caller passed a bool query, but `UrlQueueOrder.buildQuery` makes that a supported thing to do — and since `poll()` deletes what it fetches, an order returning a bool query would have deleted other sessions' queued URLs.

The branch is now unified: the caller's query is always wrapped in a fresh bool with the session filter, never mutated in place. That matters because order components are container singletons reused across sessions and batches, so mutating a cached query would accumulate one session filter per fetch.

## Tests

Unit tests for each built-in order, an integration test that swaps the order and asserts `poll()` changes accordingly, a DI test that resolves all five component names, a regression test for the session-filter fix, and tests covering all three weigher hook points plus the degrade-on-throw behavior.

`mvn -pl fess-crawler,fess-crawler-lasta,fess-crawler-opensearch clean package` passes.
