### PR TITLE
fix: make the fetch order actually take effect, and quieten its failure paths

### DIFF
--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/DepthFirstUrlQueueOrder.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/DepthFirstUrlQueueOrder.java
@@ -27,6 +27,9 @@ import org.opensearch.search.sort.SortOrder;
  * <p>
  * The approximation is bounded by the polling fetch size: a batch is fetched, then fully
  * consumed before the next one, so URLs discovered mid-batch wait for the following batch.
+ * A crawl whose frontier fits in a single batch therefore proceeds level by level no matter
+ * which order is selected. Lowering the queue service's polling fetch size tightens the
+ * approximation, at the cost of one queue query per that many URLs.
  * </p>
  */
 public class DepthFirstUrlQueueOrder implements UrlQueueOrder {

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/SequentialUrlQueueOrder.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/SequentialUrlQueueOrder.java
@@ -23,6 +23,14 @@ import org.opensearch.search.sort.SortOrder;
 
 /**
  * Fetches queued URLs by descending weight, then by discovery order. This is the default.
+ *
+ * <p>
+ * Weight is the primary key, so a {@code UrlQueueWeigher} takes effect under this order
+ * without any {@code crawl.order} setting; discovery order only decides between entries of
+ * equal weight. Weights are uniform out of the box, which leaves discovery order as the
+ * effective sort. Use {@link WeightFirstUrlQueueOrder} instead when entries of equal weight
+ * should not be held to discovery order.
+ * </p>
  */
 public class SequentialUrlQueueOrder implements UrlQueueOrder {
 

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/WeightFirstUrlQueueOrder.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/order/impl/WeightFirstUrlQueueOrder.java
@@ -23,6 +23,20 @@ import org.opensearch.search.sort.SortOrder;
 
 /**
  * Fetches queued URLs by descending weight only, leaving ties in the index order.
+ *
+ * <p>
+ * This differs from the default {@link SequentialUrlQueueOrder} only in what happens between
+ * entries of equal weight: that order falls back to discovery order, this one lets the search
+ * engine return them however it likes. Choose it when a queue carries a large backlog scored
+ * by a {@code UrlQueueWeigher} and only the score should decide what is crawled next, with no
+ * bias towards whatever was discovered first.
+ * </p>
+ *
+ * <p>
+ * Without a weigher every entry is at the default weight, every entry ties, and the fetch
+ * order is whatever the index hands back - so this order only means something once weights
+ * differ.
+ * </p>
  */
 public class WeightFirstUrlQueueOrder implements UrlQueueOrder {
 

--- a/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueService.java
+++ b/fess-crawler-opensearch/src/main/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueService.java
@@ -75,8 +75,15 @@ public class OpenSearchUrlQueueService extends AbstractCrawlerService implements
 
     /**
      * The number of URLs to fetch when polling.
+     *
+     * <p>
+     * A batch is handed out in full before the queue is queried again, so this is also how
+     * often the {@link UrlQueueOrder} is re-evaluated. A large batch makes every order
+     * degenerate towards the discovery order, because the URLs found while a batch is being
+     * consumed cannot be considered until the next one.
+     * </p>
      */
-    protected int pollingFetchSize = 1000;
+    protected int pollingFetchSize = 100;
 
     /**
      * The maximum size of the crawling queue.

--- a/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
+++ b/fess-crawler-opensearch/src/test/java/org/codelibs/fess/crawler/service/impl/OpenSearchUrlQueueServiceTest.java
@@ -576,6 +576,44 @@ public class OpenSearchUrlQueueServiceTest extends LastaDiTestCase {
     }
 
     @Test
+    public void test_poll_reevaluatesTheOrderOncePerBatch() {
+        final String sessionId = "batch-session";
+        final long base = System.currentTimeMillis();
+        insertUrlQueue(sessionId, "http://www.example.com/shallow1", 1, base);
+        insertUrlQueue(sessionId, "http://www.example.com/shallow2", 1, base + 1L);
+
+        final int defaultFetchSize = urlQueueService.pollingFetchSize;
+        urlQueueService.setUrlQueueOrder(new DepthFirstUrlQueueOrder());
+        urlQueueService.setPollingFetchSize(2);
+        try {
+            // Both shallow URLs are fetched as one batch. Equal depth, so the newer wins.
+            assertEquals("http://www.example.com/shallow2", urlQueueService.poll(sessionId).getUrl());
+
+            // A deeper URL turns up while that batch is still being handed out.
+            insertUrlQueue(sessionId, "http://www.example.com/deep", 5, base + 2L);
+
+            // The batch is drained before the queue is consulted again, so the deeper URL
+            // waits even though the order asks for the deepest first.
+            assertEquals("http://www.example.com/shallow1", urlQueueService.poll(sessionId).getUrl());
+            assertEquals("http://www.example.com/deep", urlQueueService.poll(sessionId).getUrl());
+        } finally {
+            urlQueueService.setUrlQueueOrder(new SequentialUrlQueueOrder());
+            urlQueueService.setPollingFetchSize(defaultFetchSize);
+            urlQueueService.clearCache();
+        }
+    }
+
+    private void insertUrlQueue(final String sessionId, final String url, final int depth, final long createTime) {
+        final OpenSearchUrlQueue urlQueue = new OpenSearchUrlQueue();
+        urlQueue.setSessionId(sessionId);
+        urlQueue.setUrl(url);
+        urlQueue.setCreateTime(createTime);
+        urlQueue.setDepth(depth);
+        urlQueue.setMethod("GET");
+        urlQueueService.insert(urlQueue);
+    }
+
+    @Test
     public void test_di_registersTheBuiltInOrders() {
         for (final String name : new String[] { "sequentialUrlQueueOrder", "randomUrlQueueOrder", "depthFirstUrlQueueOrder",
                 "newestFirstUrlQueueOrder", "weightFirstUrlQueueOrder" }) {

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerThread.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/CrawlerThread.java
@@ -473,8 +473,11 @@ public class CrawlerThread implements Runnable {
         try {
             urlQueueWeigher.apply(crawlerContext.sessionId, childList);
         } catch (final Exception e) {
-            logger.warn("Failed to apply weigher {} to child URLs. Falling back to inherited weights.",
-                    urlQueueWeigher.getClass().getName(), e);
+            logger.warn("Failed to apply weigher {} to {} child URL(s). Queueing them with whatever weights it left behind.",
+                    urlQueueWeigher.getClass().getName(), childList.size());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Weigher {} failed.", urlQueueWeigher.getClass().getName(), e);
+            }
         }
         urlQueueService.offerAll(crawlerContext.sessionId, childList);
     }

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/DefaultResponseProcessor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/processor/impl/DefaultResponseProcessor.java
@@ -279,8 +279,11 @@ public class DefaultResponseProcessor implements ResponseProcessor {
             try {
                 urlQueueWeigher.apply(crawlerContext.getSessionId(), childList);
             } catch (final Exception e) {
-                logger.warn("Failed to apply weigher {} to child URLs. Falling back to inherited weights.",
-                        urlQueueWeigher.getClass().getName(), e);
+                logger.warn("Failed to apply weigher {} to child URLs of {}. Queueing them with whatever weights it left behind.",
+                        urlQueueWeigher.getClass().getName(), url);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Weigher {} failed.", urlQueueWeigher.getClass().getName(), e);
+                }
             }
             CrawlingParameterUtil.getUrlQueueService().offerAll(crawlerContext.getSessionId(), childList);
         }


### PR DESCRIPTION
Follow-ups from verifying #193 against a live Fess + OpenSearch. Each item was measured on a real crawl, not inferred.

## The polling batch made every order look the same

`fetchUrlQueueList` hands out a whole batch before querying the queue again, so the polling fetch size is also how often the `UrlQueueOrder` is consulted. At 1000, a crawl whose frontier fits in one batch proceeds level by level whatever is configured — the sort only reorders siblings. On a 10-page fixture all five orders produced an identical breadth-first shape at 1000, and their intended shapes at 1.

Lowered to 100. On a 901-page fixture (300 branches, depth 3) with `depthFirstUrlQueueOrder`:

| pollingFetchSize | backtracks | first depth-2 at | first depth-3 at |
| --- | --- | --- | --- |
| 1000 | 0 | #302 | #602 |
| 100 | 2 | #102 | #202 |

A batch of `B` against a level `W` URLs wide dives roughly `W / B` times, so this is a proportional improvement rather than a strict depth-first search — `DepthFirstUrlQueueOrder`'s javadoc already said as much and now spells out the single-batch case. The extra queue queries are negligible next to fetching the pages themselves.

A new test pins the semantics directly: with a batch of 2, a deeper URL offered while the batch is being consumed still waits for the following batch.

## A failing weigher printed a stack trace per page

Both weigher call sites logged the exception at WARN, so a weigher that fails consistently produced one full stack trace for every page with children — the same problem already fixed one file over for an unresolvable `crawl.order`. Measured: 7 pages with children, 7 stack traces; now 7 single lines and the traces at DEBUG.

The wording was also wrong. A weigher that throws part way through has already mutated part of the batch, so "Falling back to inherited weights" claims more than the code does. The messages now name the parent URL (or the child count) so a repeated warning points at the page that tripped it.

## Neither weight-based order said which to reach for

`sequentialUrlQueueOrder` is `weight DESC, createTime ASC`; `weightFirstUrlQueueOrder` is `weight DESC`. They differ only between entries of equal weight, and the fact that gets missed is that weight is already the *default* order's primary key — a `UrlQueueWeigher` changes the fetch order with no `crawl.order` setting at all. Confirmed live: with a weigher scoring `/a/`=3.0, `/b/`=2.0, `/c/`=1.0 and `crawl.order` unset, the crawl came back strictly weight-ordered within each level.

Both javadocs now say this, and `WeightFirstUrlQueueOrder`'s says what it is for — a large weighted backlog where only the score should decide what comes next, with no bias towards whatever was discovered first — and warns that without a weigher every entry ties and the order has nothing to sort by.

For the record, the second sort field is not what makes the difference at scale. On a queue-shaped index of 2,000,000 entries, `size=100`, two runs:

| weights | `weight DESC` | `weight DESC, createTime ASC` |
| --- | --- | --- |
| all at the default 1.0 | 4.0 / 1.0 ms | 11.0 / 8.0 ms |
| spread 0.5–5.0 by a weigher | 4.0 / 11.0 ms | 4.0 / 8.0 ms |

The single-field sort is consistently cheaper only when every entry ties, which is the case where its result is arbitrary anyway; once weights differ the two are within noise of each other. Either way it is milliseconds per queue poll, i.e. per 100 URLs.

## Tests

`mvn -B clean install` passes: 2044 / 15 / 52 across the three modules, no failures.

fess-docs is updated in codelibs/fess-docs#514; the matching Fess change is codelibs/fess#3354.
