### PR TITLE
fix(transformer): recognise the HTML5 form of a charset declaration

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformer.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformer.java
@@ -136,11 +136,17 @@ public class HtmlTransformer extends AbstractTransformer {
     /**
      * Precompiled pattern for extracting a charset value from a content string in {@link #parseCharset(String)}.
      * <p>
-     * The {@code ; charset=} part is deliberately anchored to an opening {@code <meta} tag. The string it is
-     * matched against is the first {@link #preloadSizeForCharset} bytes of the raw response body, which is neither
-     * parsed nor guaranteed to be well-formed HTML, so without that anchor any occurrence of {@code ; charset=}
-     * in ordinary body text (an article about character encodings, a code sample, ...) would be picked up as the
-     * declared encoding of the whole document.
+     * Both spellings of the declaration are accepted: the {@code http-equiv="Content-Type"} form, where the
+     * charset follows a {@code ;} inside the content type, and the HTML5 form, where {@code charset} is an
+     * attribute of the {@code <meta>} tag on its own. Only the first was matched before, so a page using the
+     * short form declared nothing as far as this class was concerned.
+     * <p>
+     * The charset is deliberately anchored to an opening {@code <meta} tag. The string it is matched against is
+     * the first {@link #preloadSizeForCharset} bytes of the raw response body, which is neither parsed nor
+     * guaranteed to be well-formed HTML, so without that anchor any occurrence of {@code charset=} in ordinary
+     * body text (an article about character encodings, a code sample, ...) would be picked up as the declared
+     * encoding of the whole document. Inside the tag the name has to start a word, so it cannot be picked out of
+     * a longer attribute name.
      * <p>
      * The tag is delimited with {@code [^<>]*} rather than by matching a complete {@code <meta ...>} element on
      * purpose: {@code >} keeps the match from running past the end of the tag into the body, {@code <} stops it at
@@ -149,7 +155,7 @@ public class HtmlTransformer extends AbstractTransformer {
      * character class also matches line terminators, so attributes spread over several lines are handled.
      */
     private static final Pattern CHARSET_PATTERN =
-            Pattern.compile("<meta\\s[^<>]*; *charset *= *([a-zA-Z0-9\\-_]+)", Pattern.CASE_INSENSITIVE);
+            Pattern.compile("<meta\\s(?:[^<>]*?[\\s;])?charset *= *[\"']?([a-zA-Z0-9\\-_]+)", Pattern.CASE_INSENSITIVE);
 
     /** The crawler container for dependency injection. */
     @Resource

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformerTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/transformer/impl/HtmlTransformerTest.java
@@ -191,6 +191,52 @@ public class HtmlTransformerTest extends PlainTestCase {
     }
 
     @Test
+    public void test_parseCharset_html5ShortForm() {
+        String content;
+
+        // HTML5 spells the declaration as a charset attribute of its own. Only the content-type
+        // form was recognised before, so a page like this declared nothing and was decoded as the
+        // default rather than as what it said it was.
+        content = "<meta charset=\"Shift_JIS\">";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+
+        content = "<meta charset=\"UTF-8\">";
+        assertEquals("UTF-8", htmlTransformer.parseCharset(content));
+
+        // unquoted, single quoted, spaced around the equals sign, and upper case
+        content = "<meta charset=EUC-JP>";
+        assertEquals("EUC-JP", htmlTransformer.parseCharset(content));
+
+        content = "<meta charset='Shift_JIS'>";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+
+        content = "<meta charset = \"Shift_JIS\">";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+
+        content = "<META CHARSET=\"Shift_JIS\">";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+
+        // XHTML style self-closing tag, and a declaration preceded by other meta tags
+        content = "<meta charset=\"Shift_JIS\" />";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+
+        content = "<html><head><meta name=\"viewport\" content=\"width=device-width\">" + "<meta charset=\"Shift_JIS\"></head>";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+
+        // the preloaded window cuts the tag before its closing quote and bracket
+        content = "<html><head><meta charset=\"Shift_JIS";
+        assertEquals("Shift_JIS", htmlTransformer.parseCharset(content));
+    }
+
+    @Test
+    public void test_parseCharset_notAnAttributeNameOfItsOwn() {
+        // "charset" has to start an attribute name; a longer name ending in it is not a
+        // declaration, and neither is one outside any meta tag.
+        assertNull(htmlTransformer.parseCharset("<meta data-charset=\"Shift_JIS\">"));
+        assertNull(htmlTransformer.parseCharset("<div charset=\"Shift_JIS\">"));
+    }
+
+    @Test
     public void test_parseCharset_outsideMetaTag() {
         String content;
 


### PR DESCRIPTION
Found while checking Fess 15.9 against a live crawl before the release.

## Problem

`parseCharset` only matched the `http-equiv="Content-Type"` spelling, where the charset follows a `;` inside the content type. A page that uses the HTML5 form declared nothing as far as this class was concerned:

```html
<meta charset="Shift_JIS">
```

`loadCharset` then returned null, and `updateCharset` treats that as "no declaration anywhere" and sets UTF-8 — discarding the charset the response header had already supplied. A page served as Shift_JIS with a matching HTML5 declaration was decoded as UTF-8: its title and body came out as replacement characters, and it could no longer be searched in its own language.

Japanese sites that predate UTF-8 but have been updated to the HTML5 doctype are the common case here.

## Fix

The pattern accepts both spellings. The charset stays anchored to an opening `<meta>` tag, so a mention in body text is still not a declaration, and it has to start an attribute name, so `data-charset` is not one either.

## Tests

`HtmlTransformerTest` gains a case covering the HTML5 form — quoted, single quoted, unquoted, spaced around the equals sign, upper case, self-closing, preceded by other meta tags, and cut short by the preload window — and one asserting that `data-charset` and a `charset` attribute on a non-meta tag are not declarations. Every existing case still passes, and the new ones fail without the change.

`CommandExtractorTest.test_processDescendants_killed_orphan_gone` fails on this machine, on `master` as well as here; it depends on how orphaned child processes are reaped and is unrelated to this change.
