### PR TITLE
fix(s3): walk every page of the S3 directory listing

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/s3/S3Client.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/s3/S3Client.java
@@ -301,19 +301,25 @@ public class S3Client extends AbstractCrawlerClient {
                 final ListObjectsV2Request listRequest =
                         ListObjectsV2Request.builder().bucket(bucketName).prefix(path).delimiter("/").build();
 
-                final ListObjectsV2Response listResponse = awsS3Client.listObjectsV2(listRequest);
-
-                // Add objects (excluding the prefix itself if it matches exactly)
-                for (final S3Object s3Object : listResponse.contents()) {
-                    final String objectKey = s3Object.key();
-                    if (!objectKey.equals(path)) {
-                        requestDataSet.add(RequestDataBuilder.newRequestData().get().url("s3://" + bucketName + "/" + objectKey).build());
+                // A single ListObjectsV2 response is capped at 1000 entries, which objects and common
+                // prefixes share, so every page has to be walked. The pages are iterated once because
+                // ListObjectsV2Iterable#contents() and #commonPrefixes() each re-paginate from scratch,
+                // which would double the number of requests.
+                for (final ListObjectsV2Response listResponse : awsS3Client.listObjectsV2Paginator(listRequest)) {
+                    // Add objects (excluding the prefix itself if it matches exactly)
+                    for (final S3Object s3Object : listResponse.contents()) {
+                        final String objectKey = s3Object.key();
+                        if (!objectKey.equals(path)) {
+                            requestDataSet
+                                    .add(RequestDataBuilder.newRequestData().get().url("s3://" + bucketName + "/" + objectKey).build());
+                        }
                     }
-                }
 
-                // Add common prefixes (directories)
-                for (final CommonPrefix prefix : listResponse.commonPrefixes()) {
-                    requestDataSet.add(RequestDataBuilder.newRequestData().get().url("s3://" + bucketName + "/" + prefix.prefix()).build());
+                    // Add common prefixes (directories)
+                    for (final CommonPrefix prefix : listResponse.commonPrefixes()) {
+                        requestDataSet
+                                .add(RequestDataBuilder.newRequestData().get().url("s3://" + bucketName + "/" + prefix.prefix()).build());
+                    }
                 }
 
                 throw new ChildUrlsException(requestDataSet, this.getClass().getName() + "#getResponseData");

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/s3/S3ClientPaginationTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/s3/S3ClientPaginationTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.crawler.client.s3;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codelibs.core.lang.ThreadUtil;
+import org.codelibs.fess.crawler.container.StandardCrawlerContainer;
+import org.codelibs.fess.crawler.entity.ResponseData;
+import org.codelibs.fess.crawler.exception.ChildUrlsException;
+import org.codelibs.fess.crawler.helper.impl.MimeTypeHelperImpl;
+import org.dbflute.utflute.core.PlainTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyExistsException;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Test class verifying that S3Client walks every page of a ListObjectsV2 result.
+ *
+ * <p>
+ * S3 caps a single ListObjectsV2 response at 1000 entries, and objects and common
+ * prefixes share that budget. This fixture deliberately exceeds the cap so that a
+ * non-paginating implementation silently drops the tail of the listing.
+ * </p>
+ */
+public class S3ClientPaginationTest extends PlainTestCase {
+
+    private static final Logger logger = LogManager.getLogger(S3ClientPaginationTest.class);
+
+    private static final String IMAGE_NAME = "localstack/localstack:4.14.0";
+
+    private static final String SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+    private static final String ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE";
+
+    private static final String BUCKET_NAME = "fess";
+
+    /** Number of objects placed directly at the bucket root, above the 1000-entry page cap. */
+    private static final int FILE_COUNT = 1005;
+
+    /** Number of sub-directories at the bucket root. They sort after the files, so they land on a later page. */
+    private static final int DIR_COUNT = 5;
+
+    public S3Client s3Client;
+
+    private GenericContainer<?> localstackServer;
+
+    @Override
+    protected void setUp(final TestInfo testInfo) throws Exception {
+        super.setUp(testInfo);
+
+        final int port = 4566;
+        logger.info("Creating {}", IMAGE_NAME);
+        localstackServer = new GenericContainer<>(IMAGE_NAME)//
+                .withEnv("SERVICES", "s3")//
+                .withExposedPorts(port)//
+                .waitingFor(new HttpWaitStrategy()//
+                        .forPath("/_localstack/health")//
+                        .forPort(port)//
+                        .withStartupTimeout(Duration.ofSeconds(120)));
+        logger.info("Starting {}", IMAGE_NAME);
+        localstackServer.start();
+        logger.info("Started {}", IMAGE_NAME);
+
+        final Integer mappedPort = localstackServer.getFirstMappedPort();
+        final String endpoint = String.format("http://%s:%s", localstackServer.getHost(), mappedPort);
+        logger.info("endpoint: {}", endpoint);
+
+        final StandardCrawlerContainer container = new StandardCrawlerContainer().singleton("mimeTypeHelper", MimeTypeHelperImpl.class)//
+                .singleton("s3Client", S3Client.class);
+        s3Client = container.getComponent("s3Client");
+        final Map<String, Object> params = new HashMap<>();
+        params.put("endpoint", endpoint);
+        params.put("accessKey", ACCESS_KEY);
+        params.put("secretKey", SECRET_KEY);
+        params.put("region", "us-east-1");
+        s3Client.setInitParameterMap(params);
+
+        Exception lastException = null;
+        for (int i = 0; i < 10; i++) {
+            try {
+                setupS3Fixture(endpoint);
+                lastException = null;
+                break;
+            } catch (final Exception e) {
+                lastException = e;
+                logger.warn("[{}] {}", i + 1, e.getMessage());
+            }
+            ThreadUtil.sleep(1000L);
+        }
+        if (lastException != null) {
+            // Never leave a partial fixture behind: it would surface as a bogus pagination failure.
+            throw new IllegalStateException("Failed to create the S3 fixture.", lastException);
+        }
+    }
+
+    private void setupS3Fixture(final String endpoint) throws Exception {
+        try (software.amazon.awssdk.services.s3.S3Client client = software.amazon.awssdk.services.s3.S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .forcePathStyle(true)
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+                .build()) {
+            try {
+                client.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
+            } catch (final BucketAlreadyOwnedByYouException | BucketAlreadyExistsException e) {
+                // A previous attempt already created it.
+            }
+
+            final ExecutorService executorService = Executors.newFixedThreadPool(16);
+            try {
+                final List<Future<?>> futures = new ArrayList<>();
+                for (int i = 0; i < FILE_COUNT; i++) {
+                    final String key = String.format("file%04d.txt", i);
+                    futures.add(executorService.submit(() -> putObject(client, key)));
+                }
+                for (int i = 0; i < DIR_COUNT; i++) {
+                    final String key = String.format("zdir%d/file.txt", i);
+                    futures.add(executorService.submit(() -> putObject(client, key)));
+                }
+                // get() rethrows whatever a task threw, so a short fixture cannot be mistaken
+                // for a truncated listing.
+                for (final Future<?> future : futures) {
+                    future.get(300L, TimeUnit.SECONDS);
+                }
+            } finally {
+                executorService.shutdownNow();
+            }
+        }
+    }
+
+    private void putObject(final software.amazon.awssdk.services.s3.S3Client client, final String key) {
+        client.putObject(PutObjectRequest.builder().bucket(BUCKET_NAME).key(key).contentType("text/plain").build(),
+                RequestBody.fromBytes("x".getBytes()));
+    }
+
+    @Override
+    protected void tearDown(final TestInfo testInfo) throws Exception {
+        localstackServer.stop();
+        super.tearDown(testInfo);
+    }
+
+    @Test
+    public void test_doGet_listingBeyondSinglePage() throws Exception {
+        try (final ResponseData responseData = s3Client.doGet("s3://" + BUCKET_NAME + "/")) {
+            fail();
+        } catch (final ChildUrlsException e) {
+            final Set<String> urls = e.getChildUrlList().stream().map(d -> d.getUrl()).collect(Collectors.toSet());
+
+            // Every object and every sub-directory must be discovered, not just the first page.
+            assertEquals(FILE_COUNT + DIR_COUNT, urls.size());
+
+            // The first page boundary must not cut the listing short.
+            assertTrue(urls.contains("s3://" + BUCKET_NAME + "/file0000.txt"));
+            assertTrue(urls.contains("s3://" + BUCKET_NAME + "/file0999.txt"));
+            assertTrue(urls.contains("s3://" + BUCKET_NAME + "/file1004.txt"));
+
+            // Common prefixes share the page budget with objects, so they are lost first.
+            for (int i = 0; i < DIR_COUNT; i++) {
+                assertTrue(urls.contains("s3://" + BUCKET_NAME + "/zdir" + i + "/"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`S3Client.getResponseData()` listed a directory with a single, unpaginated `ListObjectsV2` call. `isTruncated()` and `nextContinuationToken()` were never consulted, so any bucket or prefix holding more than 1000 entries had its tail silently discarded — the crawl completed successfully, with no warning, having queued only the first 1000 children.

This switches the listing to `listObjectsV2Paginator` so every page is walked.

Fixes #195.

## Objects and common prefixes share the cap

Worth spelling out, because it is not obvious from the symptom: the 1000-entry limit is a *combined* budget for `contents()` and `commonPrefixes()`. Sub-directories are therefore lost before you run out of objects, whenever they sort after the object keys.

The regression test makes exactly that case: a bucket root with 1005 files (`file0000.txt`…`file1004.txt`) and 5 sub-directories (`zdir0/`…`zdir4/`). Since `f` < `z`, page 1 is precisely the first 1000 files and page 2 holds the remaining 5 files plus all 5 prefixes. Before this change the listing returned 1000 children and **not one directory**, so an entire subtree was unreachable rather than merely truncated.

## Why the pages are iterated, and not the iterable

`ListObjectsV2Iterable` exposes `contents()` and `commonPrefixes()` directly, which reads as the idiomatic SDK usage. It is the wrong choice here: in AWS SDK 2.54.2 each of those builds its own `PaginatedItemsIterable` over the pages, and `iterator()` starts a fresh `PaginatedResponsesIterator` per call, so using both performs **two complete pagination passes** — double the `ListObjectsV2` requests against the bucket. Iterating the pages once and reading both collections off each page avoids that. A comment in the code records this so it does not get "simplified" back later.

## Correction to the issue's root-cause analysis

The issue attributes this to #190. That is not right, and the difference matters for anyone auditing similar code:

- `S3Client` has never paginated. It shipped this way in #114, when the class was first added.
- #190 removed the MinIO-based `StorageClient`, whose `minioClient.listObjects(...)` returned a lazily-paginating iterable and so walked buckets of any size with no explicit paging code.

So #190 did not introduce the defect; it deleted the only code path that did not have it. The user-visible regression on migrating from `storage://` to `s3://` is real, but the bug is original to `S3Client` and affected `s3://` crawls in every release since #114.

`GcsClient` is **not** affected — it uses `Page.iterateAll()`, which follows page tokens transparently. `S3Client` was the only unpaginated listing in the repository.

## Behavior notes

- **Exception handling is unchanged.** The paginator is lazy, so `NoSuchBucketException` (and every other `S3Exception`) now surfaces at first iteration rather than at the call site. The loop sits inside the same `try`, so these still land in the existing catch and come out as `CrawlingAccessException`, exactly as before.
- **The child set is now genuinely unbounded.** It was implicitly capped at 1000 by the bug; a flat prefix with a very large number of keys will now materialize all of them as `RequestData` before `ChildUrlsException` is thrown. This restores the pre-#190 `StorageClient` behavior and matches `FileSystemClient`, so it is the established pattern — but it is a real change in memory profile for very large buckets, and I would rather flag it than bury it. Adding a bound would need a new configuration parameter and is out of scope here.

## Testing

- New `S3ClientPaginationTest` (LocalStack `4.14.0` via Testcontainers, same setup as the existing `S3ClientTest`). Verified to fail without the fix — `expected: <1010> but was: <1000>` — and pass with it. Runs in ~5s.
- `S3ClientTest` (7) and `S3ClientInitTest` (7) unchanged and green: 15 tests, 0 failures.
- Full `fess-crawler` suite: 2045 tests, 3 failures, **all pre-existing on `master`**, none S3-related — `FtpClientTest#test_doHead_accessTimeoutTarget` and `Hc5HttpClientTest#test_doHead_accessTimeoutTarget` are timing flakes that pass in isolation, and `CommandExtractorTest#test_processDescendants_killed_orphan_gone` fails identically on a clean checkout of `master` (verified in a separate worktree).
- `mvn package` BUILD SUCCESS, so the javadoc and license gates pass; `formatter:format` and `license:format` are clean.

The one line over 140 columns in `S3Client.java` (`:372`) is a pre-existing string literal the formatter cannot wrap, untouched by this change.

## Backport

This targets `master` (15.9.0-SNAPSHOT). The bug is present in 15.8.x, which the issue reports against, so a backport to the `15.8.x` branch is probably wanted — happy to open it, but leaving that call to you rather than assuming.
