### PR TITLE
fix(extractor): recognise the HTML5 form of a charset declaration

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractor.java
@@ -153,9 +153,36 @@ public class HtmlExtractor extends AbstractXmlExtractor {
      */
     protected static final int JSONLD_MAX_TYPES_PER_BLOCK = 256;
 
-    /** Pattern for extracting charset from meta tags. */
-    protected Pattern metaCharsetPattern = Pattern.compile("<meta.*content\\s*=\\s*['\"].*;\\s*charset=([\\w\\d\\-_]*)['\"]\\s*/?>",
-            Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
+    /**
+     * Pattern for extracting a charset declaration from a {@code <meta>} tag, used by
+     * {@link org.codelibs.fess.crawler.extractor.impl.AbstractXmlExtractor#getEncoding(java.io.BufferedInputStream)}.
+     * <p>
+     * Both spellings of the declaration are accepted: the {@code http-equiv="Content-Type"} form, where the
+     * charset follows a {@code ;} inside the content type, and the HTML5 form, where {@code charset} is an
+     * attribute of the {@code <meta>} tag on its own. Only the first was matched before, so a page using the
+     * short form declared nothing as far as this extractor was concerned and was decoded with
+     * {@link #encoding} instead.
+     * <p>
+     * The charset is deliberately anchored to an opening {@code <meta} tag. The string it is matched against is
+     * the first {@link #preloadSizeForCharset} bytes of the document, which is neither parsed nor guaranteed to
+     * be well-formed HTML, so without that anchor any occurrence of {@code charset=} in ordinary body text (an
+     * article about character encodings, a code sample, ...) would be picked up as the declared encoding of the
+     * whole document. Inside the tag the name has to start a word, so it cannot be picked out of a longer
+     * attribute name.
+     * <p>
+     * The tag is delimited with {@code [^<>]*} rather than by matching a complete {@code <meta ...>} element on
+     * purpose: {@code >} keeps the match from running past the end of the tag into the body, {@code <} stops it at
+     * the next tag when the {@code <meta>} tag itself is malformed, and requiring neither a closing quote nor a
+     * closing {@code >} still detects a declaration in a tag that the preload window cut in half. A negated
+     * character class also matches line terminators, so attributes spread over several lines are handled.
+     * <p>
+     * This is the same shape as the pattern
+     * {@link org.codelibs.fess.crawler.transformer.impl.HtmlTransformer} uses on the web-crawl path; the two must
+     * agree on what counts as a charset declaration so that the same page is decoded the same way whether it is
+     * reached over HTTP or from a file, SMB or FTP share.
+     */
+    protected Pattern metaCharsetPattern =
+            Pattern.compile("<meta\\s(?:[^<>]*?[\\s;])?charset *= *[\"']?([a-zA-Z0-9\\-_]+)", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 
     /**
      * Pattern for HTML tags.

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlXpathExtractor.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/extractor/impl/HtmlXpathExtractor.java
@@ -64,12 +64,15 @@ import jakarta.annotation.Resource;
  */
 public class HtmlXpathExtractor extends AbstractXmlExtractor {
     /**
-     * Regular expression pattern to match the charset attribute in the meta tag of HTML documents.
-     * The pattern captures the charset value specified in the content attribute of the meta tag.
-     * Example: &lt;meta http-equiv="Content-Type" content="text/html; charset=UTF-8"&gt;
+     * Regular expression pattern to match a charset declaration in a meta tag of an HTML document.
+     * Both spellings are captured: the {@code http-equiv="Content-Type"} form, for example
+     * &lt;meta http-equiv="Content-Type" content="text/html; charset=UTF-8"&gt;, and the HTML5 form,
+     * &lt;meta charset="UTF-8"&gt;. See {@link HtmlExtractor#metaCharsetPattern} for why the declaration is
+     * anchored to an opening {@code <meta} tag and why the tag is delimited the way it is; this extractor
+     * reads the same documents and must recognise the same declarations.
      */
-    protected Pattern metaCharsetPattern = Pattern.compile("<meta.*content\\s*=\\s*['\"].*;\\s*charset=([\\w\\d\\-_]*)['\"]\\s*/?>",
-            Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
+    protected Pattern metaCharsetPattern =
+            Pattern.compile("<meta\\s(?:[^<>]*?[\\s;])?charset *= *[\"']?([a-zA-Z0-9\\-_]+)", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 
     /**
      * Map of features for the DOM parser.

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlExtractorTest.java
@@ -19,6 +19,7 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -76,6 +77,20 @@ public class HtmlExtractorTest extends PlainTestCase {
         return new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8));
     }
 
+    /**
+     * Runs the charset detection of {@link HtmlExtractor} over the given document head. A head with no
+     * charset declaration falls back to {@link HtmlExtractor#getEncoding()}, so callers that assert a
+     * non-detection set a distinctive default first.
+     */
+    private String detectEncoding(final String head) {
+        final BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(head.getBytes(StandardCharsets.UTF_8)));
+        try {
+            return htmlExtractor.getEncoding(bis);
+        } finally {
+            CloseableUtil.closeQuietly(bis);
+        }
+    }
+
     @Test
     public void test_getHtml_utf8() {
         final InputStream in = ResourceUtil.getResourceAsStream("extractor/test_utf8.html");
@@ -123,6 +138,66 @@ public class HtmlExtractorTest extends PlainTestCase {
         final String encoding = htmlExtractor.getEncoding(bis);
         CloseableUtil.closeQuietly(bis);
         assertEquals("Shift_JIS", encoding);
+    }
+
+    @Test
+    public void test_getEncoding_html5ShortForm() {
+        // HTML5 spells the declaration as a charset attribute of its own. Only the content-type
+        // form was recognised before, so a page like this declared nothing and was decoded as the
+        // default rather than as what it said it was.
+        assertEquals("Shift_JIS", detectEncoding("<meta charset=\"Shift_JIS\">"));
+        assertEquals("UTF-8", detectEncoding("<meta charset=\"UTF-8\">"));
+
+        // unquoted, single quoted, spaced around the equals sign, and upper case
+        assertEquals("EUC-JP", detectEncoding("<meta charset=EUC-JP>"));
+        assertEquals("Shift_JIS", detectEncoding("<meta charset='Shift_JIS'>"));
+        assertEquals("Shift_JIS", detectEncoding("<meta charset = \"Shift_JIS\">"));
+        assertEquals("Shift_JIS", detectEncoding("<META CHARSET=\"Shift_JIS\">"));
+
+        // XHTML style self-closing tag, and a declaration preceded by other meta tags
+        assertEquals("Shift_JIS", detectEncoding("<meta charset=\"Shift_JIS\" />"));
+        assertEquals("Shift_JIS", detectEncoding(
+                "<html><head><meta name=\"viewport\" content=\"width=device-width\">" + "<meta charset=\"Shift_JIS\"></head>"));
+
+        // the preloaded window cuts the tag before its closing quote and bracket
+        assertEquals("Shift_JIS", detectEncoding("<html><head><meta charset=\"Shift_JIS"));
+    }
+
+    @Test
+    public void test_getEncoding_contentTypeForm() {
+        // The http-equiv spelling was the only one recognised before and must keep working.
+        assertEquals("Shift_JIS", detectEncoding("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS\">"));
+        assertEquals("Shift_JIS", detectEncoding("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS\"/>"));
+
+        // A tag whose attributes are spread over several lines is now recognised too: the old
+        // pattern spanned the tag with "." and so gave up at the first line terminator.
+        assertEquals("EUC-JP", detectEncoding("<meta\n  http-equiv=\"Content-Type\"\n  content=\"text/html; charset=EUC-JP\">"));
+    }
+
+    @Test
+    public void test_getEncoding_notADeclaration() {
+        // "charset" has to start an attribute name of a meta tag; a longer name ending in it is not a
+        // declaration, and neither is one outside any meta tag. A distinctive default makes the
+        // fall-through visible.
+        htmlExtractor.setEncoding("ISO-8859-1");
+        assertEquals("ISO-8859-1", detectEncoding("<meta data-charset=\"Shift_JIS\">"));
+        assertEquals("ISO-8859-1", detectEncoding("<div charset=\"Shift_JIS\">"));
+        assertEquals("ISO-8859-1", detectEncoding("<p>write charset=Shift_JIS to declare it</p>"));
+        assertEquals("ISO-8859-1", detectEncoding("<html><head><title>no declaration</title></head>"));
+    }
+
+    @Test
+    public void test_getHtml_sjis_html5ShortForm() {
+        // The file, SMB and FTP crawl paths reach this extractor rather than HtmlTransformer, so a
+        // Shift_JIS page that declares its charset the HTML5 way came out as replacement characters
+        // and could no longer be searched in its own language.
+        final String html = "<html><head><meta charset=\"Shift_JIS\"><title>タイトル</title></head><body>テスト</body></html>";
+        final InputStream in = new ByteArrayInputStream(html.getBytes(Charset.forName("Shift_JIS")));
+        final ExtractData data = htmlExtractor.getText(in, null);
+        final String content = data.getContent();
+        CloseableUtil.closeQuietly(in);
+        assertTrue(content.contains("テスト"));
+        assertEquals("タイトル", data.getValues("title")[0]);
     }
 
     @Test

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlXpathExtractorTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/extractor/impl/HtmlXpathExtractorTest.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.crawler.extractor.impl;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -106,6 +107,37 @@ public class HtmlXpathExtractorTest extends PlainTestCase {
         final String encoding = htmlXpathExtractor.getEncoding(bis);
         CloseableUtil.closeQuietly(bis);
         assertEquals("Shift_JIS", encoding);
+    }
+
+    @Test
+    public void test_getEncoding_html5ShortForm() {
+        // This extractor reads the same documents as HtmlExtractor and carried the same pattern, so
+        // it too saw no declaration at all in the HTML5 short form.
+        assertEquals("Shift_JIS", detectEncoding("<meta charset=\"Shift_JIS\">"));
+        assertEquals("EUC-JP", detectEncoding("<html><head><meta charset=EUC-JP></head>"));
+    }
+
+    @Test
+    public void test_getEncoding_contentTypeForm() {
+        // The http-equiv spelling was the only one recognised before and must keep working.
+        assertEquals("Shift_JIS", detectEncoding("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS\">"));
+    }
+
+    @Test
+    public void test_getEncoding_notADeclaration() {
+        // A distinctive default makes the fall-through visible when nothing is declared.
+        htmlXpathExtractor.setEncoding("ISO-8859-1");
+        assertEquals("ISO-8859-1", detectEncoding("<meta data-charset=\"Shift_JIS\">"));
+        assertEquals("ISO-8859-1", detectEncoding("<p>write charset=Shift_JIS to declare it</p>"));
+    }
+
+    private String detectEncoding(final String head) {
+        final BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(head.getBytes(StandardCharsets.UTF_8)));
+        try {
+            return htmlXpathExtractor.getEncoding(bis);
+        } finally {
+            CloseableUtil.closeQuietly(bis);
+        }
     }
 
     @Test


### PR DESCRIPTION
The HTML extractors matched only the http-equiv="Content-Type" spelling, where
the charset follows a ";" inside the content type. A page that uses the HTML5
form, <meta charset="Shift_JIS">, declared nothing as far as they were
concerned, so getEncoding found no declaration at all and decoded the document
with the default encoding of UTF-8 instead.

A Shift_JIS page then came out as replacement characters: its title and body
were unreadable and it could no longer be searched in its own language. The
same page crawled over HTTP was fine, which is what makes this easy to miss.
The web path hands the response to HtmlTransformer, whose pattern was corrected
earlier; the file, SMB and FTP paths have no such transformer and reach the
extractors instead, so they kept the pattern that understood only the older
spelling. This completes that fix on the half of the crawler it did not reach.

Both spellings are accepted now, using the pattern the transformer settled on,
so one document is decoded the same way whichever protocol it arrived over. The
charset stays anchored to an opening <meta> tag, because the string being
matched is a raw prefix of the document that is neither parsed nor guaranteed
to be well-formed, and without that anchor a mention of charset= in ordinary
body text would be read as the encoding of the whole document; the name also
has to start an attribute, so data-charset is not a declaration. Spanning the
tag with a negated character class rather than "." has the side benefit of
finding a declaration whose attributes are spread over several lines.

HtmlXpathExtractor held a byte-identical copy of the old pattern and is
corrected with it, since it reads the same documents. XmlExtractor takes its
encoding from the XML declaration and is unaffected.


---

Completes the fix started in #196, which covered the transformer (web crawling) but not the extractor (file, SMB and FTP crawling).
