### PR TITLE
build: drop the gRPC transport that google-cloud-storage never uses here

### DIFF
--- a/fess-crawler/pom.xml
+++ b/fess-crawler/pom.xml
@@ -361,6 +361,139 @@
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-storage</artifactId>
 			<version>${google.cloud.storage.version}</version>
+			<!-- google-cloud-storage ships two transports and pulls the dependencies of both.
+			     GcsClient and the gcs: URL handler build their client with
+			     StorageOptions.newBuilder(), which is the JSON over HTTP transport; the gRPC one
+			     is only reachable through StorageOptions.grpc(), which nothing here calls. Its
+			     stack (gRPC itself, the generated gRPC storage client, the OpenTelemetry SDK, and
+			     google-cloud-monitoring, which is there for gRPC's client-side metrics) is
+			     therefore dead weight in every artifact that depends on this.
+			     The OpenTelemetry api/context/common jars stay: gax-httpjson uses them.
+			     io.grpc:grpc-api is NOT excluded and must not be: HttpStorageRpc#startSpan
+			     opens an OpenCensus span on every request, and OpenCensus carries its current
+			     span in io.grpc.Context, which has lived in grpc-api since gRPC 1.60 (the
+			     grpc-context artifact still exists but no longer holds the class). Excluding it
+			     leaves the JSON transport throwing NoClassDefFoundError on the first call.
+			     If a future release needs the gRPC transport, delete this block rather than
+			     adding artifacts back one at a time. -->
+			<exclusions>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-inprocess</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-alts</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-auth</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-protobuf</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-protobuf-lite</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-opentelemetry</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-grpclb</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-netty-shaded</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-util</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-stub</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-googleapis</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-xds</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-services</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.grpc</groupId>
+					<artifactId>grpc-rls</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.api</groupId>
+					<artifactId>gax-grpc</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.cloud</groupId>
+					<artifactId>google-cloud-core-grpc</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.cloud</groupId>
+					<artifactId>google-cloud-monitoring</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.api.grpc</groupId>
+					<artifactId>proto-google-cloud-monitoring-v3</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.api.grpc</groupId>
+					<artifactId>grpc-google-cloud-storage-v2</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.api.grpc</groupId>
+					<artifactId>gapic-google-cloud-storage-v2</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.cloud.opentelemetry</groupId>
+					<artifactId>exporter-metrics</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry.contrib</groupId>
+					<artifactId>opentelemetry-gcp-resources</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-sdk</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-sdk-trace</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-sdk-logs</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-sdk-metrics</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-sdk-common</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Why

`google-cloud-storage` ships two transports and declares the dependencies of both.
`GcsClient` and the `gcs:` URL handler both build their client with
`StorageOptions.newBuilder()`, which is the JSON-over-HTTP transport; the gRPC one is
reachable only through `StorageOptions.grpc()`, which nothing calls. Its stack was on the
classpath anyway, and in every artifact that depends on fess-crawler:

**29 jars, 26.4 MiB removed, nothing added.** `grpc-xds` (10.5 MiB) and
`grpc-netty-shaded` (10.3 MiB) are 21 MiB of that between them.

## Three things deliberately kept

Each of these looks like part of the gRPC stack and is not:

| Kept | Why |
|---|---|
| `io.grpc:grpc-api` | `HttpStorageRpc#startSpan` opens an OpenCensus span on every request, and OpenCensus keeps its current span in `io.grpc.Context` — which has lived in `grpc-api` since gRPC 1.60. The `grpc-context` artifact still exists but no longer holds the class. |
| `proto-google-cloud-storage-v2` | `JsonConversions#bucketInfoDecode` uses `com.google.storage.v2.BucketName`. The v2 protos are shared between the transports. |
| `opentelemetry-api`, `-context`, `-common` | `gax-httpjson` uses them. |

**Both of the first two were found by running the tests, not by reading the dependency
tree.** A first attempt excluded `io.grpc:*` and `proto-google-cloud-storage-v2`; that
compiles clean and then throws on the first call:

```
java.lang.NoClassDefFoundError: io/grpc/Context
  at io.opencensus.trace.unsafe.ContextManagerImpl.currentContext
  ...
  at com.google.cloud.storage.spi.v1.HttpStorageRpc.startSpan(HttpStorageRpc.java:384)

java.lang.NoClassDefFoundError: com/google/storage/v2/BucketName
  at com.google.cloud.storage.Utils.lambda$static$4(Utils.java:155)
  at com.google.cloud.storage.JsonConversions.bucketInfoDecode(JsonConversions.java:613)
```

Worth knowing for anyone reviewing a similar change: compile-clean says nothing here.

## Why the OpenTelemetry SDK and the generated gRPC client are safe

Not by argument — by reading the constant pools of the classes in
`google-cloud-storage-2.71.0.jar`:

- Exactly one class references `io/opentelemetry/sdk` or
  `com/google/cloud/opentelemetry`: `OpenTelemetryBootstrappingUtils`. Its only caller in
  the jar is `GrpcStorageOptions`.
- Every class referencing `com/google/storage/v2/StorageClient` is either a `Grpc*` class
  or a `BlobWriteSessionConfig` factory, which only a caller asking for gRPC uploads
  reaches.

## Verification

`mvn test` → **2057 tests, 0 failures, 0 errors, BUILD SUCCESS**, including
`GcsClientTest` (7 tests) against `fsouza/fake-gcs-server` via testcontainers, which
exercises create, `doGet` and `doHead` over the real JSON API.

## Note for the Fess side

Fess declares `google-cloud-storage` directly too, so these exclusions do not reach it;
codelibs/fess needs the same block. That is a separate PR.
