### PR TITLE
docs(build): say why the okhttp dependency has no caller here

### DIFF
--- a/fess-crawler/pom.xml
+++ b/fess-crawler/pom.xml
@@ -337,6 +337,12 @@
 			<artifactId>jai-imageio-jpeg2000</artifactId>
 			<version>${jai.imageio.version}</version>
 		</dependency>
+		<!-- No class here imports okhttp3, and that is not a mistake. This declaration is how
+		     Fess comes to ship okhttp 5.x in WEB-INF/lib, which plugins then use at runtime:
+		     fess-ds-microsoft365 calls okhttp from its own code and deliberately does not shade
+		     it, excluding the okhttp 4.12.0 that Kiota brings so that it runs on the copy Fess
+		     supplies. Deleting this for having no local caller breaks that plugin with a
+		     NoClassDefFoundError at crawl time, which no test here would catch. -->
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp-jvm</artifactId>


### PR DESCRIPTION
Stacked on #200.

Nothing in this repository imports `okhttp3`, in main or in test, so `com.squareup.okhttp3:okhttp-jvm` reads as dead weight in a dependency audit. It is not.

It is how Fess comes to ship okhttp 5.x in `WEB-INF/lib`. `fess-ds-microsoft365` calls okhttp from its own code and deliberately does not shade it — its pom excludes the okhttp 4.12.0 that Kiota brings, with the comment:

> Kiota pulls okhttp 4.12.0, but this plugin does not shade okhttp: at runtime it uses the okhttp-jvm 5.x that Fess supplies.

Deleting this declaration would break the Microsoft 365 data store with a `NoClassDefFoundError` at crawl time, and no test in this repository would catch it.

I nearly deleted it while auditing the distribution for unused jars — grep over this repo and over codelibs/fess found no caller. That is exactly the failure this comment exists to prevent. Comment only, no behaviour change.