### PR TITLE
build!: leave the s3: crawler client to the fess-storage-s3 plugin

### DIFF
--- a/fess-crawler-lasta/src/main/resources/crawler/client.xml
+++ b/fess-crawler-lasta/src/main/resources/crawler/client.xml
@@ -51,17 +51,13 @@
 		<property name="charset">"UTF-8"</property>
 	</component>
 
-	<component name="s3Client"
-		class="org.codelibs.fess.crawler.client.s3.S3Client" instance="prototype">
-		<property name="charset">"UTF-8"</property>
-	</component>
-
-	<!-- gcs: has no client registered here. GcsClient stays in this library, but the Google Cloud
-	     Storage SDK it needs is 17 MiB that most installations never crawl, so Fess ships it in the
-	     fess-lib-gcs plugin, which registers the client through crawlerClientCreator the way
-	     fess-crawler-playwright registers playwrightClient. Registering it here instead would make
-	     every CrawlerClientFactory fail to build wherever the SDK is absent, because the component
-	     reference below is resolved when the factory is created. -->
+	<!-- s3: and gcs: have no client registered here. S3Client and GcsClient stay in this library,
+	     but the SDKs they need are 8 MiB and 17 MiB of jars that most installations never crawl, so
+	     Fess ships them in the fess-storage-s3 and fess-storage-gcs plugins, which register the
+	     clients through crawlerClientCreator the way fess-crawler-playwright registers
+	     playwrightClient. Registering them here instead would make every CrawlerClientFactory fail
+	     to build wherever the SDK is absent, because the component references in clientFactory
+	     below are resolved when the factory is created, not when a client is first used. -->
 
 	<component name="crawlerClientCreator"
 		class="org.codelibs.fess.crawler.client.CrawlerClientCreator">
@@ -92,10 +88,6 @@
 		<postConstruct name="addClient">
 			<arg>"ftps:.*"</arg>
 			<arg>ftpClient</arg>
-		</postConstruct>
-		<postConstruct name="addClient">
-			<arg>"s3:.*"</arg>
-			<arg>s3Client</arg>
 		</postConstruct>
 	</component>
 


### PR DESCRIPTION
First of three PRs that move the S3 storage backend out of the Fess distribution, following what codelibs/fess#3424 and codelibs/fess-crawler#203 did for Google Cloud Storage. **Merge this one first**, and let its snapshot publish before the Fess side lands.

`S3Client` and the `s3:` URL handler stay here and keep compiling against the AWS SDK; only the registration moves. The SDK itself leaves the war through an exclusion on the Fess side, and ships in the new `fess-storage-s3` plugin, which declares the `s3Client` component and registers it through `crawlerClientCreator` — the way `fess-crawler-playwright` registers `playwrightClient`.

## Why the registration cannot stay here

`clientFactory` resolves its component references when the factory is created, not when a client is first used. A reference to `s3Client` therefore makes **every** `CrawlerClientFactory` fail to build wherever the SDK is absent, which is every installation without the plugin. That is the same reason the `gcsClient` registration was removed in #203.

## Verified

A LastaDi container was booted on a plain JVM with `crawler/client.xml`, `crawler/mimetype.xml` and `fess_storage.xml`, on a class path built the way Fess builds one — `WEB-INF/classes`, then the war's runtime jars with the AWS SDK excluded, then the plugin jar.

With this change, `clientFactory` builds and maps `s3://bucket/key` to `org.codelibs.fess.crawler.client.s3.S3Client` — the class from this library, registered by the plugin.

Without it, using the current `crawler/client.xml` against the same plugin:

```
TooManyRegistrationComponentException
[Component Key] s3Client
[Registered Components]
  componentName: s3Client  definedDiXml: crawler/client.xml
  componentName: s3Client  (from the plugin's crawler/client++.xml)
```

`clientFactory` fails to build there, so every crawl dies — which is what makes the merge order a requirement rather than a preference, and why the plugin is paired with a Fess version.

## Also in this change

The `gcs:` comment being replaced still named `fess-lib-gcs`, which was renamed to `fess-storage-gcs` before it was ever published. Both protocols now share one comment.

No test changes: the S3 tests here build their own container with `.singleton("s3Client", S3Client.class)` rather than reading `crawler/client.xml`, so none of them pins the registration. `crawler/client.xml` is not read by any test in this repository.
