### PR TITLE
fix: use the jcifs 3.x property names for NTLM parameters and SMB1 logging

### DIFF
--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/config/WebAuthenticationConfig.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/http/config/WebAuthenticationConfig.java
@@ -238,11 +238,14 @@ public class WebAuthenticationConfig {
      *
      * <p>Supported parameters include:</p>
      * <ul>
-     * <li>jcifs.smb.client.SO_SNDBUF - TCP send buffer size</li>
-     * <li>jcifs.smb.client.SO_RCVBUF - TCP receive buffer size</li>
-     * <li>jcifs.smb.client.domain - Default domain</li>
-     * <li>And other jcifs.* properties</li>
+     * <li>jcifs.client.domain - Default domain</li>
+     * <li>jcifs.client.snd_buf_size - TCP send buffer size</li>
+     * <li>jcifs.client.rcv_buf_size - TCP receive buffer size</li>
+     * <li>And other jcifs.* properties read by PropertyConfiguration</li>
      * </ul>
+     *
+     * <p>jcifs 3.0.0 dropped the .smb segment from every key, so the 2.x
+     * spelling jcifs.smb.client.* is ignored without error.</p>
      */
     private Map<String, String> ntlmParameters;
 

--- a/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb1/SmbClient.java
+++ b/fess-crawler/src/main/java/org/codelibs/fess/crawler/client/smb1/SmbClient.java
@@ -130,7 +130,7 @@ public class SmbClient extends AbstractCrawlerClient {
     public static final String SMB_OWNER_ATTRIBUTES = "smb1OwnerAttributes";
 
     static {
-        if (Config.getInt("jcifs.smb1.util.loglevel", -1) == -1) {
+        if (Config.getInt("jcifs.util.loglevel", -1) == -1) {
             if (logger.isTraceEnabled()) {
                 LogStream.setLevel(4);
             } else if (logger.isDebugEnabled()) {

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc4HttpClientAuthConfigTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc4HttpClientAuthConfigTest.java
@@ -55,8 +55,8 @@ public class Hc4HttpClientAuthConfigTest extends PlainTestCase {
         config.setCredentials(credentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "TESTDOMAIN");
-        ntlmParams.put("jcifs.smb.client.SO_SNDBUF", "65535");
+        ntlmParams.put("jcifs.client.domain", "TESTDOMAIN");
+        ntlmParams.put("jcifs.client.snd_buf_size", "65535");
         config.setNtlmParameters(ntlmParams);
 
         WebAuthenticationConfig[] configs = new WebAuthenticationConfig[] { config };
@@ -180,7 +180,7 @@ public class Hc4HttpClientAuthConfigTest extends PlainTestCase {
         ntlmConfig.setCredentials(ntlmCredentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "NTLMDOMAIN");
+        ntlmParams.put("jcifs.client.domain", "NTLMDOMAIN");
         ntlmConfig.setNtlmParameters(ntlmParams);
 
         WebAuthenticationConfig[] configs = new WebAuthenticationConfig[] { basicConfig, ntlmConfig };

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc5HttpClientAuthConfigTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc5HttpClientAuthConfigTest.java
@@ -58,8 +58,8 @@ public class Hc5HttpClientAuthConfigTest extends PlainTestCase {
         config.setCredentials(credentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "TESTDOMAIN");
-        ntlmParams.put("jcifs.smb.client.SO_SNDBUF", "65535");
+        ntlmParams.put("jcifs.client.domain", "TESTDOMAIN");
+        ntlmParams.put("jcifs.client.snd_buf_size", "65535");
         config.setNtlmParameters(ntlmParams);
 
         WebAuthenticationConfig[] configs = new WebAuthenticationConfig[] { config };
@@ -184,7 +184,7 @@ public class Hc5HttpClientAuthConfigTest extends PlainTestCase {
         ntlmConfig.setCredentials(ntlmCredentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "NTLMDOMAIN");
+        ntlmParams.put("jcifs.client.domain", "NTLMDOMAIN");
         ntlmConfig.setNtlmParameters(ntlmParams);
 
         WebAuthenticationConfig[] configs = new WebAuthenticationConfig[] { basicConfig, ntlmConfig };
@@ -328,8 +328,8 @@ public class Hc5HttpClientAuthConfigTest extends PlainTestCase {
         config.setCredentials(credentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "TESTDOMAIN");
-        ntlmParams.put("jcifs.smb.client.SO_SNDBUF", "65535");
+        ntlmParams.put("jcifs.client.domain", "TESTDOMAIN");
+        ntlmParams.put("jcifs.client.snd_buf_size", "65535");
         config.setNtlmParameters(ntlmParams);
 
         Map<String, Object> params = new HashMap<>();
@@ -339,8 +339,8 @@ public class Hc5HttpClientAuthConfigTest extends PlainTestCase {
         Properties result = httpClient.collectNtlmParameters();
 
         assertNotNull(result);
-        assertEquals("TESTDOMAIN", result.getProperty("jcifs.smb.client.domain"));
-        assertEquals("65535", result.getProperty("jcifs.smb.client.SO_SNDBUF"));
+        assertEquals("TESTDOMAIN", result.getProperty("jcifs.client.domain"));
+        assertEquals("65535", result.getProperty("jcifs.client.snd_buf_size"));
     }
 
     @Test
@@ -441,8 +441,8 @@ public class Hc5HttpClientAuthConfigTest extends PlainTestCase {
         config1.setCredentials(credentials1);
 
         Map<String, String> ntlmParams1 = new HashMap<>();
-        ntlmParams1.put("jcifs.smb.client.domain", "DOMAIN1");
-        ntlmParams1.put("jcifs.smb.client.SO_SNDBUF", "65535");
+        ntlmParams1.put("jcifs.client.domain", "DOMAIN1");
+        ntlmParams1.put("jcifs.client.snd_buf_size", "65535");
         config1.setNtlmParameters(ntlmParams1);
 
         // Second NTLM config with different params
@@ -459,8 +459,8 @@ public class Hc5HttpClientAuthConfigTest extends PlainTestCase {
         config2.setCredentials(credentials2);
 
         Map<String, String> ntlmParams2 = new HashMap<>();
-        ntlmParams2.put("jcifs.smb.client.domain", "DOMAIN2"); // Overrides DOMAIN1
-        ntlmParams2.put("jcifs.smb.client.SO_RCVBUF", "32768");
+        ntlmParams2.put("jcifs.client.domain", "DOMAIN2"); // Overrides DOMAIN1
+        ntlmParams2.put("jcifs.client.rcv_buf_size", "32768");
         config2.setNtlmParameters(ntlmParams2);
 
         Map<String, Object> params = new HashMap<>();
@@ -471,9 +471,9 @@ public class Hc5HttpClientAuthConfigTest extends PlainTestCase {
 
         assertNotNull(result);
         // Later config overrides earlier
-        assertEquals("DOMAIN2", result.getProperty("jcifs.smb.client.domain"));
-        assertEquals("65535", result.getProperty("jcifs.smb.client.SO_SNDBUF"));
-        assertEquals("32768", result.getProperty("jcifs.smb.client.SO_RCVBUF"));
+        assertEquals("DOMAIN2", result.getProperty("jcifs.client.domain"));
+        assertEquals("65535", result.getProperty("jcifs.client.snd_buf_size"));
+        assertEquals("32768", result.getProperty("jcifs.client.rcv_buf_size"));
     }
 
     @Test
@@ -504,7 +504,7 @@ public class Hc5HttpClientAuthConfigTest extends PlainTestCase {
         ntlmConfig.setCredentials(ntlmCredentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "NTLMDOMAIN");
+        ntlmParams.put("jcifs.client.domain", "NTLMDOMAIN");
         ntlmConfig.setNtlmParameters(ntlmParams);
 
         Map<String, Object> params = new HashMap<>();
@@ -514,7 +514,7 @@ public class Hc5HttpClientAuthConfigTest extends PlainTestCase {
         Properties result = httpClient.collectNtlmParameters();
 
         assertNotNull(result);
-        assertEquals("NTLMDOMAIN", result.getProperty("jcifs.smb.client.domain"));
+        assertEquals("NTLMDOMAIN", result.getProperty("jcifs.client.domain"));
         assertEquals(1, result.size());
     }
 }

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc5HttpClientTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc5HttpClientTest.java
@@ -262,7 +262,7 @@ public class Hc5HttpClientTest extends PlainTestCase {
         config.setCredentials(credentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "TESTDOMAIN");
+        ntlmParams.put("jcifs.client.domain", "TESTDOMAIN");
         config.setNtlmParameters(ntlmParams);
 
         Map<String, Object> params = new HashMap<>();
@@ -345,7 +345,7 @@ public class Hc5HttpClientTest extends PlainTestCase {
         config1.setCredentials(credentials1);
 
         Map<String, String> ntlmParams1 = new HashMap<>();
-        ntlmParams1.put("jcifs.smb.client.domain", "DOMAIN1");
+        ntlmParams1.put("jcifs.client.domain", "DOMAIN1");
         config1.setNtlmParameters(ntlmParams1);
 
         WebAuthenticationConfig config2 = new WebAuthenticationConfig();
@@ -361,7 +361,7 @@ public class Hc5HttpClientTest extends PlainTestCase {
         config2.setCredentials(credentials2);
 
         Map<String, String> ntlmParams2 = new HashMap<>();
-        ntlmParams2.put("jcifs.smb.client.domain", "DOMAIN2");
+        ntlmParams2.put("jcifs.client.domain", "DOMAIN2");
         config2.setNtlmParameters(ntlmParams2);
 
         Map<String, Object> params = new HashMap<>();
@@ -405,7 +405,7 @@ public class Hc5HttpClientTest extends PlainTestCase {
         ntlmConfig.setCredentials(ntlmCredentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "NTLMDOMAIN");
+        ntlmParams.put("jcifs.client.domain", "NTLMDOMAIN");
         ntlmConfig.setNtlmParameters(ntlmParams);
 
         Map<String, Object> params = new HashMap<>();
@@ -441,7 +441,7 @@ public class Hc5HttpClientTest extends PlainTestCase {
         config.setCredentials(credentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "TESTDOMAIN");
+        ntlmParams.put("jcifs.client.domain", "TESTDOMAIN");
         config.setNtlmParameters(ntlmParams);
 
         Map<String, Object> params = new HashMap<>();
@@ -545,7 +545,7 @@ public class Hc5HttpClientTest extends PlainTestCase {
         config1.setCredentials(credentials1);
 
         Map<String, String> ntlmParams1 = new HashMap<>();
-        ntlmParams1.put("jcifs.smb.client.domain", "DOMAIN1");
+        ntlmParams1.put("jcifs.client.domain", "DOMAIN1");
         config1.setNtlmParameters(ntlmParams1);
 
         WebAuthenticationConfig config2 = new WebAuthenticationConfig();
@@ -562,7 +562,7 @@ public class Hc5HttpClientTest extends PlainTestCase {
         config2.setCredentials(credentials2);
 
         Map<String, String> ntlmParams2 = new HashMap<>();
-        ntlmParams2.put("jcifs.smb.client.domain", "DOMAIN2");
+        ntlmParams2.put("jcifs.client.domain", "DOMAIN2");
         config2.setNtlmParameters(ntlmParams2);
 
         Map<String, Object> params = new HashMap<>();

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc5NtlmAuthenticationStrategyTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/Hc5NtlmAuthenticationStrategyTest.java
@@ -151,7 +151,7 @@ public class Hc5NtlmAuthenticationStrategyTest extends PlainTestCase {
         config.setCredentials(credentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "TESTDOMAIN");
+        ntlmParams.put("jcifs.client.domain", "TESTDOMAIN");
         config.setNtlmParameters(ntlmParams);
 
         Map<String, Object> params = new HashMap<>();
@@ -284,7 +284,7 @@ public class Hc5NtlmAuthenticationStrategyTest extends PlainTestCase {
         ntlmConfig.setCredentials(ntlmCredentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "NTLMDOMAIN");
+        ntlmParams.put("jcifs.client.domain", "NTLMDOMAIN");
         ntlmConfig.setNtlmParameters(ntlmParams);
 
         Map<String, Object> params = new HashMap<>();
@@ -346,7 +346,7 @@ public class Hc5NtlmAuthenticationStrategyTest extends PlainTestCase {
         config.setCredentials(credentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "TESTDOMAIN");
+        ntlmParams.put("jcifs.client.domain", "TESTDOMAIN");
         config.setNtlmParameters(ntlmParams);
 
         Map<String, Object> params = new HashMap<>();
@@ -386,7 +386,7 @@ public class Hc5NtlmAuthenticationStrategyTest extends PlainTestCase {
         ntlmConfig.setCredentials(ntlmCredentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "NTLMDOMAIN");
+        ntlmParams.put("jcifs.client.domain", "NTLMDOMAIN");
         ntlmConfig.setNtlmParameters(ntlmParams);
 
         Map<String, Object> params = new HashMap<>();

--- a/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/config/WebAuthenticationConfigTest.java
+++ b/fess-crawler/src/test/java/org/codelibs/fess/crawler/client/http/config/WebAuthenticationConfigTest.java
@@ -220,12 +220,12 @@ public class WebAuthenticationConfigTest extends PlainTestCase {
         assertNull(config.getNtlmParameters());
 
         Map<String, String> params = new HashMap<>();
-        params.put("jcifs.smb.client.domain", "MYDOMAIN");
-        params.put("jcifs.smb.client.SO_SNDBUF", "65536");
+        params.put("jcifs.client.domain", "MYDOMAIN");
+        params.put("jcifs.client.snd_buf_size", "65536");
 
         config.setNtlmParameters(params);
         assertEquals(params, config.getNtlmParameters());
-        assertEquals("MYDOMAIN", config.getNtlmParameters().get("jcifs.smb.client.domain"));
+        assertEquals("MYDOMAIN", config.getNtlmParameters().get("jcifs.client.domain"));
 
         config.setNtlmParameters(null);
         assertNull(config.getNtlmParameters());
@@ -304,13 +304,13 @@ public class WebAuthenticationConfigTest extends PlainTestCase {
         config.setCredentials(credentials);
 
         Map<String, String> ntlmParams = new HashMap<>();
-        ntlmParams.put("jcifs.smb.client.domain", "CORP");
+        ntlmParams.put("jcifs.client.domain", "CORP");
         config.setNtlmParameters(ntlmParams);
 
         assertEquals(AuthSchemeType.NTLM, config.getAuthSchemeType());
         assertEquals(CredentialsType.NTLM, config.getCredentials().getType());
         assertEquals("CORP", config.getCredentials().getDomain());
-        assertEquals("CORP", config.getNtlmParameters().get("jcifs.smb.client.domain"));
+        assertEquals("CORP", config.getNtlmParameters().get("jcifs.client.domain"));
     }
 
     /**


### PR DESCRIPTION
Follow-up to codelibs/jcifs#81 / codelibs/jcifs#87, which found that jcifs 3.0.0
renamed every configuration key (dropping the `.smb` segment) and that old keys are
ignored without any diagnostic. Two places in this repository still use the old names.

## NTLM parameters

`WebAuthenticationConfig#ntlmParameters` documents what a crawler config may put in
that map:

```java
 * <li>jcifs.smb.client.SO_SNDBUF - TCP send buffer size</li>
 * <li>jcifs.smb.client.SO_RCVBUF - TCP receive buffer size</li>
 * <li>jcifs.smb.client.domain - Default domain</li>
```

All three are dead names.

* `jcifs.smb.client.domain` is a real property under its **new** name,
  `jcifs.client.domain`. The map is turned into a `Properties` by
  `Hc5HttpClient` / `Hc4HttpClient` and handed to `Hc5JcifsEngine` / `JcifsEngine`,
  which do `new BaseContext(new PropertyConfiguration(props))`. `PropertyConfiguration`
  looks the key up verbatim, does not find it, and uses the default — so an NTLM
  domain configured this way has been silently ignored since the jcifs 3.x upgrade.
* `SO_SNDBUF` and `SO_RCVBUF` were never jcifs property names under **any** prefix,
  in 2.x or 3.x. The socket buffer properties are `snd_buf_size` and `rcv_buf_size`.

The list is corrected and gains a line naming the rename, so the 2.x spelling does not
get copied back in from an old example. Once jcifs#87 ships, a configuration still
carrying the old key will also log a warning naming the replacement.

## SMB1 log level

`smb1/SmbClient`'s static block derives the jcifs `LogStream` level from SLF4J, but
only when the user has not pinned one:

```java
if (Config.getInt("jcifs.smb1.util.loglevel", -1) == -1) {
```

Since jcifs 3.0.0 the legacy stack reads `jcifs.util.loglevel` — its own `Config`
static block does exactly that. So the guard never fires: a user who sets
`-Djcifs.util.loglevel=3` has it applied by jcifs and then immediately overwritten
here. Changed to test the key jcifs actually reads.

## Tests

Five test classes use these key strings as the example NTLM parameters. The keys are
opaque to the assertions — they only check the map round-trips — so this is a rename,
not a behaviour change, but leaving dead names in the tests is how the old spelling
keeps getting copied. `SO_SNDBUF` / `SO_RCVBUF` become `snd_buf_size` /
`rcv_buf_size`.

## Verification

* `mvn -pl fess-crawler test` for the five affected classes — 94 tests, 0 failures,
  0 errors.
* `mvn formatter:format && mvn license:format` — no further changes.
* Property names checked against jcifs 3.0.3 (the version `fess-parent` pins):
  `PropertyConfiguration` reads `jcifs.client.domain`, `jcifs.client.snd_buf_size`
  and `jcifs.client.rcv_buf_size`; `org.codelibs.jcifs.smb1.Config`'s static block
  reads `jcifs.util.loglevel`.
