### PR TITLE
chore(deps): take the lite OOXML schemas and drop the PDFBox CLI extras

### DIFF
--- a/fess-crawler-lasta/pom.xml
+++ b/fess-crawler-lasta/pom.xml
@@ -57,12 +57,6 @@
 			<groupId>org.codelibs.fess</groupId>
 			<artifactId>fess-crawler</artifactId>
 			<version>${project.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.poi</groupId>
-					<artifactId>poi-ooxml-lite</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.lastaflute</groupId>

--- a/fess-crawler/pom.xml
+++ b/fess-crawler/pom.xml
@@ -209,6 +209,19 @@
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-parser-microsoft-module</artifactId>
 			<version>${tika.version}</version>
+			<exclusions>
+				<exclusion>
+					<!-- poi-ooxml-full carries every OOXML XmlBeans schema (13.6 MiB); poi-ooxml,
+					     which poi-ooxml-lite comes with, carries the 2,555 the extractors actually
+					     reach (5.7 MiB). Every one of the 911 schema classes referenced from the
+					     jars this project ships - poi-ooxml and tika-parser-microsoft-module, the
+					     only two that name any - is present in the lite jar, the 26 Visio ones
+					     included. Tika asks for the full jar because signing and schema-level
+					     editing need it; Fess only reads text out of the documents. -->
+					<groupId>org.apache.poi</groupId>
+					<artifactId>poi-ooxml-full</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tika</groupId>
@@ -287,9 +300,25 @@
 			<version>${pdfbox.version}</version>
 		</dependency>
 		<dependency>
+			<!-- Kept as a direct dependency, although nothing here calls it, so that it stays on
+			     ${pdfbox.version} with the rest of PDFBox: tika-parser-pdf-module asks for it too,
+			     and dropping the declaration would let Tika pick the version instead. Tika reaches
+			     exactly one class in it, org.apache.pdfbox.tools.imageio.ImageIOUtil. The command
+			     line entry points are what need picocli, and pdfbox-debugger is a Swing viewer; a
+			     server never loads either. -->
 			<groupId>org.apache.pdfbox</groupId>
 			<artifactId>pdfbox-tools</artifactId>
 			<version>${pdfbox.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.pdfbox</groupId>
+					<artifactId>pdfbox-debugger</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>info.picocli</groupId>
+					<artifactId>picocli</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.pdfbox</groupId>


### PR DESCRIPTION
Two dependency changes that take 8.6 MiB off the class path every Fess installation carries, with no loss of extraction coverage.

## poi-ooxml-full -> poi-ooxml-lite

`tika-parser-microsoft-module` asks for `poi-ooxml-full`, the jar carrying every OOXML XmlBeans schema. `poi-ooxml` comes with `poi-ooxml-lite`, the subset POI itself reaches. The two define the same `org.openxmlformats.schemas.*` classes and cannot coexist, so `fess-crawler-lasta` had been excluding the lite one. This exclusion is inverted: exclude the full one at the point that pulls it in, and let `poi-ooxml` bring the lite one.

|  | classes | size |
|---|---|---|
| poi-ooxml-full | 6,063 | 13.59 MiB |
| poi-ooxml-lite | 2,555 | 5.72 MiB |

The lite set is a strict subset of the full one (0 classes are lite-only).

**Why this is safe.** Scanning the constant pool of every jar this project puts on the class path, exactly two of them name an OOXML schema class: `poi-ooxml` (908) and `tika-parser-microsoft-module` (27). All 911 are present in the lite jar, including the 26 `com.microsoft.schemas.office.visio` ones. Tika asks for the full jar because signing and schema-level editing need it; extraction only reads text.

`MsVisioExtractor` is unaffected either way - it uses HDGF (`poi-scratchpad`), not the OOXML schemas.

**Residual risk worth naming.** XmlBeans resolves `.xsb` type descriptors by name at run time (full 9,082, lite 1,601), which a static scan cannot cover. POI generates the lite set from its own usage, and the whole test suite passes, but a document exercising a schema no POI code path touches is not something either check would catch.

## pdfbox-tools keeps its version, loses its extras

`pdfbox-tools` is not called from this project, but it is not removable: `tika-parser-pdf-module` reaches `org.apache.pdfbox.tools.imageio.ImageIOUtil`. Dropping the declaration would hand the version choice to Tika and let it drift from the rest of PDFBox, so the declaration stays and two transitive dependencies go instead:

- `pdfbox-debugger` (0.32 MiB) - a Swing viewer
- `picocli` (0.40 MiB) - referenced only by the 20 command line entry points, not by `ImageIOUtil`

## Verification

- `mvn clean test` across all four modules: **2,125 tests, 0 failures** (`fess-crawler` 2,057, `fess-crawler-lasta` 15, `fess-crawler-opensearch` 53).
- Resolved tree confirms `poi-ooxml-lite` in, `poi-ooxml-full` / `pdfbox-debugger` / `picocli` out, `pdfbox-tools` still pinned at the managed PDFBox version.

`JodExtractorTest` is excluded from surefire by default and is unaffected by this change; forced to run it fails the same 3 LibreOffice-dependent cases on `main` as on this branch.
