### PR TITLE
chore(deps): stop shipping okhttp for the plugins that use it

### DIFF
--- a/fess-crawler/pom.xml
+++ b/fess-crawler/pom.xml
@@ -366,17 +366,6 @@
 			<artifactId>jai-imageio-jpeg2000</artifactId>
 			<version>${jai.imageio.version}</version>
 		</dependency>
-		<!-- No class here imports okhttp3, and that is not a mistake. This declaration is how
-		     Fess comes to ship okhttp 5.x in WEB-INF/lib, which plugins then use at runtime:
-		     fess-ds-microsoft365 calls okhttp from its own code and deliberately does not shade
-		     it, excluding the okhttp 4.12.0 that Kiota brings so that it runs on the copy Fess
-		     supplies. Deleting this for having no local caller breaks that plugin with a
-		     NoClassDefFoundError at crawl time, which no test here would catch. -->
-		<dependency>
-			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>okhttp-jvm</artifactId>
-			<version>${okhttp.version}</version>
-		</dependency>
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>


### PR DESCRIPTION
No class here imports `okhttp3`. The declaration existed so that Fess would carry `okhttp-jvm` in `WEB-INF/lib` for data store plugins to pick up at run time, and its comment said so. Those plugins now carry it themselves, so **2.93 MiB leaves every Fess distribution**: `okhttp-jvm` (0.92), `kotlin-stdlib` (1.64), `okio-jvm` (0.37).

Fess's `WEB-INF/lib` goes from 220 jars to 217.

## The comment was narrower than the truth

It named only fess-ds-microsoft365, which calls okhttp from its own code. **fess-ds-box needed it too, and silently**: seventeen classes of `box-java-sdk` call okhttp, and the SDK was getting Fess's 5.x rather than the 4.12.0 it asks for, because `WEB-INF/lib` precedes `WEB-INF/plugin`. Nothing in either pom recorded that.

Both plugins now declare `okhttp-jvm` at the version fess-parent pins and shade it in, so they agree on one version and neither depends on what the war happens to hold:

- codelibs/fess-ds-microsoft365#65
- codelibs/fess-ds-box#23

## Nothing else was using it

Checked across every plugin repository in the workspace:

| | |
|---|---|
| fess-ds-microsoft365, fess-ds-box | genuinely need it — now bundle it |
| fess-llm-gemini, -ollama, -openai | MockWebServer at test scope only; main sources never touch okhttp3 |
| fess-webapp-multimodal, fess-crawler-playwright | inherited it from here at compile scope without using it |
| Fess itself | `src/test` only |

## Ordering

**Both plugin PRs have to be released before this merges.** An installation that upgrades the war first would lose okhttp under a plugin still built the old way.

## Verification

Full suite: 2,057 tests, one failure — `test_doHead_accessTimeoutTarget`, which asserts that a one-second timeout interrupts a two-second sleep. It fails on a *different* client each run and is not related to this change:

| run | branch | failure |
|---|---|---|
| 1 | this branch | `Hc4HttpClientTest.test_doHead_accessTimeoutTarget` |
| 2 | this branch | `FtpClientTest.test_doHead_accessTimeoutTarget` |
| 3 | **unmodified main** | `Hc5HttpClientTest.test_doHead_accessTimeoutTarget` **plus an error in `SmbClientTest.test_resolveSidsDisabled`** |

Run on its own, `Hc4HttpClientTest` passes 3 times out of 3 on this branch. This module has no okhttp reference at all — no import, no MockWebServer, no test dependency — so there is no path from this change to those tests.

On the Fess side, with this build installed: **7,470 tests, 0 failures, 0 errors**, and no `NoClassDefFoundError` anywhere in the output.
